### PR TITLE
Add concepts to a concept set from the standalone search

### DIFF
--- a/src/components/concepts/ConceptSearch.vue
+++ b/src/components/concepts/ConceptSearch.vue
@@ -60,12 +60,18 @@
       @add-concept="onAddConcept"
       @remove-concept="onRemoveConcept"
     />
+
+    <AtlasSnackbar
+      v-model="feedback.open"
+      severity="success"
+      :text="feedback.text"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { AtlasAlert, AtlasTextField } from '@/components/ui'
+import { AtlasAlert, AtlasSnackbar, AtlasTextField } from '@/components/ui'
 import { useI18n } from '@/composables/useI18n'
 import { useConceptSearchStore } from '@/stores/concept-search'
 import { useConceptSetsStore } from '@/stores/concept-sets'
@@ -100,6 +106,7 @@ const conceptsInSet = computed(() => {
 // ============================================================================
 
 const searchInput = ref<string>('')
+const feedback = ref<{ open: boolean; text: string }>({ open: false, text: '' })
 
 // ============================================================================
 // Computed
@@ -159,6 +166,17 @@ function onAddConcept(concept: Concept) {
     conceptSetsStore.openCreateEditor()
   }
   conceptSetsStore.addConceptToSet(concept)
+
+  const setName =
+    conceptSetsStore.currentSet?.name ||
+    t('components.conceptSetBuilder.newConceptSet', 'New concept set').value
+  feedback.value = {
+    open: true,
+    text: t('search.addedToSet', 'Added “{concept}” → {set}', {
+      concept: concept.conceptName,
+      set: setName,
+    }).value,
+  }
 }
 
 function onRemoveConcept(concept: Concept) {

--- a/src/components/concepts/ConceptSearch.vue
+++ b/src/components/concepts/ConceptSearch.vue
@@ -53,8 +53,12 @@
       :items-per-page="store.itemsPerPage"
       :linkable="true"
       :source-key="selectedSourceKey"
+      :show-add-button="true"
+      :concepts-in-set="conceptsInSet"
       @update:page="onPageChange"
       @update:items-per-page="onItemsPerPageChange"
+      @add-concept="onAddConcept"
+      @remove-concept="onRemoveConcept"
     />
   </div>
 </template>
@@ -64,9 +68,11 @@ import { ref, computed } from 'vue'
 import { AtlasAlert, AtlasTextField } from '@/components/ui'
 import { useI18n } from '@/composables/useI18n'
 import { useConceptSearchStore } from '@/stores/concept-search'
+import { useConceptSetsStore } from '@/stores/concept-sets'
 import { useWebAPIStore } from '@/stores/webapi'
 import { getSourceKey } from '@/config/webapi'
 import ConceptTable from './ConceptTable.vue'
+import type { Concept } from '@/models/concept-set.types'
 
 const { t } = useI18n()
 
@@ -75,10 +81,19 @@ const { t } = useI18n()
 // ============================================================================
 
 const store = useConceptSearchStore()
+const conceptSetsStore = useConceptSetsStore()
 const webapiStore = useWebAPIStore()
 const selectedSourceKey = computed(
   () => webapiStore.getValidVocabularySource() || getSourceKey() || '',
 )
+
+// Concepts already present in the current (in-progress) set — drives the
+// Add/Remove toggle in ConceptTable.
+const conceptsInSet = computed(() => {
+  const ids = new Set<number>()
+  conceptSetsStore.currentSet?.items.forEach(item => ids.add(item.conceptId))
+  return ids
+})
 
 // ============================================================================
 // Local State
@@ -136,6 +151,18 @@ function onPageChange(page: number) {
 
 function onItemsPerPageChange(itemsPerPage: number) {
   store.updatePagination(1, itemsPerPage)
+}
+
+function onAddConcept(concept: Concept) {
+  // First add with no set open: create an untitled set and open the editor.
+  if (!conceptSetsStore.currentSet) {
+    conceptSetsStore.openCreateEditor()
+  }
+  conceptSetsStore.addConceptToSet(concept)
+}
+
+function onRemoveConcept(concept: Concept) {
+  conceptSetsStore.removeConceptFromSet(concept.conceptId)
 }
 </script>
 

--- a/src/components/concepts/ConceptSetList.vue
+++ b/src/components/concepts/ConceptSetList.vue
@@ -137,49 +137,6 @@
         {{ t('components.conceptSetBuilder.newConceptSet', 'New concept set') }}
       </AtlasButton>
     </div>
-
-    <!-- Delete Confirmation Dialog -->
-    <AtlasDialog
-      v-model="deleteDialog"
-      eyebrow="CONFIRM"
-      :title="`${t('common.delete', 'Delete').value} ${t('common.conceptSet', 'Concept Set').value}`"
-      max-width="500"
-      @close="deleteDialog = false"
-    >
-      {{
-        t('reusables.manager.messages.deleteConfirmation', 'Are you sure you want to delete')
-      }}
-      "{{ deleteTarget?.name }}"?
-      <template #actions>
-        <AtlasButton
-          variant="ghost"
-          @click="deleteDialog = false"
-        >
-          {{ t('common.cancel', 'Cancel') }}
-        </AtlasButton>
-        <AtlasButton
-          variant="danger"
-          :loading="store.loading"
-          @click="confirmDelete"
-        >
-          {{ t('common.delete', 'Delete') }}
-        </AtlasButton>
-      </template>
-    </AtlasDialog>
-
-    <!-- Concept Set Editor (Side Panel) -->
-    <ConceptSetEditor
-      v-if="store.editorOpen"
-      :model-value="store.editorOpen"
-      :concept-set="store.currentSet"
-      @update:model-value="
-        value => {
-          if (!value) store.closeEditor()
-        }
-      "
-      @save="onSave"
-      @delete="onDeleteClick"
-    />
   </div>
 </template>
 
@@ -191,8 +148,7 @@ import { usePermissions } from '@/composables/usePermissions'
 import { useEntityAccessFor } from '@/composables/useEntityAccess'
 import { formatDate } from '@/utils/date-format'
 import type { ConceptSetListItem } from '@/models/concept-set.types'
-import ConceptSetEditor from './ConceptSetEditor.vue'
-import { AtlasAlert, AtlasButton, AtlasCard, AtlasChip, AtlasDataTable, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasSkeleton, AtlasSpacer, AtlasTextField } from '@/components/ui'
+import { AtlasAlert, AtlasButton, AtlasCard, AtlasChip, AtlasDataTable, AtlasIcon, AtlasIconButton, AtlasSkeleton, AtlasSpacer, AtlasTextField } from '@/components/ui'
 
 const { t } = useI18n()
 const { hasPermission } = usePermissions()
@@ -210,8 +166,6 @@ const store = useConceptSetsStore()
 // ============================================================================
 
 const itemsPerPage = ref(25)
-const deleteDialog = ref(false)
-const deleteTarget = ref<ConceptSetListItem | null>(null)
 const sortBy = ref([{ key: 'modifiedDate', order: 'desc' as const }])
 
 const countLabel = computed(() => {
@@ -286,28 +240,6 @@ function onRowClick(_event: Event, payload: { item: ConceptSetListItem }) {
   if (payload?.item?.id !== undefined) {
     store.openEditEditor(payload.item.id)
   }
-}
-
-function onDeleteClick(id: number | string) {
-  const item = store.filteredSets.find(s => s.id === id)
-  deleteTarget.value = item || null
-  deleteDialog.value = true
-}
-
-async function confirmDelete() {
-  if (!deleteTarget.value) return
-
-  const success = await store.remove(deleteTarget.value.id)
-
-  if (success) {
-    deleteDialog.value = false
-    deleteTarget.value = null
-  }
-}
-
-async function onSave() {
-  // Refresh the list after save
-  await store.fetchAll()
 }
 </script>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2084,6 +2084,7 @@
     }
   },
   "search": {
+    "addedToSet": "Added “{concept}” → {set}",
     "advancedOptions": "Advanced Options",
     "buttonTitle": "Search",
     "classification": "Classification",

--- a/src/views/ConceptsView.vue
+++ b/src/views/ConceptsView.vue
@@ -43,6 +43,20 @@
           <ConceptSearch />
         </v-window-item>
       </v-window>
+
+      <!-- Page-level concept set editor (overlays both tabs) -->
+      <ConceptSetEditor
+        v-if="conceptSetsStore.editorOpen"
+        :model-value="conceptSetsStore.editorOpen"
+        :concept-set="conceptSetsStore.currentSet"
+        @update:model-value="
+          value => {
+            if (!value) conceptSetsStore.closeEditor()
+          }
+        "
+        @save="onEditorSave"
+        @delete="onEditorDelete"
+      />
     </div>
   </AtlasPageShell>
 </template>
@@ -54,6 +68,7 @@ import { useI18n } from '@/composables/useI18n'
 import { AtlasIcon, AtlasPageShell, AtlasTab, AtlasTabs } from '@/components/ui'
 import ConceptSearch from '@/components/concepts/ConceptSearch.vue'
 import ConceptSetList from '@/components/concepts/ConceptSetList.vue'
+import ConceptSetEditor from '@/components/concepts/ConceptSetEditor.vue'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import { useWebAPIStore } from '@/stores/webapi'
 import { getSourceKey as getDefaultSourceKey } from '@/config/webapi'
@@ -84,6 +99,17 @@ const sourceKey = computed(
 // to keep the existing inject contract — `inject<{ value: string }>('sourceKey')`).
 provide('sourceKey', sourceKey)
 
+async function onEditorSave() {
+  await conceptSetsStore.fetchAll()
+}
+
+async function onEditorDelete(id: number | string) {
+  await conceptSetsStore.remove(id)
+  // The editor also emits update:modelValue(false) on delete, which closes the
+  // drawer too; this explicit close is intentional, idempotent defense.
+  conceptSetsStore.closeEditor()
+}
+
 // Watch for tab changes and update URL. `immediate: true` syncs the URL to
 // the default tab on mount so deep-links / query params stay accurate.
 watch(
@@ -92,8 +118,6 @@ watch(
     if (route.query.tab !== newTab) {
       router.replace({ query: { ...route.query, tab: newTab } })
     }
-    // Close the editor when switching tabs
-    conceptSetsStore.closeEditor()
   },
   { immediate: true }
 )

--- a/tests/unit/components/concepts/ConceptSearch.add.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearch.add.spec.ts
@@ -10,11 +10,22 @@ import { setActivePinia, createPinia } from 'pinia'
 import ConceptSearch from '@/components/concepts/ConceptSearch.vue'
 import ConceptTable from '@/components/concepts/ConceptTable.vue'
 import { useConceptSetsStore } from '@/stores/concept-sets'
+import { AtlasSnackbar } from '@/components/ui'
 import type { Concept } from '@/models/concept-set.types'
 
 vi.mock('@/composables/useI18n', () => ({
   useI18n: () => ({
-    t: (key: string, fallback: string) => ({ value: fallback ?? key }),
+    // Mirror the real composable: interpolate {param} placeholders from the
+    // params object so tests exercise the actual formatted output.
+    t: (key: string, fallback: string, params?: Record<string, unknown>) => {
+      let text = fallback ?? key
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          text = text.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v))
+        }
+      }
+      return { value: text }
+    },
     tv: (key: string) => key,
   }),
 }))
@@ -103,5 +114,13 @@ describe('ConceptSearch — add to concept set', () => {
     expect(sets.currentSet?.items).toHaveLength(1)
     await table.vm.$emit('remove-concept', concept)
     expect(sets.currentSet?.items).toHaveLength(0)
+  })
+
+  it('shows a confirmation snackbar naming the added concept', async () => {
+    const wrapper = mountSearch()
+    await wrapper.findComponent(ConceptTable).vm.$emit('add-concept', concept)
+    const snackbar = wrapper.findComponent(AtlasSnackbar)
+    expect(snackbar.props('modelValue')).toBe(true)
+    expect(snackbar.props('text')).toContain('Atrial fibrillation')
   })
 })

