### PR TITLE
Add "Included Source Codes" tab to the Concept Set editor

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -140,6 +140,20 @@
                 {{ store.includedLoading ? '…' : store.includedItems.length }}
               </AtlasChip>
             </AtlasTab>
+            <AtlasTab value="source-codes">
+              <AtlasIcon
+                start
+                icon="mdi-barcode-scan"
+              />
+              {{ t('cs.manager.tabs.sourceCodes', 'Source Codes') }}
+              <AtlasChip
+                size="sm"
+                tone="primary"
+                class="cs-editor__tab-count"
+              >
+                {{ store.sourceCodeLoading ? '…' : store.sourceCodeItems.length }}
+              </AtlasChip>
+            </AtlasTab>
             <AtlasTab value="search">
               <AtlasIcon
                 start
@@ -240,6 +254,15 @@
                 :source-key="sourceKey"
                 @view-concept="onViewConcept"
                 @retry="store.resolveIncluded(sourceKey)"
+              />
+            </v-window-item>
+
+            <!-- Source Codes Tab -->
+            <v-window-item value="source-codes">
+              <IncludedSourceCodesTable
+                :active="activeTab === 'source-codes'"
+                :source-key="sourceKey"
+                @view-concept="onViewConcept"
               />
             </v-window-item>
 
@@ -600,6 +623,7 @@ import type { VersionsConfig, VersionsTableItem, User } from '@/components/versi
 import ConceptSearchInline from './ConceptSearchInline.vue'
 import ConceptSetTable from './ConceptSetTable.vue'
 import IncludedConceptsTable from './IncludedConceptsTable.vue'
+import IncludedSourceCodesTable from './IncludedSourceCodesTable.vue'
 import RecommendTab from './RecommendTab.vue'
 import CompareTab from './CompareTab.vue'
 import ConceptDetailContent from './detail/ConceptDetailContent.vue'

