### PR TITLE
fix(date-format): guard formatRelativeTime against future and invalid dates

### DIFF
--- a/src/utils/date-format.ts
+++ b/src/utils/date-format.ts
@@ -46,11 +46,18 @@ export function formatRelativeTime(isoDate: string | number | undefined | null):
 
   try {
     const date = new Date(isoDate)
+
+    if (isNaN(date.getTime())) {
+      return 'Unknown'
+    }
+
     const now = new Date()
     const diffMs = now.getTime() - date.getTime()
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 0) {
+    // Timestamps in the future (client/server clock skew) clamp to Today
+    // rather than falling through to a negative "-1 days ago".
+    if (diffDays <= 0) {
       return 'Today'
     } else if (diffDays === 1) {
       return 'Yesterday'

--- a/tests/unit/utils/date-format.spec.ts
+++ b/tests/unit/utils/date-format.spec.ts
@@ -160,5 +160,28 @@ describe('Date Format Utils', () => {
 
       expect(result).toBe('Today')
     })
+
+    it('should return Today for a timestamp a few hours in the future (clock skew)', () => {
+      const threeHoursAhead = Date.now() + (3 * 60 * 60 * 1000)
+
+      const result = formatRelativeTime(threeHoursAhead)
+
+      expect(result).toBe('Today')
+    })
+
+    it('should never render a negative "days ago" for future dates', () => {
+      const threeDaysAhead = Date.now() + (3 * 24 * 60 * 60 * 1000)
+
+      const result = formatRelativeTime(threeDaysAhead)
+
+      expect(result).toBe('Today')
+      expect(result).not.toContain('-')
+    })
+
+    it('should return Unknown for an invalid date string', () => {
+      const result = formatRelativeTime('not-a-date')
+
+      expect(result).toBe('Unknown')
+    })
   })
 })


### PR DESCRIPTION
Timestamps ahead of the local clock (client/server skew on the created/modified columns in AnalysisDataTable) produced a negative diff that fell through the "days ago" branches, rendering "-1 days ago". Future timestamps now clamp to "Today".

Unparseable input had no isNaN guard (unlike formatDate above it), so NaN diffs skipped every branch and rendered "NaN year ago". It now returns "Unknown", matching the null/undefined behavior.