### PR TITLE
fix(pathway-csv): count each person once per event cohort in count report

### DIFF
--- a/src/utils/pathway-csv.ts
+++ b/src/utils/pathway-csv.ts
@@ -57,7 +57,12 @@ export function toEventCohortCountRows(
 ): Array<Record<string, string | number>> {
   const tally = new Map<string, number>()
   for (const p of group.pathways) {
-    const steps = p.path.split('-')
+    // Count each person once per event cohort. A treatment pathway can repeat
+    // an event (e.g. A → B → A when repeats are allowed), but this report is
+    // person-level — its '%' divides by totalPathwaysCount (persons) — so a
+    // recurring event must not add personCount more than once per path.
+    // Mirrors the deduping in toDistinctEventCountRows below.
+    const steps = new Set(p.path.split('-'))
     for (const s of steps) {
       const c = eventCodes.find(x => x.code === Number(s))
       if (!c || c.isCombo) continue

--- a/tests/unit/utils/pathway-csv.spec.ts
+++ b/tests/unit/utils/pathway-csv.spec.ts
@@ -49,6 +49,23 @@ describe('pathway-csv', () => {
     expect(rows.find(r => r['Event Cohort'] === 'A+B')).toBeUndefined()
   })
 
+  it('toEventCohortCountRows counts each person once per event cohort when a path repeats an event', () => {
+    // A → B → A: the 100 persons on this path all have event A (once) and B (once).
+    // Counting per occurrence would tally A twice (200) and push '%' to 200%.
+    const repeatGroup = {
+      targetCohortId: 1,
+      targetCohortCount: 100,
+      totalPathwaysCount: 100,
+      pathways: [{ path: '1-2-1', personCount: 100 }],
+    }
+    const rows = toEventCohortCountRows(repeatGroup, eventCodes)
+    const a = rows.find(r => r['Event Cohort'] === 'A')
+    const b = rows.find(r => r['Event Cohort'] === 'B')
+    expect(a?.['Count']).toBe(100)
+    expect(a?.['%']).toBe(100)
+    expect(b?.['Count']).toBe(100)
+  })
+
   it('toDistinctEventCountRows includes zero bucket', () => {
     const rows = toDistinctEventCountRows(group, eventCodes)
     const zero = rows.find(r => r['Distinct Events'] === 0)


### PR DESCRIPTION
toEventCohortCountRows iterated every step in a pathway and added personCount per occurrence, so a path that repeats an event (e.g. A → B → A, allowed when repeats are enabled) counted those persons multiple times. Since the row's '%' divides by totalPathwaysCount (a person count), this pushed counts and percentages above 100%.

Dedupe steps within each path with a Set before tallying, matching the person-level semantics already used by toDistinctEventCountRows.

Add a regression test covering a repeated-event path (1-2-1), which fails without the fix (Count 200 vs 100).