### PR TITLE
Fix nested criteria loss on cohort JSON import and surface tag-assignment errors

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -2073,22 +2073,31 @@ async function handleSave(): Promise<{ id?: number; name?: string }> {
       prev => !currentTags.some(current => current.id === prev.id)
     )
 
+    const tagFailures: string[] = []
+
     for (const tag of tagsToAdd) {
       if (tag.id) {
-        const success = await assignTagToCohort(cohortId, tag.id)
-        if (!success) {
-          logger.warn('CohortBuilder', `Failed to assign tag ${tag.id}`)
+        const result = await assignTagToCohort(cohortId, tag.id)
+        if (!result.success) {
+          logger.warn('CohortBuilder', `Failed to assign tag ${tag.id}`, result.error)
+          tagFailures.push(result.error ?? `Failed to assign tag "${tag.name}"`)
         }
       }
     }
 
     for (const tag of tagsToRemove) {
       if (tag.id) {
-        const success = await unassignTagFromCohort(cohortId, tag.id)
-        if (!success) {
-          logger.warn('CohortBuilder', `Failed to unassign tag ${tag.id}`)
+        const result = await unassignTagFromCohort(cohortId, tag.id)
+        if (!result.success) {
+          logger.warn('CohortBuilder', `Failed to unassign tag ${tag.id}`, result.error)
+          tagFailures.push(result.error ?? `Failed to unassign tag "${tag.name}"`)
         }
       }
+    }
+
+    if (tagFailures.length > 0) {
+      errorMessage.value = tagFailures.join('; ')
+      showError.value = true
     }
 
     loadedTags.value = [...currentTags]

--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -648,6 +648,7 @@ import { logger } from '@/utils/logger'
 import { ref, computed, inject, watch, toRef, onBeforeUnmount } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import { useConceptSetsStore } from '@/stores/concept-sets'
+import { useNotifications } from '@/stores/notifications'
 import { usePermissions } from '@/composables/usePermissions'
 import { useEntityAccess } from '@/composables/useEntityAccess'
 import type { ConceptSet, Concept, ConceptSetItem } from '@/models/concept-set.types'
@@ -673,7 +674,7 @@ import {
   parseConceptSetJson,
 } from './concept-set-import'
 
-const { t } = useI18n()
+const { t, tv } = useI18n()
 const webapiStore = useWebAPIStore()
 
 // ============================================================================
@@ -698,6 +699,7 @@ const emit = defineEmits<{
 // ============================================================================
 
 const store = useConceptSetsStore()
+const notify = useNotifications()
 
 // ============================================================================
 // Local State
@@ -1022,7 +1024,12 @@ async function onSave() {
     if (result) {
       const savedId = result?.id
       if (savedId !== undefined && savedId !== null) {
-        await store.syncTags(savedId, loadedTags.value, selectedTags.value)
+        const tagResult = await store.syncTags(savedId, loadedTags.value, selectedTags.value)
+        if (!tagResult.success) {
+          notify.danger(tv('conceptSets.tagUpdateFailed', 'Failed to update tags'), {
+            message: tagResult.error,
+          })
+        }
         loadedTags.value = [...selectedTags.value]
       }
       hasUnsavedChanges.value = false

--- a/src/models/atlas.types.ts
+++ b/src/models/atlas.types.ts
@@ -134,7 +134,6 @@ export interface AtlasPrimaryCriteria {
 
 export interface AtlasCriteria {
   [key: string]: unknown // Criteria type specific fields
-  CorrelatedCriteria?: AtlasCorrelatedCriteria // Nested criteria
   Occurrence?: AtlasOccurrence // Cardinality
 }
 
@@ -418,6 +417,7 @@ export interface ConceptSetItem {
  * Atlas criteria type object (the criteria-specific part)
  */
 export interface AtlasCriteriaTypeObject {
+  CorrelatedCriteria?: AtlasCorrelatedCriteria // Nested criteria (CIRCE nests it here, not on the wrapper)
   CodesetId?: number | null
   First?: boolean
   OccurrenceStartDate?: AtlasRange

--- a/src/services/atlas-converter.ts
+++ b/src/services/atlas-converter.ts
@@ -455,7 +455,9 @@ function convertEventToAtlas(event: CohortEvent, wrapInCriteria: boolean = false
   }
 
   if (event.nestedCriteria) {
-    atlasEvent.CorrelatedCriteria = convertGroupToAtlasGroup(event.nestedCriteria)
+    // CIRCE nests CorrelatedCriteria inside the criteria-type object itself
+    // (e.g. Measurement.CorrelatedCriteria), not as a sibling of it — see #131.
+    criteriaTypeObj.CorrelatedCriteria = convertGroupToAtlasGroup(event.nestedCriteria)
   }
 
   return atlasEvent
@@ -1158,8 +1160,10 @@ function convertAtlasToEvent(
     }
   }
 
-  const eventWithCorrelatedCriteria = atlasEvent as { CorrelatedCriteria?: AtlasGroupShape }
-  const correlatedCriteria = eventWithCorrelatedCriteria.CorrelatedCriteria
+  // CIRCE nests CorrelatedCriteria inside the criteria-type object itself
+  // (e.g. Measurement.CorrelatedCriteria), not as a sibling of it — see #131.
+  const criteriaObjWithCorrelatedCriteria = criteriaObj as { CorrelatedCriteria?: AtlasGroupShape }
+  const correlatedCriteria = criteriaObjWithCorrelatedCriteria.CorrelatedCriteria
   if (correlatedCriteria) {
     event.nestedCriteria = convertAtlasGroupToGroup(correlatedCriteria, conceptSets)
   }

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -261,16 +261,16 @@ export async function deleteConceptSet(id: number | string): Promise<boolean> {
 export async function assignTagToConceptSet(
   id: number | string,
   tagId: number
-): Promise<boolean> {
+): Promise<{ success: boolean; error?: string }> {
   try {
     await fetchJSON(`/conceptset/${id}/tag/`, {
       method: 'POST',
       body: JSON.stringify(tagId),
     })
-    return true
+    return { success: true }
   } catch (error) {
     logger.error('ConceptSet', `Failed to assign tag ${tagId} to concept set ${id}`, error)
-    return false
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }
 
@@ -281,14 +281,14 @@ export async function assignTagToConceptSet(
 export async function unassignTagFromConceptSet(
   id: number | string,
   tagId: number
-): Promise<boolean> {
+): Promise<{ success: boolean; error?: string }> {
   try {
     await fetchJSON(`/conceptset/${id}/tag/${tagId}`, {
       method: 'DELETE',
     })
-    return true
+    return { success: true }
   } catch (error) {
     logger.error('ConceptSet', `Failed to unassign tag ${tagId} from concept set ${id}`, error)
-    return false
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -123,7 +123,23 @@ export async function httpClient<T>(endpoint: string, options: HttpClientOptions
       }
 
       if (!response.ok) {
-        const error = new Error(`HTTP ${response.status}: ${response.statusText}`)
+        // Surface the server's error body (e.g. WebAPI's tag-assignment
+        // constraint violations) instead of the bare status text, which
+        // alone doesn't say what went wrong (#132).
+        let detail = response.statusText
+        try {
+          const text = await response.text()
+          if (text) {
+            try {
+              detail = (JSON.parse(text) as { message?: string }).message ?? text
+            } catch {
+              detail = text
+            }
+          }
+        } catch {
+          // keep statusText
+        }
+        const error = new Error(`HTTP ${response.status}: ${detail}`)
         if (isRetryableError(error, response.status) && attempt < maxRetries - 1) {
           const delay = initialDelay * Math.pow(2, attempt)
           logger.warn(

--- a/src/services/webapi.ts
+++ b/src/services/webapi.ts
@@ -250,31 +250,37 @@ export async function deleteCohortDefinition(id: number): Promise<boolean> {
 /**
  * Assign tag to cohort definition
  */
-export async function assignTagToCohort(cohortId: number, tagId: number): Promise<boolean> {
+export async function assignTagToCohort(
+  cohortId: number,
+  tagId: number
+): Promise<{ success: boolean; error?: string }> {
   try {
     await fetchJSON(`/cohortdefinition/${cohortId}/tag/`, {
       method: 'POST',
       body: JSON.stringify(tagId),
     })
-    return true
+    return { success: true }
   } catch (error) {
     logger.error('WebAPI', `Failed to assign tag ${tagId} to cohort ${cohortId}`, error)
-    return false
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }
 
 /**
  * Unassign tag from cohort definition
  */
-export async function unassignTagFromCohort(cohortId: number, tagId: number): Promise<boolean> {
+export async function unassignTagFromCohort(
+  cohortId: number,
+  tagId: number
+): Promise<{ success: boolean; error?: string }> {
   try {
     await fetchJSON(`/cohortdefinition/${cohortId}/tag/${tagId}`, {
       method: 'DELETE',
     })
-    return true
+    return { success: true }
   } catch (error) {
     logger.error('WebAPI', `Failed to unassign tag ${tagId} from cohort ${cohortId}`, error)
-    return false
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }
 

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -308,18 +308,30 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     id: number | string,
     oldTags: Tag[],
     newTags: Tag[]
-  ): Promise<void> {
+  ): Promise<{ success: boolean; error?: string }> {
     const toAdd = newTags.filter(n => n.id && !oldTags.some(o => o.id === n.id))
     const toRemove = oldTags.filter(o => o.id && !newTags.some(n => n.id === o.id))
+    const failures: string[] = []
     for (const tag of toAdd) {
-      if (tag.id) await assignTagToConceptSet(id, tag.id)
+      if (tag.id) {
+        const result = await assignTagToConceptSet(id, tag.id)
+        if (!result.success) failures.push(result.error ?? `Failed to assign tag "${tag.name}"`)
+      }
     }
     for (const tag of toRemove) {
-      if (tag.id) await unassignTagFromConceptSet(id, tag.id)
+      if (tag.id) {
+        const result = await unassignTagFromConceptSet(id, tag.id)
+        if (!result.success) failures.push(result.error ?? `Failed to unassign tag "${tag.name}"`)
+      }
     }
     if (currentSet.value?.id === id) {
       currentSet.value = { ...currentSet.value, tags: [...newTags] } as typeof currentSet.value
     }
+    if (failures.length > 0) {
+      error.value = failures.join('; ')
+      return { success: false, error: error.value }
+    }
+    return { success: true }
   }
 
   /**

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -1555,6 +1555,41 @@ describe('CohortBuilder', () => {
     expect(setup.showError).toBe(true)
   })
 
+  it('handleSave surfaces the server message when a tag assignment fails', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = 'Savable'
+    setup.entryEvents = [{ id: 'e1', criteriaType: 'X', attributes: [] }]
+    setup.handleTagsUpdate([{ id: 7, name: 'protected' }] as any)
+
+    const webapi = await import('@/services/webapi')
+    vi.mocked(webapi.assignTagToCohort).mockResolvedValueOnce({
+      success: false,
+      error: 'Tag group "Status" allows only one assignment',
+    })
+
+    await setup.handleSave()
+    expect(setup.errorMessage).toBe('Tag group "Status" allows only one assignment')
+    expect(setup.showError).toBe(true)
+  })
+
+  it('handleSave falls back to a per-tag message when unassignment fails without detail', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = 'Savable'
+    setup.entryEvents = [{ id: 'e1', criteriaType: 'X', attributes: [] }]
+    setup.loadedTags = [{ id: 9, name: 'old-tag' }]
+
+    const webapi = await import('@/services/webapi')
+    vi.mocked(webapi.unassignTagFromCohort).mockResolvedValueOnce({ success: false })
+
+    await setup.handleSave()
+    expect(setup.errorMessage).toBe('Failed to unassign tag "old-tag"')
+    expect(setup.showError).toBe(true)
+  })
+
   // ---------------------------------------------------------------------------
   // Export failure branches (conversionError set)
   // ---------------------------------------------------------------------------

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -68,8 +68,8 @@ vi.mock('@/services/webapi', () => ({
     }),
   }),
   saveCohortDefinition: vi.fn().mockResolvedValue({ id: 99, name: 'Saved' }),
-  assignTagToCohort: vi.fn().mockResolvedValue(true),
-  unassignTagFromCohort: vi.fn().mockResolvedValue(true),
+  assignTagToCohort: vi.fn().mockResolvedValue({ success: true }),
+  unassignTagFromCohort: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 vi.mock('@/services/concept-set.service', () => ({

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -28,6 +28,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import ConceptSetEditor from '@/components/concepts/ConceptSetEditor.vue'
 import { useConceptSetsStore } from '@/stores/concept-sets'
+import { useNotifications } from '@/stores/notifications'
 import { useWebAPIStore } from '@/stores/webapi'
 import { useAuthStore } from '@/stores/auth'
 import { emptyEntityAccess } from '@/models/auth.types'
@@ -659,6 +660,34 @@ describe('ConceptSetEditor', () => {
       vm.parseJsonImport()
       expect(vm.jsonError).toMatch(/invalid json/i)
       expect(vm.jsonItems).toHaveLength(0)
+    })
+  })
+
+  describe('Tag sync on save', () => {
+    it('notifies with the server message when tag sync fails after save', async () => {
+      const store = useConceptSetsStore()
+      vi.spyOn(store, 'update').mockResolvedValue(mockConceptSet)
+      vi.spyOn(store, 'syncTags').mockResolvedValue({
+        success: false,
+        error: 'Tag "protected" may only be assigned once',
+      })
+      const notifications = useNotifications()
+      const dangerSpy = vi.spyOn(notifications, 'danger')
+
+      const wrapper = mountComponent({ conceptSet: mockConceptSet })
+      await flushPromises()
+      const vm = wrapper.vm as unknown as {
+        formValid: boolean
+        onSave: () => Promise<void>
+      }
+      vm.formValid = true
+      await vm.onSave()
+
+      expect(store.syncTags).toHaveBeenCalledWith(mockConceptSet.id, expect.anything(), expect.anything())
+      expect(dangerSpy).toHaveBeenCalledWith(
+        'Failed to update tags',
+        expect.objectContaining({ message: 'Tag "protected" may only be assigned once' })
+      )
     })
   })
 })

--- a/tests/unit/services/atlas-converter.nested.spec.ts
+++ b/tests/unit/services/atlas-converter.nested.spec.ts
@@ -49,7 +49,10 @@ describe('atlas-converter: nested criteria sub-groups (#112)', () => {
 
   it('serializes nested-criteria sub-groups to CorrelatedCriteria.Groups', () => {
     const atlas = convertInternalToAtlas(cohortWithNestedGroup())
-    const cc = (atlas.PrimaryCriteria.CriteriaList[0] as Record<string, any>).CorrelatedCriteria
+    const entry = atlas.PrimaryCriteria.CriteriaList[0] as Record<string, any>
+    // CIRCE nests CorrelatedCriteria inside the criteria-type object
+    // (ConditionOccurrence), not as a sibling of it — see #131.
+    const cc = entry.ConditionOccurrence.CorrelatedCriteria
     expect(cc.Groups).toHaveLength(1)
     expect(cc.Groups[0].Type).toBe('ANY')
     expect(cc.Groups[0].CriteriaList).toHaveLength(1)
@@ -62,5 +65,69 @@ describe('atlas-converter: nested criteria sub-groups (#112)', () => {
     expect(nested?.nestedGroups).toHaveLength(1)
     expect(nested?.nestedGroups?.[0].logicType).toBe('ANY')
     expect(nested?.nestedGroups?.[0].events).toHaveLength(1)
+  })
+})
+
+/**
+ * #131: imported cohort definitions (e.g. from the phenotype library / legacy
+ * ATLAS exports) place CorrelatedCriteria *inside* the criteria-type object
+ * (Measurement.CorrelatedCriteria), not as a sibling of it. Reading it from
+ * the wrong location silently dropped every entry event's nested criteria.
+ */
+describe('atlas-converter: legacy CIRCE CorrelatedCriteria placement (#131)', () => {
+  function legacyAtlasJsonWithNestedEntryCriteria() {
+    return {
+      ConceptSets: [],
+      PrimaryCriteria: {
+        CriteriaList: [
+          {
+            Measurement: {
+              CodesetId: 1,
+              MeasurementTypeExclude: false,
+              CorrelatedCriteria: {
+                Type: 'AT_LEAST',
+                Count: 1,
+                CriteriaList: [
+                  {
+                    Criteria: { ConditionOccurrence: { CodesetId: 2, ConditionTypeExclude: false } },
+                    StartWindow: { Start: { Days: 0, Coeff: -1 }, End: { Days: 365, Coeff: 1 } },
+                    Occurrence: { Type: 2, Count: 1 },
+                  },
+                ],
+                DemographicCriteriaList: [],
+                Groups: [],
+              },
+            },
+          },
+        ],
+        ObservationWindow: { PriorDays: 0, PostDays: 0 },
+        PrimaryCriteriaLimit: { Type: 'First' },
+      },
+      QualifiedLimit: { Type: 'First' },
+      ExpressionLimit: { Type: 'First' },
+      InclusionRules: [],
+      CensorWindow: {},
+      CollapseSettings: { CollapseType: 'ERA', EraPad: 0 },
+      CensoringCriteria: [],
+    } as unknown as import('@/models/atlas.types').AtlasJSON
+  }
+
+  it('reads nested criteria that CIRCE places inside the criteria-type object', () => {
+    const cohort = convertAtlasToInternal(legacyAtlasJsonWithNestedEntryCriteria())
+    const nested = cohort.entryEvents?.[0]?.nestedCriteria
+    expect(nested).toBeDefined()
+    expect(nested?.logicType).toBe('AT_LEAST')
+    expect(nested?.events).toHaveLength(1)
+    expect(nested?.events[0].criteriaType).toBe('ConditionOccurrence')
+  })
+
+  it('does not lose nested entry-event criteria on an import/export round-trip', () => {
+    const cohort = convertAtlasToInternal(legacyAtlasJsonWithNestedEntryCriteria())
+    const reExported = convertInternalToAtlas(cohort as import('@/models/cohort.types').CohortDefinition)
+    const entry = reExported.PrimaryCriteria.CriteriaList[0] as Record<string, any>
+    expect(entry.Measurement.CorrelatedCriteria).toBeDefined()
+    expect(entry.Measurement.CorrelatedCriteria.CriteriaList).toHaveLength(1)
+    // Must not regress to the old (wrong) sibling placement.
+    expect(entry.CorrelatedCriteria).toBeUndefined()
   })
 })

--- a/tests/unit/services/atlas-converter.spec.ts
+++ b/tests/unit/services/atlas-converter.spec.ts
@@ -1684,7 +1684,10 @@ describe('Atlas Converter - Phase 1 Attributes (US1)', () => {
       })
 
       const atlasJSON = convertInternalToAtlas(cohort)
-      const correlated = atlasJSON.PrimaryCriteria.CriteriaList[0]?.CorrelatedCriteria
+      // CIRCE nests CorrelatedCriteria inside the criteria-type object
+      // (ConditionOccurrence), not as a sibling of it — see #131.
+      const entry = atlasJSON.PrimaryCriteria.CriteriaList[0] as Record<string, any>
+      const correlated = entry.ConditionOccurrence?.CorrelatedCriteria
 
       expect(correlated).toBeDefined()
       expect(correlated?.Type).toBe('ALL')
@@ -1725,7 +1728,8 @@ describe('Atlas Converter - Phase 1 Attributes (US1)', () => {
       })
 
       const atlasJSON = convertInternalToAtlas(cohort)
-      const correlated = atlasJSON.PrimaryCriteria.CriteriaList[0]?.CorrelatedCriteria
+      const entry = atlasJSON.PrimaryCriteria.CriteriaList[0] as Record<string, any>
+      const correlated = entry.ConditionOccurrence?.CorrelatedCriteria
 
       expect(correlated?.Type).toBe('AT_LEAST')
       expect(correlated?.Count).toBe(2)
@@ -4810,8 +4814,10 @@ describe('Atlas Converter - Phase 1 Attributes (US1)', () => {
         PrimaryCriteria: {
           CriteriaList: [
             {
-              ConditionOccurrence: { CodesetId: null },
-              CorrelatedCriteria: { Count: 2 }, // no Type, no CriteriaList
+              ConditionOccurrence: {
+                CodesetId: null,
+                CorrelatedCriteria: { Count: 2 }, // no Type, no CriteriaList
+              },
             },
           ],
         },

--- a/tests/unit/services/concept-set.service.tags.spec.ts
+++ b/tests/unit/services/concept-set.service.tags.spec.ts
@@ -50,4 +50,16 @@ describe('ConceptSetService tags', () => {
     expect(result.success).toBe(false)
     expect(result.error).toContain('err')
   })
+
+  it('returns the server error message when unassigning fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'err',
+      text: async () => '',
+    })
+    const result = await unassignTagFromConceptSet(1, 2)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('err')
+  })
 })

--- a/tests/unit/services/concept-set.service.tags.spec.ts
+++ b/tests/unit/services/concept-set.service.tags.spec.ts
@@ -23,8 +23,8 @@ describe('ConceptSetService tags', () => {
   })
 
   it('POSTs the raw tagId to /conceptset/{id}/tag/', async () => {
-    const ok = await assignTagToConceptSet(42, 7)
-    expect(ok).toBe(true)
+    const result = await assignTagToConceptSet(42, 7)
+    expect(result.success).toBe(true)
     const [url, options] = mockFetch.mock.calls[0]
     expect(url).toContain('/conceptset/42/tag/')
     expect(options.method).toBe('POST')
@@ -32,15 +32,22 @@ describe('ConceptSetService tags', () => {
   })
 
   it('DELETEs /conceptset/{id}/tag/{tagId}', async () => {
-    const ok = await unassignTagFromConceptSet(42, 7)
-    expect(ok).toBe(true)
+    const result = await unassignTagFromConceptSet(42, 7)
+    expect(result.success).toBe(true)
     const [url, options] = mockFetch.mock.calls[0]
     expect(url).toContain('/conceptset/42/tag/7')
     expect(options.method).toBe('DELETE')
   })
 
-  it('returns false when the request fails', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'err' })
-    expect(await assignTagToConceptSet(1, 2)).toBe(false)
+  it('returns the server error message when the request fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'err',
+      text: async () => '',
+    })
+    const result = await assignTagToConceptSet(1, 2)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('err')
   })
 })

--- a/tests/unit/services/http-client.spec.ts
+++ b/tests/unit/services/http-client.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for src/services/http-client.ts error-body surfacing.
+ *
+ * #132: a bare "HTTP 500: Internal Server Error" doesn't say what actually
+ * went wrong (e.g. a violated tag-group constraint). The server's response
+ * body must be read and surfaced instead of being discarded.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mockFetch = vi.fn()
+
+describe('services/http-client error surfacing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = mockFetch
+  })
+
+  it('surfaces the JSON error body message on a non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ message: 'Tag name already exists in this group' }),
+    })
+
+    const { httpClient } = await import('@/services/http-client')
+    await expect(httpClient('/tag/', { method: 'POST', skipAuth: true })).rejects.toThrow(
+      'HTTP 400: Tag name already exists in this group'
+    )
+  })
+
+  it('surfaces a plain-text error body when it is not JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => 'mandatory tag group violated',
+    })
+
+    const { httpClient } = await import('@/services/http-client')
+    await expect(httpClient('/tag/', { method: 'POST', skipAuth: true })).rejects.toThrow(
+      'HTTP 400: mandatory tag group violated'
+    )
+  })
+
+  it('falls back to statusText when the body cannot be read', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+    })
+
+    const { httpClient } = await import('@/services/http-client')
+    await expect(httpClient('/tag/', { method: 'POST', skipAuth: true })).rejects.toThrow(
+      'HTTP 400: Bad Request'
+    )
+  })
+})