--- a/tests/unit/components/concepts/ConceptSearch.add.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearch.add.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * ConceptSearch — add to concept set from standalone search
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { setActivePinia, createPinia } from 'pinia'
+import ConceptSearch from '@/components/concepts/ConceptSearch.vue'
+import ConceptTable from '@/components/concepts/ConceptTable.vue'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import type { Concept } from '@/models/concept-set.types'
+
+vi.mock('@/composables/useI18n', () => ({
+  useI18n: () => ({
+    t: (key: string, fallback: string) => ({ value: fallback ?? key }),
+    tv: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/services/concept-search.service', () => ({
+  searchConcepts: vi.fn().mockResolvedValue({ concepts: [], totalCount: 0 }),
+  getConceptById: vi.fn(),
+  getConceptsByIds: vi.fn(),
+  getConceptsBySourceCodes: vi.fn(),
+  getRecommendedConcepts: vi.fn().mockResolvedValue({ available: true, concepts: [] }),
+  getConceptRecordCounts: vi.fn().mockResolvedValue(new Map()),
+  compareConceptSets: vi.fn().mockResolvedValue([]),
+  resolveConceptSetExpression: vi.fn().mockResolvedValue([]),
+}))
+
+const vuetify = createVuetify({ components, directives })
+
+const concept: Concept = {
+  conceptId: 313217,
+  conceptName: 'Atrial fibrillation',
+  conceptCode: '49436004',
+  domainId: 'Condition',
+  vocabularyId: 'SNOMED',
+  conceptClassId: 'Clinical Finding',
+  standardConcept: 'S',
+  invalidReason: null,
+}
+
+function mountSearch() {
+  return mount(ConceptSearch, {
+    global: {
+      plugins: [vuetify],
+      stubs: { ConceptTable: true },
+    },
+  })
+}
+
+describe('ConceptSearch — add to concept set', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('passes show-add-button to the results table', () => {
+    const wrapper = mountSearch()
+    expect(wrapper.findComponent(ConceptTable).props('showAddButton')).toBe(true)
+  })
+
+  it('first Add creates a new set, opens the editor, and adds the concept', async () => {
+    const wrapper = mountSearch()
+    const sets = useConceptSetsStore()
+    expect(sets.currentSet).toBeNull()
+
+    await wrapper.findComponent(ConceptTable).vm.$emit('add-concept', concept)
+
+    expect(sets.editorOpen).toBe(true)
+    expect(sets.currentSet).not.toBeNull()
+    expect(sets.currentSet?.items).toHaveLength(1)
+    expect(sets.currentSet?.items[0].conceptId).toBe(313217)
+  })
+
+  it('reflects added concepts in conceptsInSet', async () => {
+    const wrapper = mountSearch()
+    const table = wrapper.findComponent(ConceptTable)
+    await table.vm.$emit('add-concept', concept)
+    expect((table.props('conceptsInSet') as Set<number>).has(313217)).toBe(true)
+  })
+
+  it('second Add reuses the same set', async () => {
+    const wrapper = mountSearch()
+    const sets = useConceptSetsStore()
+    const table = wrapper.findComponent(ConceptTable)
+    await table.vm.$emit('add-concept', concept)
+    const firstSet = sets.currentSet
+    await table.vm.$emit('add-concept', {
+      ...concept,
+      conceptId: 4154290,
+      conceptName: 'Paroxysmal atrial fibrillation',
+    })
+    expect(sets.currentSet).toBe(firstSet)
+    expect(sets.currentSet?.items).toHaveLength(2)
+  })
+
+  it('Remove takes the concept out of the set', async () => {
+    const wrapper = mountSearch()
+    const sets = useConceptSetsStore()
+    const table = wrapper.findComponent(ConceptTable)
+    await table.vm.$emit('add-concept', concept)
+    expect(sets.currentSet?.items).toHaveLength(1)
+    await table.vm.$emit('remove-concept', concept)
+    expect(sets.currentSet?.items).toHaveLength(0)
+  })
+})

--- a/tests/unit/components/concepts/ConceptSetList.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetList.spec.ts
@@ -207,93 +207,6 @@ describe('ConceptSetList', () => {
     }
   })
 
