### PR TITLE
Surface concept-set load errors in Compare; align entry "ANY" marker

### DIFF
--- a/src/components/cohort/EntryEventsList.vue
+++ b/src/components/cohort/EntryEventsList.vue
@@ -11,7 +11,7 @@
         aria-disabled="true"
         :title="t('components.cohortExpressionEditor.entryEventsAnyHint', 'Entry events are matched with ANY (or)').value"
       >
-        {{ t('options.any', 'ANY') }}
+        <span class="entry-any-label__text">{{ t('options.any', 'ANY') }}</span>
       </div>
       <div class="events-container__body">
         <!-- Toolbar: add-criteria menu + observation-period pill -->
@@ -236,25 +236,51 @@ function updateObservationPeriod(field: 'priorDays' | 'postDays', value: string 
   padding: 12px 20px 16px;
 }
 
-/* Greyed, non-interactive "ANY" label (discussion #100). Mirrors the
-   inclusion-rule vertical match-type label but neutral and not clickable —
-   entry events are always an implicit OR. */
+/* Greyed, non-interactive "ANY" label (discussion #100). Mirrors the geometry
+   of the inclusion-rule vertical match-type label (GroupCriteriaUI's
+   .vertical-label / ::before accent stripe) so the two read as the same family,
+   but neutral and not clickable — entry events are always an implicit OR, so
+   there's nothing to edit. Greys are hard-coded (not theme tokens) for the same
+   reason GroupCriteriaUI hard-codes its navy: this app's --v-theme-*-variant
+   tokens resolve to 0,0,0 and can't express a muted grey. */
 .entry-any-label {
   position: relative;
   width: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
+  border: 1px solid #d4d9e0;
+  border-radius: 0 0 0 8px;
+  background: #f6f7f9;
+  user-select: none;
+  cursor: default;
+}
+
+/* Left accent stripe — the grey counterpart of the coloured bar the editable
+   match-type marker shows. */
+.entry-any-label::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 30%;
+  background: #aab2bf;
+  border-radius: 0 0 0 6px;
+}
+
+.entry-any-label__text {
+  position: relative;
+  z-index: 1;
   writing-mode: sideways-lr;
   text-orientation: sideways;
   font-weight: 700;
   font-size: 14px;
   letter-spacing: 0.5px;
-  color: rgb(var(--v-theme-on-surface-variant));
-  background: rgb(var(--v-theme-surface-variant), 0.5);
-  border-right: 1px solid rgb(var(--v-theme-outline-variant));
-  user-select: none;
-  cursor: default;
+  padding-left: 8px;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  color: #79828f;
 }
 
 .add-filter-wrapper {

--- a/src/components/concepts/CompareTab.vue
+++ b/src/components/concepts/CompareTab.vue
@@ -283,10 +283,17 @@ function onOtherSelected(id: number) {
 
 async function preloadOther(id: number) {
   store.loadingComparison = true
+  store.comparisonError = null
   try {
     const { getConceptSetById } = await import('@/services/concept-set.service')
-    const set = await getConceptSetById(id)
+    const set = await getConceptSetById(id, { rethrow: true })
     if (set) store.comparisonOtherSet = set
+  } catch (err) {
+    // A saved set often can't be resolved against the active vocabulary source
+    // (its concepts may not exist there). Surface the reason instead of leaving
+    // the chip silently empty with the Compare button stuck disabled.
+    store.comparisonOtherSet = null
+    store.comparisonError = err instanceof Error ? err.message : String(err)
   } finally {
     store.loadingComparison = false
   }

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -52,7 +52,23 @@ async function fetchJSON<T>(endpoint: string, options?: RequestInit): Promise<T>
   })
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+    // Surface the server's error body (e.g. WebAPI's "Current data source does
+    // not contain required concepts …") instead of the bare status text, which
+    // alone is useless for diagnosing why a concept set won't resolve.
+    let detail = response.statusText
+    try {
+      const text = await response.text()
+      if (text) {
+        try {
+          detail = (JSON.parse(text) as { message?: string }).message ?? text
+        } catch {
+          detail = text
+        }
+      }
+    } catch {
+      // keep statusText
+    }
+    throw new Error(`HTTP ${response.status}: ${detail}`)
   }
 
   // Handle 204 No Content
