### PR TITLE
Cohort duplication, characterization picker search, and export toolbar fix

### DIFF
--- a/src/components/characterization/LinkedCohortPicker.vue
+++ b/src/components/characterization/LinkedCohortPicker.vue
@@ -69,10 +69,21 @@
       @close="dialogOpen = false"
     >
       <div class="linked-cohort-picker__dialog-body">
+        <AtlasTextField
+          v-model="search"
+          :label="t('common.search', 'Search').value"
+          prepend-icon="mdi-magnify"
+          variant="outlined"
+          hide-details
+          clearable
+          class="mb-3"
+          data-testid="linked-cohort-picker-search"
+        />
         <AtlasDataTable
           v-model="selectedIds"
           :headers="dialogHeaders"
           :items="selectableItems"
+          :search="search"
           item-value="id"
           show-select
           data-testid="linked-cohort-picker-table"
@@ -99,7 +110,7 @@
 </template>
 
 <script setup lang="ts">
-import { AtlasButton, AtlasDataTable, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem } from '@/components/ui'
+import { AtlasButton, AtlasDataTable, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem, AtlasTextField } from '@/components/ui'
 import { computed, ref } from 'vue'
 
 import { useI18n } from '@/composables/useI18n'
@@ -119,6 +130,7 @@ const { t, tv } = useI18n()
 
 const dialogOpen = ref(false)
 const selectedIds = ref<number[]>([])