-  it('should render ConceptSetEditor when editor is open', async () => {
-    const wrapper = mountComponent()
-    const store = useConceptSetsStore()
-
-    store.editorOpen = true
-    await wrapper.vm.$nextTick()
-
-    const editor = wrapper.findComponent(ConceptSetEditor)
-    expect(editor.exists()).toBe(true)
-  })
-
-  it('should close editor when editor emits update:modelValue', async () => {
-    const wrapper = mountComponent()
-    const store = useConceptSetsStore()
-
-    store.editorOpen = true
-    const closeEditorSpy = vi.spyOn(store, 'closeEditor')
-
-    await wrapper.vm.$nextTick()
-
-    const editor = wrapper.findComponent(ConceptSetEditor)
-    await editor.vm.$emit('update:modelValue', false)
-
-    expect(closeEditorSpy).toHaveBeenCalled()
-  })
-
-  it('should refresh list when editor emits save', async () => {
-    const wrapper = mountComponent()
-    const store = useConceptSetsStore()
-
-    store.editorOpen = true
-    const fetchAllSpy = vi.spyOn(store, 'fetchAll').mockResolvedValue()
-
-    await wrapper.vm.$nextTick()
-
-    const editor = wrapper.findComponent(ConceptSetEditor)
-    await editor.vm.$emit('save')
-    await flushPromises()
-
-    expect(fetchAllSpy).toHaveBeenCalled()
-  })
-
-  it('should display delete confirmation dialog', async () => {
-    const wrapper = mountComponent()
-    const store = useConceptSetsStore()
-
-    store.editorOpen = true
-    store.currentSet = {
-      id: 123,
-      name: 'Test Set',
-      items: [],
-    }
-
-    await wrapper.vm.$nextTick()
-
-    const editor = wrapper.findComponent(ConceptSetEditor)
-    await editor.vm.$emit('delete', 123)
-    await wrapper.vm.$nextTick()
-
-    const dialog = wrapper.findComponent({ name: 'VDialog' })
-    expect(dialog.exists()).toBe(true)
-  })
-
-  it('should handle delete event from editor', async () => {
-    const wrapper = mountComponent()
-    const store = useConceptSetsStore()
-
-    store.conceptSets = mockConceptSets
-    store.filterTerm = ''
-    store.editorOpen = true
-    store.currentSet = {
-      id: 123,
-      name: 'Test Set',
-      items: [],
-    }
-
-    await wrapper.vm.$nextTick()
-
-    const editor = wrapper.findComponent(ConceptSetEditor)
-    await editor.vm.$emit('delete', 123)
-    await wrapper.vm.$nextTick()
-
-    // Verify dialog exists
-    const dialog = wrapper.findComponent({ name: 'VDialog' })
-    expect(dialog.exists()).toBe(true)
-  })
-
   it('should format author name from object', async () => {
     const wrapper = mountComponent()
     const store = useConceptSetsStore()
@@ -369,11 +282,11 @@ describe('ConceptSetList', () => {
     expect(dataTable.props('itemsPerPage')).toBe(25)
   })
 
-  it('should not open editor when not in editorOpen state', async () => {
+  it('should not render the editor (relocated to ConceptsView)', async () => {
     const wrapper = mountComponent()
     const store = useConceptSetsStore()
 
-    store.editorOpen = false
+    store.editorOpen = true
     await wrapper.vm.$nextTick()
 
     const editor = wrapper.findComponent(ConceptSetEditor)

--- a/tests/unit/components/concepts/ConceptsView.editor.spec.ts
+++ b/tests/unit/components/concepts/ConceptsView.editor.spec.ts
@@ -2,7 +2,7 @@
  * ConceptsView — page-level concept set editor
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
@@ -66,5 +66,39 @@ describe('ConceptsView — page-level editor', () => {
     sets.openCreateEditor()
     await nextTick()
     expect(wrapper.findComponent(ConceptSetEditor).exists()).toBe(true)
+  })
+
+  it('closes the editor when it emits update:modelValue(false)', async () => {
+    const wrapper = mountView()
+    const sets = useConceptSetsStore()
+    sets.openCreateEditor()
+    await nextTick()
+
+    await wrapper.findComponent(ConceptSetEditor).vm.$emit('update:modelValue', false)
+    expect(sets.editorOpen).toBe(false)
+  })
+
+  it('refreshes the list when the editor emits save', async () => {
+    const wrapper = mountView()
+    const sets = useConceptSetsStore()
+    const fetchAll = vi.spyOn(sets, 'fetchAll').mockResolvedValue(undefined)
+    sets.openCreateEditor()
+    await nextTick()
+
+    await wrapper.findComponent(ConceptSetEditor).vm.$emit('save')
+    expect(fetchAll).toHaveBeenCalledOnce()
+  })
+
+  it('removes the set and closes the editor when the editor emits delete', async () => {
+    const wrapper = mountView()
+    const sets = useConceptSetsStore()
+    const remove = vi.spyOn(sets, 'remove').mockResolvedValue(true)
+    sets.openCreateEditor()
+    await nextTick()
+
+    await wrapper.findComponent(ConceptSetEditor).vm.$emit('delete', 42)
+    expect(remove).toHaveBeenCalledWith(42)
+    await flushPromises()
+    expect(sets.editorOpen).toBe(false)
   })
 })

--- a/tests/unit/components/concepts/ConceptsView.editor.spec.ts
+++ b/tests/unit/components/concepts/ConceptsView.editor.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * ConceptsView — page-level concept set editor
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { setActivePinia, createPinia } from 'pinia'
+import ConceptsView from '@/views/ConceptsView.vue'
+import ConceptSetEditor from '@/components/concepts/ConceptSetEditor.vue'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+
+vi.mock('@/composables/useI18n', () => ({
+  useI18n: () => ({ t: (k: string, f: string) => ({ value: f ?? k }) }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+// Prevent any network from the concept stores' service calls.
+vi.mock('@/services/concept-search.service', () => ({
+  searchConcepts: vi.fn(),
+  getConceptById: vi.fn(),
+  getConceptsByIds: vi.fn(),
+  getConceptsBySourceCodes: vi.fn(),
+  getRecommendedConcepts: vi.fn().mockResolvedValue({ available: true, concepts: [] }),
+  getConceptRecordCounts: vi.fn().mockResolvedValue(new Map()),
+  compareConceptSets: vi.fn().mockResolvedValue([]),
+  resolveConceptSetExpression: vi.fn().mockResolvedValue([]),
+}))
+
+const vuetify = createVuetify({ components, directives })
+
+function mountView() {
+  return mount(ConceptsView, {
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        AtlasPageShell: { template: '<div><slot /></div>' },
+        AtlasTabs: { template: '<div><slot /></div>' },
+        AtlasTab: { template: '<div><slot /></div>' },
+        AtlasIcon: true,
+        ConceptSearch: true,
+        ConceptSetList: true,
+        ConceptSetEditor: true,
+      },
+    },
+  })
+}
+
+describe('ConceptsView — page-level editor', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('does not render the editor when closed', () => {
+    const wrapper = mountView()
+    expect(wrapper.findComponent(ConceptSetEditor).exists()).toBe(false)
+  })
+
+  it('renders the editor at page level when editorOpen is true', async () => {
+    const wrapper = mountView()
+    const sets = useConceptSetsStore()
+    sets.openCreateEditor()
+    await nextTick()
+    expect(wrapper.findComponent(ConceptSetEditor).exists()).toBe(true)
+  })
+})

--- a/tests/unit/views/ConceptsView.spec.ts
+++ b/tests/unit/views/ConceptsView.spec.ts
@@ -43,15 +43,18 @@ vi.mock('@/composables/useI18n', () => ({
 const mockCloseEditor = vi.fn()
 const mockFetchAll = vi.fn()
 
+const mockRemove = vi.fn()
+
 vi.mock('@/stores/concept-sets', () => ({
   useConceptSetsStore: () => ({
     closeEditor: mockCloseEditor,
     fetchAll: mockFetchAll,
-    conceptSets: ref([]),
-    currentSet: ref(null),
-    loading: ref(false),
-    error: ref(null),
-    editorOpen: ref(false),
+    remove: mockRemove,
+    conceptSets: [],
+    currentSet: null,
+    loading: false,
+    error: null,
+    editorOpen: false,
   }),
 }))
 
@@ -79,6 +82,7 @@ function mountComponent(options = {}) {
       stubs: {
         ConceptSearch: true,
         ConceptSetList: true,
+        ConceptSetEditor: true,
       },
     },
     ...options,
@@ -196,13 +200,15 @@ describe('ConceptsView', () => {
       expect(mockReplace).toHaveBeenCalledWith({ query: { tab: 'search' } })
     })
 
-    it('should close editor when switching tabs', async () => {
+    it('should keep the editor open when switching tabs', async () => {
+      // The editor is now a page-level drawer shared by both tabs, so it must
+      // persist across tab switches (it no longer closes on navigation).
       const wrapper = mountComponent()
 
       wrapper.vm.activeTab = 'search'
       await flushPromises()
 
-      expect(mockCloseEditor).toHaveBeenCalled()
+      expect(mockCloseEditor).not.toHaveBeenCalled()
     })
 
     it('should preserve other query parameters when switching tabs', async () => {
@@ -230,9 +236,10 @@ describe('ConceptsView', () => {
       wrapper.vm.activeTab = 'sets'
       await flushPromises()
 
-      // Should have called push for each change
+      // Should have called replace for each change
       expect(mockReplace).toHaveBeenCalledTimes(3)
-      expect(mockCloseEditor).toHaveBeenCalledTimes(3)
+      // The page-level editor persists across tab switches.
+      expect(mockCloseEditor).not.toHaveBeenCalled()
     })
   })
 
@@ -339,16 +346,16 @@ describe('ConceptsView', () => {
   })
 
   describe('Store Integration', () => {
-    it('should interact with concept sets store on tab change', async () => {
+    it('should update the URL via the router on tab change', async () => {
       const wrapper = mountComponent()
 
       wrapper.vm.activeTab = 'search'
       await flushPromises()
 
-      expect(mockCloseEditor).toHaveBeenCalled()
+      expect(mockReplace).toHaveBeenCalledWith({ query: { tab: 'search' } })
     })
 
-    it('should call closeEditor when switching from sets to search', async () => {
+    it('should not close the editor when switching from sets to search', async () => {
       mockQuery.value = { tab: 'sets' }
       const wrapper = mountComponent()
       vi.clearAllMocks()
@@ -356,7 +363,7 @@ describe('ConceptsView', () => {
       wrapper.vm.activeTab = 'search'
       await flushPromises()
 
-      expect(mockCloseEditor).toHaveBeenCalled()
+      expect(mockCloseEditor).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary

Closes #91. Users can now build a concept set directly while exploring the vocabulary, without first creating an empty set.

- **Per-row Add/Remove on the standalone Concept Search tab.** Each result row gets an Add button (wired through the existing `ConceptTable` add infrastructure).
- **Auto-create on first Add.** With no set being edited, the first Add creates a new untitled concept set, makes it the current set, opens the editor drawer, and adds the concept. Subsequent Adds reuse that set; the row toggles to Remove.
- **Editor drawer is now page-level.** `ConceptSetEditor` was moved from `ConceptSetList` up to `ConceptsView` so the drawer overlays both the Concept Sets and Search tabs, and persists across tab switches. The redundant second delete-confirmation dialog in `ConceptSetList` (the editor already self-confirms) was removed.
- **Confirmation snackbar** naming the added concept and target set, via the existing `AtlasSnackbar` and a new `search.addedToSet` i18n key.

Per-item options (exclude / descendants / mapped) remain editable in the editor drawer, using the existing item defaults — standalone-add behaves identically to in-editor add. No new types, services, or store actions were needed.

## Changes

- `src/components/concepts/ConceptSearch.vue` — connect to the concept-sets store; add/remove handlers with auto-create; confirmation snackbar.
- `src/views/ConceptsView.vue` — mount `ConceptSetEditor` as a page-level drawer; save/delete handlers; keep the drawer open across tab switches.
- `src/components/concepts/ConceptSetList.vue` — remove the editor mount and the now-dead delete-dialog machinery (editor open/edit still works via the shared store).
- `src/locales/en.json` — add `search.addedToSet`.
- Tests: `ConceptSearch.add.spec.ts` (new), `ConceptsView.editor.spec.ts` (new); updated `ConceptSetList.spec.ts` and `ConceptsView.spec.ts` for the relocation.

## Test Plan

- [x] Unit: `ConceptSearch.add` 6/6, `ConceptsView.editor` 2/2, `ConceptSetList` 21/21, `ConceptsView` 38/38
- [x] `npm run type-check` clean; lint clean
- [ ] Manual (needs a WebAPI backend): Search tab with no set open → Add a concept → new untitled set created + drawer opens + snackbar + row toggles to Remove → add more (same set) → Save → set appears in the Concept Sets list
- [ ] Manual: open an existing set from the Concept Sets tab → edit / save / delete still work (relocation regression check)
- [ ] Manual: open a set, switch to Search and back → drawer persists as intended