--- a/src/components/concepts/IncludedSourceCodesTable.vue
+++ b/src/components/concepts/IncludedSourceCodesTable.vue
@@ -150,7 +150,7 @@ const emptyMessage = computed(() => {
   if (store.includedItems.length === 0) {
     return t(
       'cs.manager.sourceCodesEmptyNoIncluded',
-      'No source codes — add concepts to see their mapped source codes here.',
+      'Add concepts to see their mapped source codes here.',
     ).value
   }
   return t(

--- a/src/components/concepts/IncludedSourceCodesTable.vue
+++ b/src/components/concepts/IncludedSourceCodesTable.vue
@@ -161,11 +161,11 @@ const emptyMessage = computed(() => {
 
 watch(
   () => [props.active, includedSignature.value, props.sourceKey] as const,
-  ([active], prev) => {
+  ([active, sig, key], prev) => {
     if (!active) return
     const [prevActive, prevSig, prevKey] = prev ?? [false, '', undefined]
-    if (active !== prevActive || includedSignature.value !== prevSig || props.sourceKey !== prevKey) {
-      void store.resolveSourceCodes(props.sourceKey)
+    if (active !== prevActive || sig !== prevSig || key !== prevKey) {
+      void store.resolveSourceCodes(key)
     }
   },
   { immediate: true },

--- a/src/components/concepts/IncludedSourceCodesTable.vue
+++ b/src/components/concepts/IncludedSourceCodesTable.vue
@@ -1,0 +1,220 @@
+<template>
+  <div class="included-source-codes-table">
+    <AtlasAlert
+      v-if="store.sourceCodeError"
+      severity="danger"
+      variant="tonal"
+      class="included-source-codes-table__error"
+    >
+      <div class="d-flex align-center">
+        <span class="flex-grow-1">{{ store.sourceCodeError }}</span>
+        <AtlasButton
+          size="sm"
+          variant="ghost"
+          data-testid="source-codes-retry-btn"
+          @click="store.resolveSourceCodes(props.sourceKey)"
+        >
+          {{ t('common.retry', 'Retry').value }}
+        </AtlasButton>
+      </div>
+    </AtlasAlert>
+
+    <AtlasCard
+      v-if="store.sourceCodeLoading || store.sourceCodeItems.length > 0"
+      padding="none"
+    >
+      <AtlasDataTable
+        v-model:sort-by="sortBy"
+        :headers="headers"
+        :items="store.sourceCodeItems"
+        :loading="store.sourceCodeLoading"
+        :items-per-page="50"
+        hover
+        class="included-source-codes-table__table"
+      >
+        <template
+          v-if="props.sourceKey"
+          #item.conceptName="{ item }"
+        >
+          <a
+            href="#"
+            :data-testid="`source-code-name-link-${item.conceptId}`"
+            class="concept-name-link"
+            @click.prevent="onView(item)"
+          >
+            {{ item.conceptName }}
+          </a>
+        </template>
+
+        <template
+          v-else
+          #item.conceptName="{ item }"
+        >
+          {{ item.conceptName }}
+        </template>
+
+        <template #item.domainId="{ item }">
+          <AtlasChip
+            v-if="item.domainId"
+            :color="getDomainColor(item.domainId)"
+            size="xs"
+            variant="tonal"
+          >
+            {{ item.domainId }}
+          </AtlasChip>
+        </template>
+
+        <template #item.vocabularyId="{ item }">
+          <AtlasChip
+            v-if="item.vocabularyId"
+            size="xs"
+            variant="outlined"
+          >
+            {{ item.vocabularyId }}
+          </AtlasChip>
+        </template>
+
+        <template #loading>
+          <AtlasSkeleton
+            v-for="i in 5"
+            :key="i"
+            type="table-row"
+            class="mx-2"
+          />
+        </template>
+      </AtlasDataTable>
+    </AtlasCard>
+
+    <div
+      v-else
+      class="included-source-codes-table__empty"
+    >
+      <AtlasIcon
+        icon="mdi-barcode-scan"
+        size="36"
+        class="included-source-codes-table__empty-icon"
+      />
+      <p class="included-source-codes-table__empty-text">
+        {{ emptyMessage }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useI18n } from '@/composables/useI18n'
+import type { Concept } from '@/models/concept-set.types'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import {
+  AtlasAlert,
+  AtlasButton,
+  AtlasCard,
+  AtlasChip,
+  AtlasDataTable,
+  AtlasIcon,
+  AtlasSkeleton,
+} from '@/components/ui'
+import { getDomainColor } from '@/utils/domain-colors'
+
+const { t } = useI18n()
+const store = useConceptSetsStore()
+
+interface Props {
+  active: boolean
+  sourceKey?: string
+}
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'view-concept': [payload: { conceptId: number; sourceKey: string }]
+}>()
+
+const sortBy = ref([{ key: 'conceptId', order: 'asc' as const }])
+
+const headers = [
+  { title: t('columns.conceptId', 'ID').value, key: 'conceptId', sortable: true, width: '90px' },
+  { title: t('columns.conceptCode', 'Code').value, key: 'conceptCode', sortable: true, width: '110px' },
+  { title: t('columns.conceptName', 'Name').value, key: 'conceptName', sortable: true },
+  { title: t('columns.class', 'Class').value, key: 'conceptClassId', sortable: true, width: '150px' },
+  { title: t('columns.domain', 'Domain').value, key: 'domainId', sortable: true, width: '120px' },
+  { title: t('columns.vocabulary', 'Vocabulary').value, key: 'vocabularyId', sortable: true, width: '120px' },
+]
+
+// Signature of the included concept ids — re-resolve when it changes while active.
+const includedSignature = computed(() =>
+  store.includedItems.map((c) => c.conceptId).join(','),
+)
+
+const emptyMessage = computed(() => {
+  if (store.includedItems.length === 0) {
+    return t(
+      'cs.manager.sourceCodesEmptyNoIncluded',
+      'No source codes — add concepts to see their mapped source codes here.',
+    ).value
+  }
+  return t(
+    'cs.manager.sourceCodesEmpty',
+    'No source codes map to the included concepts.',
+  ).value
+})
+
+watch(
+  () => [props.active, includedSignature.value, props.sourceKey] as const,
+  ([active], prev) => {
+    if (!active) return
+    const [prevActive, prevSig, prevKey] = prev ?? [false, '', undefined]
+    if (active !== prevActive || includedSignature.value !== prevSig || props.sourceKey !== prevKey) {
+      void store.resolveSourceCodes(props.sourceKey)
+    }
+  },
+  { immediate: true },
+)
+
+function onView(c: Concept) {
+  emit('view-concept', { conceptId: c.conceptId, sourceKey: props.sourceKey! })
+}
+</script>
+
+<style scoped>
+.included-source-codes-table {
+  width: 100%;
+}
+
+.included-source-codes-table__error {
+  margin-bottom: 12px;
+}
+
+.included-source-codes-table__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 56px 24px;
+  border-radius: 12px;
+  background: rgb(var(--v-theme-surface-variant));
+}
+
+.included-source-codes-table__empty-icon {
+  color: rgb(var(--v-theme-on-surface-variant));
+  opacity: 0.7;
+}
+
+.included-source-codes-table__empty-text {
+  margin: 0;
+  font-size: 14px;
+  color: rgb(var(--v-theme-on-surface-variant));
+  text-align: center;
+  max-width: 480px;
+}
+
+.concept-name-link {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+
+.concept-name-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2194,6 +2194,8 @@
       "fullyOptimizedMessage": "The current concept set definition is fully optimized.",
       "includedEmptyNoManual": "Add concepts on the Selected tab to see them here.",
       "includedEmptyNoResolve": "No concepts resolved from this expression.",
+      "sourceCodesEmpty": "No source codes map to the included concepts.",
+      "sourceCodesEmptyNoIncluded": "Add concepts to see their mapped source codes here.",
       "pasteIds": "Paste IDs",
       "pasteIdsTitle": "Paste concept IDs",
       "pasteIdsHint": "Separate IDs with spaces, commas, semicolons, or newlines. We resolve each ID against the vocabulary before adding.",
@@ -2225,6 +2227,7 @@
         "included": "Included",
         "includedConcepts": "Included Concepts",
         "includedSourceCodes": "Included Source Codes",
+        "sourceCodes": "Source Codes",
         "selected": "Selected",
         "versions": "Versions",
         "messages": "Messages"

--- a/src/services/concept-search.service.ts
+++ b/src/services/concept-search.service.ts
@@ -154,6 +154,39 @@ export async function getConceptsBySourceCodes(
   return parsed.data.map(mapConceptFromAPI)
 }
 
+/**
+ * Resolve the *source* codes that map to a set of standard concept IDs.
+ * Uses `POST /vocabulary/{sourceKey}/lookup/mapped` with a JSON array of concept
+ * identifiers — the resolved/included standard concept IDs. Returns the mapped
+ * source Concept records (non-standard codes such as ICD10CM, ICD9CM, source
+ * SNOMED). Mirrors getConceptsByIds, which uses lookup/identifiers.
+ */
+export async function getMappedSourceCodes(
+  sourceKey: string,
+  conceptIds: number[],
+  signal?: AbortSignal,
+): Promise<Concept[]> {
+  if (!sourceKey || sourceKey.trim() === '' || sourceKey === 'null' || sourceKey === 'undefined') {
+    throw new Error('Invalid vocabulary source. Please select a valid source in Configuration.')
+  }
+
+  if (conceptIds.length === 0) return []
+
+  const raw = await httpPost<unknown>(
+    `/vocabulary/${sourceKey}/lookup/mapped`,
+    conceptIds,
+    { signal },
+  )
+
+  const parsed = ConceptSearchResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    logger.error('ConceptSearch', 'lookup/mapped validation error', parsed.error)
+    throw new Error('Invalid mapped source code lookup response format')
+  }
+
+  return parsed.data.map(mapConceptFromAPI)
+}
+
 export async function getConceptRecordCounts(
   sourceKey: string,
   conceptIds: number[]

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -27,6 +27,7 @@ import {
   getConceptRecordCounts,
   compareConceptSets,
   resolveConceptSetExpression,
+  getMappedSourceCodes,
 } from '@/services/concept-search.service'
 import { useWebAPIStore } from '@/stores/webapi'
 import { logger } from '@/utils/logger'
@@ -63,6 +64,14 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
   const includedError = ref<string | null>(null)
   const includedFetchedAt = ref<number | null>(null)
   let includedAbortCtrl: AbortController | null = null
+
+  // Mapped source codes (the "Source Codes" tab) — the non-standard codes that
+  // map to the resolved/included standard concepts.
+  const sourceCodeItems = ref<Concept[]>([])
+  const sourceCodeLoading = ref<boolean>(false)
+  const sourceCodeError = ref<string | null>(null)
+  const sourceCodeFetchedAt = ref<number | null>(null)
+  let sourceCodeAbortCtrl: AbortController | null = null
 
   // ============================================================================
   // Getters
@@ -577,6 +586,57 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     includedLoading.value = false
     includedError.value = null
     includedFetchedAt.value = null
+    resetSourceCodes()
+  }
+
+  async function resolveSourceCodes(sourceKey?: string): Promise<void> {
+    const conceptIds = includedItems.value.map((c) => c.conceptId)
+    if (conceptIds.length === 0) {
+      sourceCodeAbortCtrl?.abort()
+      sourceCodeAbortCtrl = null
+      sourceCodeItems.value = []
+      sourceCodeError.value = null
+      sourceCodeLoading.value = false
+      return
+    }
+
+    const key = sourceKey || useWebAPIStore().getValidVocabularySource()
+    if (!key) {
+      sourceCodeError.value = 'No vocabulary source available'
+      return
+    }
+
+    sourceCodeAbortCtrl?.abort()
+    const ctrl = new AbortController()
+    sourceCodeAbortCtrl = ctrl
+
+    sourceCodeLoading.value = true
+    sourceCodeError.value = null
+
+    try {
+      const concepts = await getMappedSourceCodes(key, conceptIds, ctrl.signal)
+      if (ctrl !== sourceCodeAbortCtrl) return
+      sourceCodeItems.value = concepts
+      sourceCodeFetchedAt.value = Date.now()
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return
+      if (ctrl !== sourceCodeAbortCtrl) return
+      sourceCodeError.value = err instanceof Error ? err.message : 'Failed to resolve source codes'
+      logger.error('ConceptSetsStore', 'resolveSourceCodes error', err)
+    } finally {
+      if (ctrl === sourceCodeAbortCtrl) {
+        sourceCodeLoading.value = false
+      }
+    }
+  }
+
+  function resetSourceCodes(): void {
+    sourceCodeAbortCtrl?.abort()
+    sourceCodeAbortCtrl = null
+    sourceCodeItems.value = []
+    sourceCodeLoading.value = false
+    sourceCodeError.value = null
+    sourceCodeFetchedAt.value = null
   }
 
   // ============================================================================
@@ -647,6 +707,12 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
         includedError.value = null
         includedLoading.value = false
         includedFetchedAt.value = null
+        sourceCodeAbortCtrl?.abort()
+        sourceCodeAbortCtrl = null
+        sourceCodeItems.value = []
+        sourceCodeError.value = null
+        sourceCodeLoading.value = false
+        sourceCodeFetchedAt.value = null
         return
       }
       debouncedResolveIncluded()
@@ -716,5 +782,13 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     includedFetchedAt,
     resolveIncluded,
     resetIncluded,
+
+    // Source codes (mapped non-standard codes for included concepts)
+    sourceCodeItems,
+    sourceCodeLoading,
+    sourceCodeError,
+    sourceCodeFetchedAt,
+    resolveSourceCodes,
+    resetSourceCodes,
   }
 })

--- a/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
+++ b/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import IncludedSourceCodesTable from '@/components/concepts/IncludedSourceCodesTable.vue'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+
+vi.mock('@/composables/useI18n', () => ({
+  useI18n: () => ({ t: (_k: string, fallback: string) => ({ value: fallback }) }),
+}))
+
+const stubs = {
+  AtlasAlert: { template: '<div class="stub-alert"><slot /></div>' },
+  AtlasButton: { template: '<button><slot /></button>' },
+  AtlasCard: { template: '<div class="stub-card"><slot /></div>' },
+  AtlasChip: { template: '<span class="stub-chip"><slot /></span>' },
+  AtlasDataTable: {
+    props: ['items', 'loading'],
+    template: '<table class="stub-table"><tbody><tr v-for="i in items" :key="i.conceptId"><td>{{ i.conceptName }}</td></tr></tbody></table>',
+  },
+  AtlasIcon: { template: '<i />' },
+  AtlasSkeleton: { template: '<div class="stub-skeleton" />' },
+}
+
+function makeWrapper(props: Record<string, unknown> = {}) {
+  return mount(IncludedSourceCodesTable, {
+    props: { active: true, sourceKey: 'SYNPUF1K', ...props },
+    global: { stubs },
+  })
+}
+
+describe('IncludedSourceCodesTable', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    // Prevent the watcher from calling the real resolveSourceCodes, which would
+    // reset sourceCodeItems/sourceCodeError when includedItems is empty.
+    vi.spyOn(useConceptSetsStore(), 'resolveSourceCodes').mockResolvedValue()
+  })
+
+  it('renders rows for the store source-code items', () => {
+    const store = useConceptSetsStore()
+    store.sourceCodeItems = [
+      {
+        conceptId: 45542738,
+        conceptName: 'Type 2 diabetes mellitus',
+        conceptCode: 'E11.9',
+        domainId: 'Condition',
+        vocabularyId: 'ICD10CM',
+        conceptClassId: 'ICD10 code',
+        standardConcept: null,
+        invalidReason: null,
+      },
+    ]
+    const wrapper = makeWrapper()
+    expect(wrapper.text()).toContain('Type 2 diabetes mellitus')
+  })
+
+  it('shows the empty state when there are no source codes', () => {
+    const store = useConceptSetsStore()
+    store.sourceCodeItems = []
+    const wrapper = makeWrapper()
+    expect(wrapper.text()).toContain('No source codes')
+  })
+
+  it('triggers resolveSourceCodes when activated', async () => {
+    const store = useConceptSetsStore()
+    const spy = vi.spyOn(store, 'resolveSourceCodes').mockResolvedValue()
+    makeWrapper({ active: false })
+    expect(spy).not.toHaveBeenCalled()
+
+    const wrapper = makeWrapper({ active: true })
+    await wrapper.vm.$nextTick()
+    expect(spy).toHaveBeenCalledWith('SYNPUF1K')
+  })
+
+  it('renders an error alert with a retry button', () => {
+    const store = useConceptSetsStore()
+    store.sourceCodeError = 'Network error'
+    const wrapper = makeWrapper()
+    expect(wrapper.find('.stub-alert').exists()).toBe(true)
+  })
+})