@@ -94,7 +110,10 @@ export async function getAllConceptSets(): Promise<ConceptSetListItem[]> {
  * @param id Concept set ID
  * @returns Concept set with items or null if not found
  */
-export async function getConceptSetById(id: number | string): Promise<ConceptSet | null> {
+export async function getConceptSetById(
+  id: number | string,
+  options?: { rethrow?: boolean }
+): Promise<ConceptSet | null> {
   try {
     // Fetch metadata and expression separately
     const [metadata, expression] = await Promise.all([
@@ -112,6 +131,9 @@ export async function getConceptSetById(id: number | string): Promise<ConceptSet
     return mapConceptSetFromAPI(combined)
   } catch (error) {
     logger.error('ConceptSet', `Failed to fetch concept set ${id}`, error)
+    // Most callers treat a failed load as "not found" (null). Callers that need
+    // to tell the user *why* it failed (e.g. the Compare picker) opt into rethrow.
+    if (options?.rethrow) throw error
     return null
   }
 }

--- a/tests/unit/components/concepts/CompareTab.modes.spec.ts
+++ b/tests/unit/components/concepts/CompareTab.modes.spec.ts
@@ -166,6 +166,22 @@ describe('CompareTab — mode toggle (#102)', () => {
     expect(store.comparisonOtherSet?.id).toBe(3)
   })
 
+  it('surfaces an error (and leaves the chip empty) when the other set fails to load', async () => {
+    const wrapper = mountComponent()
+    const store = primeComparable()
+    store.comparisonOtherSet = null
+    getConceptSetByIdMock.mockRejectedValue(
+      new Error('HTTP 400: Current data source does not contain required concepts (443238,201820)')
+    )
+    ;(wrapper.vm as unknown as { onOtherSelected: (id: number) => void }).onOtherSelected(3)
+    await flushPromises()
+
+    expect(store.comparisonOtherSet).toBeNull()
+    expect(store.comparisonError).toBeTruthy()
+    expect(store.comparisonError).toContain('required concepts')
+    expect(store.loadingComparison).toBe(false)
+  })
+
   it('includes the mode in the export filename', async () => {
     downloadCsvMock.mockClear()
     const wrapper = mountComponent()

--- a/tests/unit/services/concept-set.service.spec.ts
+++ b/tests/unit/services/concept-set.service.spec.ts
@@ -174,6 +174,43 @@ describe('ConceptSetService', () => {
 
       expect(result).toBeNull()
     })
+
+    it('rethrows with the server message body when rethrow is requested', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: 3 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                message: 'Current data source does not contain required concepts (443238)',
+              })
+            ),
+        })
+
+      await expect(getConceptSetById(3, { rethrow: true })).rejects.toThrow(/required concepts/)
+    })
+
+    it('falls back to the raw body text when the error body is not JSON', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: 3 }),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: () => Promise.resolve('plain text failure'),
+        })
+
+      await expect(getConceptSetById(3, { rethrow: true })).rejects.toThrow(/plain text failure/)
+    })
   })
 
   describe('createConceptSet', () => {


### PR DESCRIPTION
## Compare tab — surface load errors

Picking a second concept set whose concepts aren't in the active vocabulary made WebAPI return `400 (does not contain required concepts)`. The error was swallowed to `null` and ignored, so the "Concept Set 2" chip never appeared and **Compare stayed disabled with no feedback** — i.e. "compare doesn't work."

- `fetchJSON` now includes the server's error body instead of bare `HTTP 400`.
- `getConceptSetById` takes an opt-in `{ rethrow }` so the Compare picker can show the reason; all other callers keep the existing null-on-failure contract.
- `CompareTab.preloadOther` catches and surfaces the reason via `comparisonError`.
- Added a regression test.

Verified end-to-end: the unresolvable set now shows a clear error; a valid compare renders the Venn + table correctly.

## Entry events — align the "ANY" marker

The non-editable entry "ANY" marker looked nothing like the editable inclusion-rule match-type marker. Restyled it to mirror that marker's geometry (bordered tab + left accent stripe + bold sideways text) in a muted grey palette, signalling it isn't editable.

Greys are hard-coded for the same reason the sibling marker hard-codes its navy: the app's `--v-theme-*-variant` tokens resolve to black.

## Tests
`CompareTab.modes` (+1 new), `concept-set.service`, and `EntryEventsList` suites pass; type-check clean.