--- a/tests/unit/services/webapi.spec.ts
+++ b/tests/unit/services/webapi.spec.ts
@@ -1613,16 +1613,18 @@ describe('WebAPI Service', () => {
       expect(result).toBeNull()
     })
 
-    it('assignTagToCohort returns false on error', async () => {
+    it('assignTagToCohort returns the error message on failure', async () => {
       mockFetch.mockRejectedValueOnce(new Error('network error'))
       const result = await webapi.assignTagToCohort(1, 10)
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('network error')
     })
 
-    it('unassignTagFromCohort returns false on error', async () => {
+    it('unassignTagFromCohort returns the error message on failure', async () => {
       mockFetch.mockRejectedValueOnce(new Error('network error'))
       const result = await webapi.unassignTagFromCohort(1, 10)
-      expect(result).toBe(false)
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('network error')
     })
   })
 })

--- a/tests/unit/services/webapi.spec.ts
+++ b/tests/unit/services/webapi.spec.ts
@@ -1626,5 +1626,24 @@ describe('WebAPI Service', () => {
       expect(result.success).toBe(false)
       expect(result.error).toBe('network error')
     })
+
+    it('assignTagToCohort POSTs the raw tagId and reports success', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') })
+      const result = await webapi.assignTagToCohort(1, 10)
+      expect(result).toEqual({ success: true })
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/cohortdefinition/1/tag/')
+      expect(options.method).toBe('POST')
+      expect(options.body).toBe('10')
+    })
+
+    it('unassignTagFromCohort DELETEs the tag and reports success', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') })
+      const result = await webapi.unassignTagFromCohort(1, 10)
+      expect(result).toEqual({ success: true })
+      const [url, options] = mockFetch.mock.calls[0]
+      expect(url).toContain('/cohortdefinition/1/tag/10')
+      expect(options.method).toBe('DELETE')
+    })
   })
 })