--- a/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
+++ b/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
@@ -58,7 +58,7 @@ describe('IncludedSourceCodesTable', () => {
     const store = useConceptSetsStore()
     store.sourceCodeItems = []
     const wrapper = makeWrapper()
-    expect(wrapper.text()).toContain('No source codes')
+    expect(wrapper.text()).toContain('Add concepts')
   })
 
   it('triggers resolveSourceCodes when activated', async () => {

--- a/tests/unit/services/concept-search.service.spec.ts
+++ b/tests/unit/services/concept-search.service.spec.ts
@@ -54,6 +54,7 @@ import {
   searchConcepts,
   getConceptById,
   getConceptsByIds,
+  getMappedSourceCodes,
   getConceptsBySourceCodes,
   getConceptRecordCounts,
   getRecommendedConcepts,
@@ -326,6 +327,82 @@ describe('ConceptSearchService', () => {
       })
       const ctrl = new AbortController()
       await getConceptsByIds('SYNPUF1K', [1], ctrl.signal)
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ signal: ctrl.signal }),
+      )
+    })
+  })
+
+  describe('getMappedSourceCodes', () => {
+    const sourceConcept = (id: number, code: string, vocab: string) => ({
+      CONCEPT_ID: id,
+      CONCEPT_NAME: `Source ${id}`,
+      DOMAIN_ID: 'Condition',
+      VOCABULARY_ID: vocab,
+      CONCEPT_CLASS_ID: 'ICD10 code',
+      STANDARD_CONCEPT: null,
+      CONCEPT_CODE: code,
+      INVALID_REASON: null,
+    })
+
+    it('POSTs the concept-id array to lookup/mapped and maps the response', async () => {
+      const apiResponse = [
+        sourceConcept(45542738, 'E11.9', 'ICD10CM'),
+        sourceConcept(44824073, '250.00', 'ICD9CM'),
+      ]
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(apiResponse)),
+      })
+
+      const result = await getMappedSourceCodes('SYNPUF1K', [201826, 443238])
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/vocabulary/SYNPUF1K/lookup/mapped'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify([201826, 443238]),
+        }),
+      )
+      expect(result).toHaveLength(2)
+      expect(result[0]).toMatchObject({ conceptId: 45542738, vocabularyId: 'ICD10CM' })
+    })
+
+    it('returns [] without calling fetch for an empty id list', async () => {
+      const result = await getMappedSourceCodes('SYNPUF1K', [])
+      expect(result).toEqual([])
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('throws for an invalid sourceKey', async () => {
+      await expect(getMappedSourceCodes('', [1])).rejects.toThrow('Invalid vocabulary source')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('throws and logs on a malformed response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ not: 'an array' })),
+      })
+
+      await expect(getMappedSourceCodes('SYNPUF1K', [1])).rejects.toThrow(
+        'Invalid mapped source code lookup response format',
+      )
+      expect(logger.error).toHaveBeenCalled()
+    })
+
+    it('passes the AbortSignal through to fetch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('[]'),
+      })
+      const ctrl = new AbortController()
+      await getMappedSourceCodes('SYNPUF1K', [1], ctrl.signal)
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ signal: ctrl.signal }),