+const search = ref('')
 
 const dialogHeaders = computed(() => [
   { title: t('cc.viewEdit.results.filters.cohorts', 'Linked Cohorts').value, key: 'name' },
@@ -133,6 +145,7 @@ const selectableItems = computed(() => {
 
 function openDialog() {
   selectedIds.value = []
+  search.value = ''
   dialogOpen.value = true
 }
 

--- a/src/components/characterization/LinkedFeatureAnalysisPicker.vue
+++ b/src/components/characterization/LinkedFeatureAnalysisPicker.vue
@@ -93,10 +93,21 @@
       @close="dialogOpen = false"
     >
       <div class="linked-fa-picker__dialog-body">
+        <AtlasTextField
+          v-model="search"
+          :label="t('common.search', 'Search').value"
+          prepend-icon="mdi-magnify"
+          variant="outlined"
+          hide-details
+          clearable
+          class="mb-3"
+          data-testid="linked-fa-picker-search"
+        />
         <AtlasDataTable
           v-model="selectedIds"
           :headers="dialogHeaders"
           :items="selectableItems"
+          :search="search"
           item-value="id"
           show-select
           data-testid="linked-fa-picker-table"
@@ -123,7 +134,7 @@
 </template>
 
 <script setup lang="ts">
-import { AtlasButton, AtlasCheckbox, AtlasDataTable, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem } from '@/components/ui'
+import { AtlasButton, AtlasCheckbox, AtlasDataTable, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem, AtlasTextField } from '@/components/ui'
 import { computed, ref } from 'vue'
 
 import { useI18n } from '@/composables/useI18n'
@@ -143,6 +154,7 @@ const { t, tv } = useI18n()
 
 const dialogOpen = ref(false)
 const selectedIds = ref<number[]>([])
+const search = ref('')
 
 const dialogHeaders = computed(() => [
   { title: t('columns.name', 'Name').value, key: 'name' },
@@ -182,6 +194,7 @@ function displaySubtitle(fa: LinkedFeatureAnalysis): string {
 
 function openDialog() {
   selectedIds.value = []
+  search.value = ''
   dialogOpen.value = true
 }
 

--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -2341,6 +2341,8 @@ defineExpose({
   },
   handleCancel,
   handleSave,
+  handleExportDownload,
+  handleExportCopy,
   // Existing expose (criteria editor / inclusion panel) is
   // re-declared here because defineExpose may only be called
   // once per component.

--- a/src/components/cohort/CohortCard.vue
+++ b/src/components/cohort/CohortCard.vue
@@ -94,6 +94,25 @@
       </AtlasTooltip>
 
       <AtlasTooltip
+        :text="copyTooltip"
+        location="top"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <AtlasIconButton
+            v-bind="{ ...tooltipProps, ariaLabel: copyTooltip }"
+            icon="mdi-content-copy"
+            variant="text"
+            size="sm"
+            class="cohort-card__action-btn"
+            :disabled="!canCopy || copying"
+            :loading="copying"
+            data-testid="cohort-card-copy"
+            @click.stop="$emit('copy', cohort)"
+          />
+        </template>
+      </AtlasTooltip>
+
+      <AtlasTooltip
         :text="deleteTooltipText"
         location="top"
       >
@@ -125,16 +144,21 @@ import { tagColor, tagContrastColor } from '@/utils/tag-color'
 interface Props {
   cohort: CohortDefinitionSummary
   selectedTags?: string[]
+  canCopy?: boolean
+  copying?: boolean
 }
 
 interface Emits {
   (e: 'delete', cohort: CohortDefinitionSummary): void
+  (e: 'copy', cohort: CohortDefinitionSummary): void
   (e: 'tag-click', tagName: string): void
   (e: 'show-info', cohort: CohortDefinitionSummary): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
   selectedTags: () => [],
+  canCopy: false,
+  copying: false,
 })
 defineEmits<Emits>()
 const router = useRouter()
@@ -145,6 +169,7 @@ const byLabel = t('columns.author', 'Author')
 const createdLabel = t('columns.created', 'Created')
 const updatedOnLabel = t('columns.modified', 'Modified')
 const infoTooltip = t('common.cohortInformation', 'Cohort information')
+const copyTooltip = t('common.duplicate', 'Duplicate')
 const deleteTooltip = t('common.delete', 'Delete')
 const noPermissionTooltip = t('common.noPermission', 'You do not have permission for this action')
 const unknownLabel = t('common.anonymous', 'Unknown')

--- a/src/components/cohort/CohortGrid.vue
+++ b/src/components/cohort/CohortGrid.vue
@@ -79,8 +79,11 @@
         :key="cohort.id"
         :cohort="cohort"
         :selected-tags="selectedTags"
+        :can-copy="canCopy"
+        :copying="copyingId === cohort.id"
         class="cohort-grid__card"
         @delete="$emit('delete', $event)"
+        @copy="$emit('copy', $event)"
         @tag-click="$emit('tag-click', $event)"
         @show-info="$emit('show-info', $event)"
       />
@@ -103,6 +106,8 @@ interface Props {
   error?: Error | null
   searchQuery?: string
   selectedTags?: string[]
+  canCopy?: boolean
+  copyingId?: number | null
 }
 
 interface Emits {
@@ -110,6 +115,7 @@ interface Emits {
   (e: 'create-cohort'): void
   (e: 'clear-filters'): void
   (e: 'delete', cohort: CohortDefinitionSummary): void
+  (e: 'copy', cohort: CohortDefinitionSummary): void
   (e: 'tag-click', tagName: string): void
   (e: 'show-info', cohort: CohortDefinitionSummary): void
 }
@@ -119,6 +125,8 @@ const props = withDefaults(defineProps<Props>(), {
   error: null,
   searchQuery: '',
   selectedTags: () => [],
+  canCopy: false,
+  copyingId: null,
 })
 
 defineEmits<Emits>()

--- a/src/components/cohort/CohortTable.vue
+++ b/src/components/cohort/CohortTable.vue
@@ -164,6 +164,16 @@
                   @click.stop="$emit('show-info', cohort)"
                 />
                 <AtlasIconButton
+                  icon="mdi-content-copy"
+                  v-bind="{ ariaLabel: t('common.duplicate', 'Duplicate').value }"
+                  variant="text"
+                  size="sm"
+                  data-testid="cohort-table-copy"
+                  :disabled="!canCopy || copyingId === cohort.id"
+                  :loading="copyingId === cohort.id"
+                  @click.stop="$emit('copy', cohort)"
+                />
+                <AtlasIconButton
                   icon="mdi-delete-outline"
                   v-bind="{ ariaLabel: t('common.delete', 'Delete').value }"
                   variant="text"
@@ -200,6 +210,8 @@ interface Props {
   error?: Error | null
   searchQuery?: string
   selectedTags?: string[]
+  canCopy?: boolean
+  copyingId?: number | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -207,6 +219,8 @@ const props = withDefaults(defineProps<Props>(), {
   error: null,
   searchQuery: '',
   selectedTags: () => [],
+  canCopy: false,
+  copyingId: null,
 })
 
 defineEmits<{
@@ -214,6 +228,7 @@ defineEmits<{
   'create-cohort': []
   'clear-filters': []
   delete: [cohort: CohortDefinitionSummary]
+  copy: [cohort: CohortDefinitionSummary]
   'tag-click': [tagName: string]
   'show-info': [cohort: CohortDefinitionSummary]
 }>()
@@ -312,7 +327,7 @@ function openCohort(cohort: CohortDefinitionSummary) {
   font-variant-numeric: tabular-nums;
 }
 .cohort-table__col-actions {
-  width: 96px;
+  width: 132px;
   white-space: nowrap;
   text-align: right;
 }

--- a/src/views/CohortBuilderView.vue
+++ b/src/views/CohortBuilderView.vue
@@ -58,6 +58,8 @@
           :is-previewing-version="builderRef.isPreviewingVersion"
           @cancel="builderRef.handleCancel()"
           @save="builderRef.handleSave()"
+          @export-download="builderRef.handleExportDownload()"
+          @export-copy="builderRef.handleExportCopy()"
         />
       </div>
     </template>

--- a/src/views/CohortsView.vue
+++ b/src/views/CohortsView.vue
@@ -109,10 +109,13 @@
         :error="error"
         :search-query="searchQuery"
         :selected-tags="filters.selectedTags"
+        :can-copy="canCreateCohort"
+        :copying-id="copyingId"
         @retry="fetchCohorts"
         @create-cohort="handleCreateCohort"
         @clear-filters="clearFilters"
         @delete="handleDeleteClick"
+        @copy="handleCopyClick"
         @tag-click="handleTagClick"
         @show-info="handleShowInfo"
       />
@@ -123,10 +126,13 @@
         :error="error"
         :search-query="searchQuery"
         :selected-tags="filters.selectedTags"
+        :can-copy="canCreateCohort"
+        :copying-id="copyingId"
         @retry="fetchCohorts"
         @create-cohort="handleCreateCohort"
         @clear-filters="clearFilters"
         @delete="handleDeleteClick"
+        @copy="handleCopyClick"
         @tag-click="handleTagClick"
         @show-info="handleShowInfo"
       />
@@ -336,12 +342,20 @@
           }}
         </div>
       </AtlasDialog>
+
+      <AtlasSnackbar
+        v-model="snackbar.show"
+        :severity="snackbar.severity"
+        :text="snackbar.message"
+        :timeout="snackbar.timeout"
+        data-testid="cohorts-view-snackbar"
+      />
     </div>
   </AtlasPageShell>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from '@/composables/useI18n'
 import { useCohorts } from '@/composables/useCohorts'
@@ -354,12 +368,14 @@ import {
   saveCohortDefinition,
 } from '@/services/webapi'
 import { logger } from '@/utils/logger'
-import { AtlasAlert, AtlasButton, AtlasChip, AtlasDialog, AtlasIcon, AtlasPageShell, AtlasProgressCircular, AtlasProgressLinear, AtlasTextField } from '@/components/ui'
+import { AtlasAlert, AtlasButton, AtlasChip, AtlasDialog, AtlasIcon, AtlasPageShell, AtlasProgressCircular, AtlasProgressLinear, AtlasSnackbar, AtlasTextField } from '@/components/ui'
+import type { AtlasSnackbarSeverity } from '@/components/ui'
 import CohortGrid from '@/components/cohort/CohortGrid.vue'
 import CohortTable from '@/components/cohort/CohortTable.vue'
 import CohortPagination from '@/components/cohort/CohortPagination.vue'
 import CohortFilters from '@/components/cohort/CohortFilters.vue'
 import type { CohortDefinitionSummary } from '@/models/webapi.types'
+import type { AtlasCohortDefinition } from '@/models/atlas.types'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -403,6 +419,28 @@ const importing = ref(false)
 const showCohortInfoDialog = ref(false)
 const cohortInfoHtml = ref<string | null>(null)
 const loadingCohortInfo = ref(false)
+
+// Copy-cohort state
+const copyingId = ref<number | null>(null)
+
+const snackbar = reactive<{
+  show: boolean
+  message: string
+  severity: AtlasSnackbarSeverity
+  timeout: number
+}>({
+  show: false,
+  message: '',
+  severity: 'success',
+  timeout: 3000,
+})
+
+function showSnackbar(message: string, severity: AtlasSnackbarSeverity = 'success') {
+  snackbar.message = message
+  snackbar.severity = severity
+  snackbar.timeout = severity === 'danger' ? 5000 : 3000
+  snackbar.show = true
+}
 
 // Cohorts state management
 const {
@@ -560,6 +598,80 @@ async function confirmImport() {
     ).value
   } finally {
     importing.value = false
+  }
+}
+
+/**
+ * Build a "{name} (copy)" name that doesn't collide with an existing
+ * cohort name, falling back to "{name} (copy 2)", "(copy 3)", … so
+ * repeated copies of the same cohort stay distinguishable.
+ */
+function buildCopyName(sourceName: string): string {
+  const existingNames = new Set(cohorts.value.map(c => c.name))
+  const base = `${sourceName} (copy)`
+  if (!existingNames.has(base)) return base
+
+  let n = 2
+  while (existingNames.has(`${sourceName} (copy ${n})`)) {
+    n += 1
+  }
+  return `${sourceName} (copy ${n})`
+}
+
+/**
+ * Duplicate a cohort: fetch its full definition, save it as a new cohort
+ * with a "(copy)" name, then jump into the new cohort's builder — WebAPI
+ * has no server-side /cohortdefinition/{id}/copy endpoint (unlike pathways
+ * or incidence rates), so the duplicate is built client-side.
+ */
+async function handleCopyClick(cohort: CohortDefinitionSummary) {
+  if (copyingId.value) return
+  copyingId.value = cohort.id
+
+  try {
+    const definition = await getCohortDefinition(cohort.id)
+    if (!definition) {
+      showSnackbar(
+        t('cohortDefinitions.copyLoadError', 'Failed to load the cohort to copy.').value,
+        'danger'
+      )
+      return
+    }
+
+    const {
+      id: _id,
+      name: _name,
+      description,
+      createdBy: _createdBy,
+      createdDate: _createdDate,
+      modifiedBy: _modifiedBy,
+      modifiedDate: _modifiedDate,
+      tags: _tags,
+      ...expression
+    } = definition as AtlasCohortDefinition
+
+    const created = await saveCohortDefinition({
+      name: buildCopyName(cohort.name),
+      description,
+      expressionType: 'SIMPLE_EXPRESSION',
+      expression,
+    })
+
+    if (!created?.id) {
+      showSnackbar(
+        t('cohortDefinitions.copyError', 'Failed to copy the cohort.').value,
+        'danger'
+      )
+      return
+    }
+
+    await fetchCohorts()
+    router.push(`/cohorts/${created.id}`)
+  } catch (err) {
+    logger.error('CohortsView', 'Failed to copy cohort', err)
+    showSnackbar(t('cohortDefinitions.copyError', 'Failed to copy the cohort.').value, 'danger')
+  } finally {
+    copyingId.value = null
   }
 }
 

--- a/tests/component/characterization/LinkedCohortPicker.spec.ts
+++ b/tests/component/characterization/LinkedCohortPicker.spec.ts
@@ -91,4 +91,56 @@ describe('LinkedCohortPicker', () => {
     expect(dialog).not.toBeNull()
     wrapper.unmount()
   })
+
+  // Discussion #123: the picker dialog had no way to filter a long cohort
+  // list, unlike the Pathways/Incidence-Rate cohort pickers.
+  describe('search (discussion #123)', () => {
+    it('renders a search field in the picker dialog', async () => {
+      const wrapper = mountPicker([])
+
+      await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+      await flushPromises()
+
+      const search = document.querySelector('[data-testid="linked-cohort-picker-search"]')
+      expect(search).not.toBeNull()
+      wrapper.unmount()
+    })
+
+    it('filters the selectable cohorts as the user types', async () => {
+      const wrapper = mountPicker([])
+
+      await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+      await flushPromises()
+
+      wrapper.vm.search = 'asthma'
+      await flushPromises()
+
+      const rows = document.querySelectorAll('[data-testid="linked-cohort-picker-table"] tbody tr')
+      const rowText = Array.from(rows).map(r => r.textContent)
+      expect(rowText.some(text => text?.includes('Asthma'))).toBe(true)
+      expect(rowText.some(text => text?.includes('Diabetes'))).toBe(false)
+      wrapper.unmount()
+    })
+
+    it('resets the search text each time the dialog is reopened', async () => {
+      const wrapper = mountPicker([])
+
+      await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+      await flushPromises()
+      wrapper.vm.search = 'asthma'
+      // The dialog's Cancel button teleports to document.body, outside the
+      // wrapper's own root — click it via the raw DOM node.
+      const cancelBtn = document.querySelector<HTMLElement>(
+        '[data-testid="linked-cohort-picker-cancel"]'
+      )
+      cancelBtn?.click()
+      await flushPromises()
+
+      await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.vm.search).toBe('')
+      wrapper.unmount()
+    })
+  })
 })

--- a/tests/component/characterization/LinkedFeatureAnalysisPicker.spec.ts
+++ b/tests/component/characterization/LinkedFeatureAnalysisPicker.spec.ts
@@ -106,4 +106,34 @@ describe('LinkedFeatureAnalysisPicker', () => {
     expect(dialogTable).not.toBeNull()
     wrapper.unmount()
   })
+
+  // Discussion #123: no way to filter the feature-analysis picker either.
+  describe('search (discussion #123)', () => {
+    it('renders a search field in the picker dialog', async () => {
+      const wrapper = mountPicker([])
+
+      await wrapper.get('[data-testid="linked-fa-picker-add"]').trigger('click')
+      await flushPromises()
+
+      const search = document.querySelector('[data-testid="linked-fa-picker-search"]')
+      expect(search).not.toBeNull()
+      wrapper.unmount()
+    })
+
+    it('filters the selectable feature analyses as the user types', async () => {
+      const wrapper = mountPicker([])
+
+      await wrapper.get('[data-testid="linked-fa-picker-add"]').trigger('click')
+      await flushPromises()
+
+      wrapper.vm.search = 'comorbid'
+      await flushPromises()
+
+      const rows = document.querySelectorAll('[data-testid="linked-fa-picker-table"] tbody tr')
+      const rowText = Array.from(rows).map(r => r.textContent)
+      expect(rowText.some(text => text?.includes('Comorbidities'))).toBe(true)
+      expect(rowText.some(text => text?.includes('Demographics'))).toBe(false)
+      wrapper.unmount()
+    })
+  })
 })

--- a/tests/component/cohort/CohortTable.spec.ts
+++ b/tests/component/cohort/CohortTable.spec.ts
@@ -25,6 +25,8 @@ function makeWrapper(props: Partial<{
   error: Error | null
   searchQuery: string
   selectedTags: string[]
+  canCopy: boolean
+  copyingId: number | null
 }> = {}) {
   // Per-test pinia + a permitted user so the row action buttons aren't
   // disabled by the new permission gating.
@@ -104,15 +106,30 @@ describe('CohortTable', () => {
 
   it('emits action events from the row buttons without bubbling row click', async () => {
     // Refresh: removed the row-level Generate button. Action column
-    // now contains only Info and Delete.
-    const wrapper = makeWrapper({ cohorts: [sampleCohorts[0]!] })
+    // now contains Copy, Info and Delete.
+    const wrapper = makeWrapper({ cohorts: [sampleCohorts[0]!], canCopy: true })
 
     await wrapper.find('[data-testid=cohort-table-info]').trigger('click')
+    await wrapper.find('[data-testid=cohort-table-copy]').trigger('click')
     await wrapper.find('[data-testid=cohort-table-delete]').trigger('click')
 
     expect(wrapper.emitted('show-info')).toHaveLength(1)
+    expect(wrapper.emitted('copy')).toHaveLength(1)
+    expect(wrapper.emitted('copy')![0]).toEqual([sampleCohorts[0]])
     expect(wrapper.emitted('delete')).toHaveLength(1)
     expect(wrapper.emitted('generate')).toBeFalsy()
+  })
+
+  it('disables the copy button when the user cannot create cohorts', () => {
+    const wrapper = makeWrapper({ cohorts: [sampleCohorts[0]!], canCopy: false })
+    const copyBtn = wrapper.get('[data-testid=cohort-table-copy]')
+    expect(copyBtn.attributes('disabled')).not.toBeUndefined()
+  })
+
+  it('disables the copy button for the row currently being copied', () => {
+    const wrapper = makeWrapper({ cohorts: [sampleCohorts[0]!], canCopy: true, copyingId: 1 })
+    const copyBtn = wrapper.get('[data-testid=cohort-table-copy]')
+    expect(copyBtn.attributes('disabled')).not.toBeUndefined()
   })
 
   it('emits tag-click when a tag chip is clicked', async () => {

--- a/tests/component/views/CohortBuilderView-interactions.spec.ts
+++ b/tests/component/views/CohortBuilderView-interactions.spec.ts
@@ -32,6 +32,8 @@ const {
   openTagsDialog,
   handleCancel,
   handleSave,
+  handleExportDownload,
+  handleExportCopy,
 } = vi.hoisted(() => ({
   openConceptSetsDialog: vi.fn(),
   openValidationDialog: vi.fn(),
@@ -39,6 +41,8 @@ const {
   openTagsDialog: vi.fn(),
   handleCancel: vi.fn(),
   handleSave: vi.fn(),
+  handleExportDownload: vi.fn(),
+  handleExportCopy: vi.fn(),
 }))
 
 // Stub the CohortBuilder child so we don't need its store wiring.
@@ -68,6 +72,8 @@ vi.mock('@/components/cohort/CohortBuilder.vue', () => ({
       'openTagsDialog',
       'handleCancel',
       'handleSave',
+      'handleExportDownload',
+      'handleExportCopy',
     ],
     data() {
       return {
@@ -89,6 +95,8 @@ vi.mock('@/components/cohort/CohortBuilder.vue', () => ({
       openTagsDialog,
       handleCancel,
       handleSave,
+      handleExportDownload,
+      handleExportCopy,
     },
   },
 }))
@@ -112,11 +120,13 @@ vi.mock('@/components/cohort/CohortToolbarActions.vue', () => ({
   default: {
     name: 'CohortToolbarActions',
     props: ['canSave', 'isPreviewingVersion'],
-    emits: ['cancel', 'save'],
+    emits: ['cancel', 'save', 'export-download', 'export-copy'],
     template:
       '<div class="stub-toolbar-actions">' +
       '<button class="actions-cancel" @click="$emit(\'cancel\')" />' +
       '<button class="actions-save" @click="$emit(\'save\')" />' +
+      '<button class="actions-export-download" @click="$emit(\'export-download\')" />' +
+      '<button class="actions-export-copy" @click="$emit(\'export-copy\')" />' +
       '</div>',
   },
 }))
@@ -209,6 +219,19 @@ describe('CohortBuilderView interactions', () => {
     await wrapper.find('.actions-save').trigger('click')
     expect(handleCancel).toHaveBeenCalled()
     expect(handleSave).toHaveBeenCalled()
+  })
+
+  // Regression: the hero-header toolbar (rendered here, not inside
+  // CohortBuilder) didn't wire export-download/export-copy at all, so
+  // clicking "Download" or "Copy to clipboard" in the real app silently
+  // did nothing — the events were emitted into the void.
+  it('forwards toolbar export-download/export-copy to the builder ref handles', async () => {
+    const wrapper = mountIt()
+    await wrapper.vm.$nextTick()
+    await wrapper.find('.actions-export-download').trigger('click')
+    await wrapper.find('.actions-export-copy').trigger('click')
+    expect(handleExportDownload).toHaveBeenCalled()
+    expect(handleExportCopy).toHaveBeenCalled()
   })
 
   it('passes the id prop through to CohortBuilder and surfaces it in the eyebrow', async () => {

--- a/tests/unit/components/cohort/CohortCard.spec.ts
+++ b/tests/unit/components/cohort/CohortCard.spec.ts
@@ -205,4 +205,38 @@ describe('CohortCard', () => {
 
     expect(wrapper.find('.atlas-card.atlas-card--interactive').exists()).toBe(true)
   })
+
+  // Discussion #124: one-click cohort duplication.
+  describe('copy action', () => {
+    it('emits copy with the cohort when the duplicate button is clicked', async () => {
+      const wrapper = mountComponent({ canCopy: true })
+
+      await wrapper.get('[data-testid="cohort-card-copy"]').trigger('click')
+
+      expect(wrapper.emitted('copy')).toBeTruthy()
+      expect(wrapper.emitted('copy')![0]).toEqual([mockCohort])
+    })
+
+    it('does not bubble the click to the card navigation handler', async () => {
+      const wrapper = mountComponent({ canCopy: true })
+
+      await wrapper.get('[data-testid="cohort-card-copy"]').trigger('click')
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('disables the duplicate button when the user lacks create permission', () => {
+      const wrapper = mountComponent({ canCopy: false })
+
+      const btn = wrapper.get('[data-testid="cohort-card-copy"]')
+      expect(btn.attributes('disabled')).not.toBeUndefined()
+    })
+
+    it('disables the duplicate button while a copy is in flight', () => {
+      const wrapper = mountComponent({ canCopy: true, copying: true })
+
+      const btn = wrapper.get('[data-testid="cohort-card-copy"]')
+      expect(btn.attributes('disabled')).not.toBeUndefined()
+    })
+  })
 })

--- a/tests/unit/views/CohortsView.spec.ts
+++ b/tests/unit/views/CohortsView.spec.ts
@@ -37,7 +37,8 @@ vi.mock('@/composables/usePagination', () => ({
 vi.mock('@/services/webapi', () => ({
   deleteCohort: vi.fn(),
   getCohortDefinition: vi.fn(),
-  getCohortPrintFriendly: vi.fn()
+  getCohortPrintFriendly: vi.fn(),
+  saveCohortDefinition: vi.fn()
 }))
 
 // Mock logger
@@ -67,7 +68,7 @@ vi.mock('@/components/cohort/CohortGrid.vue', () => ({
   default: {
     name: 'CohortGrid',
     template: '<div class="cohort-grid-mock"></div>',
-    props: ['cohorts', 'loading', 'error', 'searchQuery', 'selectedTags']
+    props: ['cohorts', 'loading', 'error', 'searchQuery', 'selectedTags', 'canCopy', 'copyingId']
   }
 }))
 
@@ -75,7 +76,7 @@ vi.mock('@/components/cohort/CohortTable.vue', () => ({
   default: {
     name: 'CohortTable',
     template: '<div class="cohort-table-mock"></div>',
-    props: ['cohorts', 'loading', 'error', 'searchQuery', 'selectedTags']
+    props: ['cohorts', 'loading', 'error', 'searchQuery', 'selectedTags', 'canCopy', 'copyingId']
   }
 }))
 
@@ -103,7 +104,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from '@/composables/useI18n'
 import { useCohorts } from '@/composables/useCohorts'
 import { usePagination } from '@/composables/usePagination'
-import { deleteCohort, getCohortDefinition, getCohortPrintFriendly } from '@/services/webapi'
+import { deleteCohort, getCohortDefinition, getCohortPrintFriendly, saveCohortDefinition } from '@/services/webapi'
 
 // Create mock implementations
 const mockPush = vi.fn()
@@ -201,6 +202,7 @@ describe('CohortsView.vue', () => {
     vi.mocked(deleteCohort).mockClear()
     vi.mocked(getCohortDefinition).mockClear()
     vi.mocked(getCohortPrintFriendly).mockClear()
+    vi.mocked(saveCohortDefinition).mockClear()
 
     // Reset ref values
     mockCohorts.value = []
@@ -549,6 +551,122 @@ describe('CohortsView.vue', () => {
       await wrapper.vm.confirmDelete()
 
       expect(wrapper.vm.deleting).toBe(false)
+    })
+  })
+
+  describe('Copy Cohort (discussion #124)', () => {
+    const mockCohort = createMockCohort(1, { name: 'Diabetes Cohort' })
+    const mockDefinition = {
+      id: 1,
+      name: 'Diabetes Cohort',
+      description: 'Original description',
+      createdBy: 'someone',
+      createdDate: 1700000000000,
+      modifiedBy: 'someone',
+      modifiedDate: 1700000000000,
+      tags: [{ id: 1, name: 'chronic' }],
+      ConceptSets: [{ id: 0, name: 'Diabetes' }],
+      PrimaryCriteria: { CriteriaList: [], ObservationWindow: { PriorDays: 0, PostDays: 0 }, PrimaryCriteriaLimit: { Type: 'First' } }
+    }
+
+    beforeEach(() => {
+      wrapper = mount(CohortsView, {
+        global: {
+          plugins: [vuetify]
+        }
+      })
+    })
+
+    it('fetches the full definition and saves a copy with a "(copy)" name', async () => {
+      vi.mocked(getCohortDefinition).mockResolvedValue(mockDefinition as any)
+      vi.mocked(saveCohortDefinition).mockResolvedValue({ id: 99, name: 'Diabetes Cohort (copy)' } as any)
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(getCohortDefinition).toHaveBeenCalledWith(mockCohort.id)
+      expect(saveCohortDefinition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Diabetes Cohort (copy)',
+          description: 'Original description',
+          expressionType: 'SIMPLE_EXPRESSION',
+        })
+      )
+      // Metadata (id/name/description/tags/audit fields) must not leak into
+      // the expression payload — only the expression-shaped fields remain.
+      const savedPayload = vi.mocked(saveCohortDefinition).mock.calls[0]![0] as any
+      expect(savedPayload.expression).toEqual({
+        ConceptSets: mockDefinition.ConceptSets,
+        PrimaryCriteria: mockDefinition.PrimaryCriteria,
+      })
+    })
+
+    it('navigates to the new cohort and refreshes the list on success', async () => {
+      vi.mocked(getCohortDefinition).mockResolvedValue(mockDefinition as any)
+      vi.mocked(saveCohortDefinition).mockResolvedValue({ id: 99, name: 'Diabetes Cohort (copy)' } as any)
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(mockFetchCohorts).toHaveBeenCalled()
+      expect(mockPush).toHaveBeenCalledWith('/cohorts/99')
+    })
+
+    it('avoids name collisions by numbering repeat copies', async () => {
+      mockCohorts.value = [
+        mockCohort,
+        createMockCohort(2, { name: 'Diabetes Cohort (copy)' }),
+      ]
+      vi.mocked(getCohortDefinition).mockResolvedValue(mockDefinition as any)
+      vi.mocked(saveCohortDefinition).mockResolvedValue({ id: 99, name: 'Diabetes Cohort (copy 2)' } as any)
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(saveCohortDefinition).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Diabetes Cohort (copy 2)' })
+      )
+    })
+
+    it('tracks copyingId while the copy is in flight and clears it after', async () => {
+      let resolveFetch: (value: unknown) => void = () => {}
+      vi.mocked(getCohortDefinition).mockImplementation(
+        () => new Promise(resolve => { resolveFetch = resolve })
+      )
+      vi.mocked(saveCohortDefinition).mockResolvedValue({ id: 99, name: 'copy' } as any)
+
+      const copyPromise = wrapper.vm.handleCopyClick(mockCohort)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.copyingId).toBe(mockCohort.id)
+
+      resolveFetch(mockDefinition)
+      await copyPromise
+
+      expect(wrapper.vm.copyingId).toBeNull()
+    })
+
+    it('does not call saveCohortDefinition when the definition fails to load', async () => {
+      vi.mocked(getCohortDefinition).mockResolvedValue(null)
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(saveCohortDefinition).not.toHaveBeenCalled()
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('does not navigate when the save fails', async () => {
+      vi.mocked(getCohortDefinition).mockResolvedValue(mockDefinition as any)
+      vi.mocked(saveCohortDefinition).mockResolvedValue(null as any)
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('handles a thrown error gracefully and clears copyingId', async () => {
+      vi.mocked(getCohortDefinition).mockRejectedValue(new Error('network down'))
+
+      await wrapper.vm.handleCopyClick(mockCohort)
+
+      expect(wrapper.vm.copyingId).toBeNull()
+      expect(mockPush).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary

Three independent cohort/characterization UX improvements:

- **One-click cohort duplication** — adds a Duplicate action to the cohort table and tile views. Fetches the full definition, saves it as a new cohort with a `(copy)` name (numbered on repeat copies), and opens it in the builder.
- **Search in the characterization pickers** — the "link a cohort" and "link a feature analysis" dialogs now have a search field wired to `AtlasDataTable`'s built-in filtering, matching the searchable pickers used elsewhere.
- **Fix cohort export Download / Copy to Clipboard** — the hero-header toolbar shown on the cohort page never listened for `export-download`/`export-copy`, so those menu items did nothing. Exposes the handlers from `CohortBuilder` and wires them into the hero-header toolbar.