--- a/tests/unit/stores/concept-sets.tags.spec.ts
+++ b/tests/unit/stores/concept-sets.tags.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
-const assignSpy = vi.fn().mockResolvedValue(true)
-const unassignSpy = vi.fn().mockResolvedValue(true)
+const assignSpy = vi.fn().mockResolvedValue({ success: true })
+const unassignSpy = vi.fn().mockResolvedValue({ success: true })
 
 vi.mock('@/services/concept-set.service', () => ({
   getAllConceptSets: vi.fn().mockResolvedValue([]),
@@ -25,9 +25,19 @@ describe('concept-sets store tags', () => {
 
   it('syncTags assigns added and unassigns removed tags', async () => {
     const store = useConceptSetsStore()
-    await store.syncTags(42, [{ id: 1, name: 'old' }], [{ id: 2, name: 'new' }])
+    const result = await store.syncTags(42, [{ id: 1, name: 'old' }], [{ id: 2, name: 'new' }])
     expect(assignSpy).toHaveBeenCalledWith(42, 2)
     expect(unassignSpy).toHaveBeenCalledWith(42, 1)
+    expect(result.success).toBe(true)
+  })
+
+  it('syncTags reports failure when the server rejects an assignment', async () => {
+    assignSpy.mockResolvedValueOnce({ success: false, error: 'HTTP 500: mandatory tag group violated' })
+    const store = useConceptSetsStore()
+    const result = await store.syncTags(42, [], [{ id: 2, name: 'new' }])
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('mandatory tag group violated')
+    expect(store.error).toContain('mandatory tag group violated')
   })
 
   it('availableTags returns sorted unique tag names', () => {


### PR DESCRIPTION
This pull request improves error handling and compatibility in tag assignment for cohorts and concept sets, and fixes how nested criteria are handled in cohort definitions imported from legacy CIRCE/ATLAS exports. The main changes include surfacing detailed server error messages for tag assignment failures, updating APIs and store methods to return structured results, and ensuring correct serialization/deserialization of nested criteria. Related tests have also been updated and expanded to cover these scenarios.