--- a/tests/unit/stores/concept-sets.spec.ts
+++ b/tests/unit/stores/concept-sets.spec.ts
@@ -20,6 +20,7 @@ vi.mock('@/services/concept-search.service', () => ({
   getRecommendedConcepts: vi.fn(),
   getConceptRecordCounts: vi.fn(),
   compareConceptSets: vi.fn(),
+  getMappedSourceCodes: vi.fn(),
 }))
 
 vi.mock('@/utils/api-mappers', () => ({
@@ -78,6 +79,7 @@ import {
   getRecommendedConcepts,
   getConceptRecordCounts,
   compareConceptSets,
+  getMappedSourceCodes,
 } from '@/services/concept-search.service'
 import type { ComparisonResultItem } from '@/models/concept-set.types'
 
@@ -1008,6 +1010,76 @@ describe('Concept Sets Store', () => {
       await inFlight
 
       expect(store.loadingComparison).toBe(false)
+    })
+  })
+
+  describe('resolveSourceCodes', () => {
+    const mappedConcept = (id: number): Concept => ({
+      conceptId: id,
+      conceptName: `Source ${id}`,
+      conceptCode: `${id}`,
+      domainId: 'Condition',
+      vocabularyId: 'ICD10CM',
+      conceptClassId: 'ICD10 code',
+      standardConcept: null,
+      invalidReason: null,
+    })
+
+    it('resolves mapped source codes from the included concept ids', async () => {
+      const store = useConceptSetsStore()
+      store.includedItems = [
+        { ...mappedConcept(1), conceptId: 201826 },
+        { ...mappedConcept(1), conceptId: 443238 },
+      ]
+      vi.mocked(getMappedSourceCodes).mockResolvedValue([mappedConcept(45542738)])
+
+      await store.resolveSourceCodes('SYNPUF1K')
+
+      expect(getMappedSourceCodes).toHaveBeenCalledWith(
+        'SYNPUF1K',
+        [201826, 443238],
+        expect.any(AbortSignal),
+      )
+      expect(store.sourceCodeItems).toHaveLength(1)
+      expect(store.sourceCodeItems[0].conceptId).toBe(45542738)
+      expect(store.sourceCodeLoading).toBe(false)
+      expect(store.sourceCodeError).toBeNull()
+    })
+
+    it('clears items and does not call the service when nothing is included', async () => {
+      const store = useConceptSetsStore()
+      store.includedItems = []
+      store.sourceCodeItems = [mappedConcept(1)]
+
+      await store.resolveSourceCodes('SYNPUF1K')
+
+      expect(getMappedSourceCodes).not.toHaveBeenCalled()
+      expect(store.sourceCodeItems).toEqual([])
+    })
+
+    it('records an error message when the service rejects', async () => {
+      const store = useConceptSetsStore()
+      store.includedItems = [{ ...mappedConcept(1), conceptId: 201826 }]
+      vi.mocked(getMappedSourceCodes).mockRejectedValue(new Error('boom'))
+
+      await store.resolveSourceCodes('SYNPUF1K')
+
+      expect(store.sourceCodeError).toBe('boom')
+      expect(store.sourceCodeLoading).toBe(false)
+    })
+
+    it('resetSourceCodes clears all state', () => {
+      const store = useConceptSetsStore()
+      store.sourceCodeItems = [mappedConcept(1)]
+      store.sourceCodeError = 'x'
+      store.sourceCodeFetchedAt = 123
+
+      store.resetSourceCodes()
+
+      expect(store.sourceCodeItems).toEqual([])
+      expect(store.sourceCodeError).toBeNull()
+      expect(store.sourceCodeFetchedAt).toBeNull()
+      expect(store.sourceCodeLoading).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

Restores the legacy ATLAS **Included Source Codes** view as a new **Source Codes** tab in the Concept Set editor (closes #92). The tab lists the non-standard source codes (ICD10CM, ICD9CM, source SNOMED, etc.) that map to the resolved/included standard concepts, fetched via WebAPI `POST /vocabulary/{sourceKey}/lookup/mapped`.

Built by mirroring the existing **Included** tab end-to-end:

- **Service** — `getMappedSourceCodes(sourceKey, conceptIds, signal?)` in `concept-search.service.ts`, calling `/lookup/mapped` (mirrors `getConceptsByIds`).
- **Store** — `sourceCodeItems / sourceCodeLoading / sourceCodeError / sourceCodeFetchedAt` + `resolveSourceCodes()` / `resetSourceCodes()` on the concept-sets store (mirrors `resolveIncluded`, with the same abort-controller staleness guard). Source codes derive from the already-resolved `includedItems` concept IDs and reset together with the Included list.
- **Component** — new `IncludedSourceCodesTable.vue`: lazily resolves on tab activation (like `RecommendTab`) and renders an `AtlasDataTable` (like `IncludedConceptsTable`). Columns: ID / Code / Name / Class / Domain / Vocabulary.
- **Editor** — new tab (icon `mdi-barcode-scan`, count badge) + window-item wired into `ConceptSetEditor.vue`.
- **i18n** — tab label and empty-state strings in `en.json`.


## Test Plan

- [x] Unit tests: service (5), store (4), component (4) — all new, TDD. Full touched-area suite: **167/167 pass**.
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean on touched files.
- [x] Manual smoke: open a Concept Set with resolved concepts → **Source Codes** tab loads mapped codes with count badge; Retry works on error; clicking a name opens the concept detail.