### PR TITLE
fix(plugins): stack overlay panel above the FAB on the z-axis

### DIFF
--- a/src/components/plugins/PluginOverlayHost.vue
+++ b/src/components/plugins/PluginOverlayHost.vue
@@ -105,7 +105,8 @@ onUnmounted(unmount)
   position: fixed;
   inset: 0;
   background: transparent;
-  z-index: 1100;
+  /* Above the FAB (z-index 2000) so the open panel sits on top of it. */
+  z-index: 2001;
   /* Reset native button chrome — this is a click-to-close overlay,
      rendered as a <button> only for a11y (keyboard activation + role). */
   border: 0;
@@ -114,15 +115,18 @@ onUnmounted(unmount)
 }
 .plugin-overlay-panel {
   position: fixed;
-  bottom: 96px;
+  /* Overlap the FAB and render above it (z-index) rather than stacking
+     above it on the y-axis. The panel covers the button while open; it's
+     dismissed via the backdrop or Esc. */
+  bottom: 24px;
   right: 24px;
   width: min(420px, calc(100vw - 48px));
-  height: min(640px, calc(100vh - 144px));
+  height: min(640px, calc(100vh - 48px));
   background: rgb(var(--v-theme-background));
   border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
   border-radius: 12px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
-  z-index: 1101;
+  z-index: 2002;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## What

The plugin overlay panel opened *above* the floating action button on the y-axis (`bottom: 96px`) and sat *behind* it in z-order (panel `z-index: 1101` vs the FAB's `2000`).

This moves the panel over the button and lifts it above the FAB so the open chat window renders on top of the floating button instead of stacked above it:

- panel `bottom: 96px → 24px` (overlaps the FAB position)
- panel `z-index: 1101 → 2002`, backdrop `1100 → 2001` — both above the FAB (`2000`)
- panel height `calc(100vh - 144px) → calc(100vh - 48px)` to match the new offset

The panel still covers the button while open and is dismissed via backdrop click or Esc.

## Files

- `src/components/plugins/PluginOverlayHost.vue`