### PR TITLE
fix(mappers): align cardinality mapping with CIRCE Occurrence.Type enum

### DIFF
--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -31,18 +31,19 @@ export const ATLAS_TO_OPERATOR: Record<string, string> = {
 
 /**
  * Cardinality type mappings
- * Internal (AT_LEAST) ↔ Atlas (0)
+ * Per the CIRCE Occurrence.Type enum: EXACTLY = 0, AT_MOST = 1, AT_LEAST = 2
+ * (must stay in sync with the inline mapping in services/atlas-converter.ts)
  */
 export const CARDINALITY_TO_ATLAS: Record<CardinalityType, 0 | 1 | 2> = {
-  AT_LEAST: 0,
+  EXACTLY: 0,
   AT_MOST: 1,
-  EXACTLY: 2,
+  AT_LEAST: 2,
 }
 
 export const ATLAS_TO_CARDINALITY: Record<0 | 1 | 2, CardinalityType> = {
-  0: 'AT_LEAST',
+  0: 'EXACTLY',
   1: 'AT_MOST',
-  2: 'EXACTLY',
+  2: 'AT_LEAST',
 }
 
 /**

--- a/tests/unit/utils/mappers.spec.ts
+++ b/tests/unit/utils/mappers.spec.ts
@@ -17,7 +17,9 @@ import {
   attributeKeyToAtlas,
   atlasToAttributeKey,
 } from '@/utils/mappers'
+import { convertInternalToAtlas } from '@/services/atlas-converter'
 import type { CardinalityType, NumericOperator, DateOperator } from '@/models/event.types'
+import type { CohortDefinition } from '@/models/cohort.types'
 
 describe('Operator Mappers', () => {
   describe('OPERATOR_TO_ATLAS', () => {
@@ -96,10 +98,10 @@ describe('Operator Mappers', () => {
 
 describe('Cardinality Mappers', () => {
   describe('CARDINALITY_TO_ATLAS', () => {
-    it('should map all cardinality types to Atlas format', () => {
-      expect(CARDINALITY_TO_ATLAS['AT_LEAST']).toBe(0)
+    it('should map all cardinality types to Atlas format per the CIRCE Occurrence.Type enum', () => {
+      expect(CARDINALITY_TO_ATLAS['EXACTLY']).toBe(0)
       expect(CARDINALITY_TO_ATLAS['AT_MOST']).toBe(1)
-      expect(CARDINALITY_TO_ATLAS['EXACTLY']).toBe(2)
+      expect(CARDINALITY_TO_ATLAS['AT_LEAST']).toBe(2)
     })
 
     it('should contain exactly 3 cardinality mappings', () => {
@@ -109,9 +111,9 @@ describe('Cardinality Mappers', () => {
 
   describe('ATLAS_TO_CARDINALITY', () => {
     it('should map all Atlas cardinality types to internal format', () => {
-      expect(ATLAS_TO_CARDINALITY[0]).toBe('AT_LEAST')
+      expect(ATLAS_TO_CARDINALITY[0]).toBe('EXACTLY')
       expect(ATLAS_TO_CARDINALITY[1]).toBe('AT_MOST')
-      expect(ATLAS_TO_CARDINALITY[2]).toBe('EXACTLY')
+      expect(ATLAS_TO_CARDINALITY[2]).toBe('AT_LEAST')
     })
 
     it('should contain exactly 3 cardinality mappings', () => {
@@ -121,17 +123,45 @@ describe('Cardinality Mappers', () => {
 
   describe('cardinalityToAtlas', () => {
     it('should convert internal cardinality types to Atlas format', () => {
-      expect(cardinalityToAtlas('AT_LEAST' as CardinalityType)).toBe(0)
+      expect(cardinalityToAtlas('EXACTLY' as CardinalityType)).toBe(0)
       expect(cardinalityToAtlas('AT_MOST' as CardinalityType)).toBe(1)
-      expect(cardinalityToAtlas('EXACTLY' as CardinalityType)).toBe(2)
+      expect(cardinalityToAtlas('AT_LEAST' as CardinalityType)).toBe(2)
     })
   })
 
   describe('atlasToCardinality', () => {
     it('should convert Atlas cardinality types to internal format', () => {
-      expect(atlasToCardinality(0)).toBe('AT_LEAST')
+      expect(atlasToCardinality(0)).toBe('EXACTLY')
       expect(atlasToCardinality(1)).toBe('AT_MOST')
-      expect(atlasToCardinality(2)).toBe('EXACTLY')
+      expect(atlasToCardinality(2)).toBe('AT_LEAST')
+    })
+  })
+
+  describe('agreement with atlas-converter', () => {
+    // Regression: the mappers previously transposed AT_LEAST (0) and EXACTLY (2)
+    // relative to the CIRCE Occurrence.Type enum, inverting "at least" and
+    // "exactly" for any caller while the converter's inline mapping was correct.
+    it('should produce the same Occurrence.Type as convertInternalToAtlas for every cardinality type', () => {
+      const types: CardinalityType[] = ['EXACTLY', 'AT_MOST', 'AT_LEAST']
+      for (const type of types) {
+        const cohort: CohortDefinition = {
+          name: 'Cardinality mapping check',
+          entryEvents: [
+            {
+              id: 'event-1',
+              criteriaType: 'ConditionOccurrence',
+              cardinality: { type, count: 1, countingMethod: 'ALL' },
+            },
+          ],
+          qualifyingLimit: 'ALL',
+          inclusionRules: [],
+          conceptSets: [],
+        }
+        const atlas = convertInternalToAtlas(cohort)
+        const occurrence = atlas.PrimaryCriteria.CriteriaList[0]?.Occurrence
+        expect(occurrence?.Type).toBe(cardinalityToAtlas(type))
+        expect(atlasToCardinality(occurrence!.Type)).toBe(type)
+      }
     })
   })
 })


### PR DESCRIPTION
CARDINALITY_TO_ATLAS and ATLAS_TO_CARDINALITY had AT_LEAST and EXACTLY transposed (AT_LEAST→0, EXACTLY→2). The CIRCE enum is EXACTLY=0, AT_MOST=1, AT_LEAST=2, as already used by the inline mapping in services/atlas-converter.ts and documented in models/atlas.types.ts.

Any caller of cardinalityToAtlas('AT_LEAST') would emit 0, which Atlas/WebAPI reads as EXACTLY — turning "at least 1 occurrence" into "exactly 1" and inverting cohort semantics. Latent today (production uses the converter's inline mapping; only the spec imported these), but a trap for any future caller.

The existing spec asserted the transposed values, locking the bug in. Corrected those assertions and added a regression test that runs each cardinality type through convertInternalToAtlas and asserts the mapper produces the identical Occurrence.Type, so the two mappings cannot silently diverge again.