### PR TITLE
fix(cohort-builder): edit embedded concept sets at the cohort level (#133)

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -488,12 +488,13 @@
       v-if="conceptSetsStore.editorOpen"
       :model-value="conceptSetsStore.editorOpen"
       :concept-set="conceptSetsStore.currentSet"
+      embedded
       @update:model-value="
         value => {
           if (!value) conceptSetsStore.closeEditor()
         }
       "
-      @save="handleConceptSetSaved"
+      @apply="handleConceptSetApplied"
     />
 
     <AtlasSnackbar
@@ -630,6 +631,7 @@ import CohortToolbarActions from './CohortToolbarActions.vue'
 import CohortToolbarStatus from './CohortToolbarStatus.vue'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { ensureUniqueConceptSetId, hasNumericConceptSetId } from '@/utils/concept-set-id'
+import { updateConceptSetUsages } from '@/utils/concept-set-usages'
 import { resolveCriteriaTargetEvent } from '@/utils/criteria-target'
 import ConceptSetsListDialog from './ConceptSetsListDialog.vue'
 import ValidationMessagesDialog from './ValidationMessagesDialog.vue'
@@ -1837,12 +1839,11 @@ async function handleEditConceptSet(conceptSet: {
 
   // Use the embedded concept set items directly (don't fetch from API)
   // The concept set is embedded in the cohort definition with all its items
-  conceptSetsStore.currentSet = {
+  conceptSetsStore.openEmbeddedEditor({
     id: conceptSet.id,
     name: conceptSet.name,
     items: (conceptSet.items || []) as ConceptSetItem[],
-  }
-  conceptSetsStore.editorOpen = true
+  })
 }
 
 /**
@@ -1870,22 +1871,35 @@ function handleCreateNewConceptSet() {
 }
 
 /**
- * Called when a concept set is saved in the editor
- * This updates the cohort definition with the saved concept set
+ * Called when the embedded editor applies its changes. The editor worked on a
+ * disposable clone, so nothing reached the cohort yet — write the result into
+ * every usage of the concept set id, which flips the unsaved-changes snapshot.
  */
-function handleConceptSetSaved() {
-  // After save, the store.currentSet should hold the saved concept set
-  const conceptSet = conceptSetsStore.currentSet
-  if (!conceptSet || (!selectedCriteriaContext.value && !pendingConceptSetCallback.value)) return
+function handleConceptSetApplied(set: { id?: number | string; name: string; items?: unknown[] }) {
+  const items = JSON.parse(JSON.stringify(set.items ?? [])) as ConceptSetItem[]
 
-  // Copy the entire concept set including items into the cohort definition
-  const conceptSetRef: ConceptSetReference = {
-    id: conceptSet.id!,
-    name: conceptSet.name,
-    items: conceptSet.items || [],
+  if (set.id !== undefined && set.id !== null) {
+    const updated: ConceptSetReference = { id: set.id, name: set.name, items }
+    updateConceptSetUsages(
+      {
+        entryEvents: entryEvents.value,
+        additionalCriteria: additionalCriteria.value,
+        inclusionRules: inclusionRules.value,
+        exitCriteria: exitCriteria.value,
+        censoringCriteria: censoringCriteria.value,
+      },
+      updated
+    )
+    entryEvents.value = [...entryEvents.value]
+    inclusionRules.value = [...inclusionRules.value]
+    if (additionalCriteria.value) additionalCriteria.value = { ...additionalCriteria.value }
+    exitCriteria.value = { ...exitCriteria.value }
+    censoringCriteria.value = [...censoringCriteria.value]
   }
 
-  assignConceptSetToContext(conceptSetRef)
+  if (selectedCriteriaContext.value || pendingConceptSetCallback.value) {
+    assignConceptSetToContext({ id: set.id ?? 0, name: set.name, items })
+  }
 }
 
 /**

--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -49,6 +49,7 @@
 
           <div class="cs-editor__actions">
             <AtlasTooltip
+              v-if="!embedded"
               :text="t('common.tags', 'Tags').value"
               location="bottom"
             >
@@ -75,7 +76,7 @@
             </AtlasTooltip>
 
             <AtlasTooltip
-              v-if="isEditMode && props.conceptSet?.id"
+              v-if="!embedded && isEditMode && props.conceptSet?.id"
               :text="t('cohortDefinitions.cohortDefinitionManager.tabs.versions', 'Versions').value"
               location="bottom"
             >
@@ -100,7 +101,7 @@
             </AtlasTooltip>
 
             <AtlasButton
-              v-if="isEditMode"
+              v-if="!embedded && isEditMode"
               variant="ghost"
               tone="danger"
               :disabled="loading || !canDelete"
@@ -110,11 +111,27 @@
             </AtlasButton>
 
             <AtlasButton
+              v-if="embedded"
+              variant="ghost"
+              data-testid="cs-editor-cancel-btn"
+              @click="onClose"
+            >
+              {{ t('common.cancel', 'Cancel') }}
+            </AtlasButton>
+
+            <AtlasButton
               :disabled="!formValid || loading || !canSubmit"
               :loading="loading"
-              @click="onSave"
+              data-testid="cs-editor-primary-btn"
+              @click="embedded ? onApply() : onSave()"
             >
-              {{ isEditMode ? t('common.save', 'Save') : t('common.create', 'Create') }}
+              {{
+                embedded
+                  ? t('common.apply', 'Apply')
+                  : isEditMode
+                    ? t('common.save', 'Save')
+                    : t('common.create', 'Create')
+              }}
             </AtlasButton>
 
             <AtlasIconButton
@@ -684,6 +701,7 @@ const webapiStore = useWebAPIStore()
 interface Props {
   modelValue: boolean
   conceptSet: ConceptSet | null
+  embedded?: boolean
 }
 
 const props = defineProps<Props>()
@@ -691,6 +709,7 @@ const props = defineProps<Props>()
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   save: []
+  apply: [conceptSet: ConceptSet]
   delete: [id: number | string]
 }>()
 
@@ -828,9 +847,13 @@ const isEditMode = computed(() => {
 const conceptSetId = computed<number | string | null>(() => props.conceptSet?.id ?? null)
 const { hasPermission } = usePermissions()
 const { canWrite, canDelete } = useEntityAccess('conceptSet', conceptSetId)
-const canSubmit = computed<boolean>(() =>
-  isEditMode.value ? canWrite.value : hasPermission('create:conceptset')
-)
+const canSubmit = computed<boolean>(() => {
+  // Embedded sets carry cohort-local codeset ids; entity access on that id
+  // would check an unrelated repository concept set. The cohort's own save
+  // flow gates persistence instead.
+  if (props.embedded) return true
+  return isEditMode.value ? canWrite.value : hasPermission('create:conceptset')
+})
 
 const itemCount = computed(() => {
   return store.currentSet?.items?.length || 0
@@ -981,6 +1004,12 @@ watch(
 watch(
   () => props.conceptSet?.id,
   async id => {
+    // An embedded id is a cohort-local CodesetId — querying /conceptset/{id}/version
+    // with it would fetch an unrelated repository set's history.
+    if (props.embedded) {
+      versionCount.value = 0
+      return
+    }
     if (id && typeof id === 'number') {
       try {
         const versions = await getConceptSetVersions(id)
@@ -1039,6 +1068,18 @@ async function onSave() {
   } finally {
     loading.value = false
   }
+}
+
+function onApply() {
+  if (!formValid.value) return
+
+  emit('apply', {
+    id: props.conceptSet?.id,
+    name: form.value.name,
+    items: store.currentSet?.items ?? [],
+  } as ConceptSet)
+  hasUnsavedChanges.value = false
+  emit('update:modelValue', false)
 }
 
 function onTitleInput(event: Event) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -93,6 +93,7 @@
     "add": "Add",
     "and": "and",
     "anonymous": "anonymous",
+    "apply": "Apply",
     "cancel": "Cancel",
     "close": "Close",
     "configureAccess": "Configure access",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -93,6 +93,7 @@
     "add": "追加",
     "and": "かつ",
     "anonymous": "匿名",
+    "apply": "適用",
     "cancel": "キャンセル",
     "close": "閉じる",
     "configureAccess": "アクセスを設定",

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -404,6 +404,21 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
   }
 
   /**
+   * Open editor on a disposable clone of a cohort-embedded concept set, so
+   * editor mutations never reach the cohort until the host applies them.
+   */
+  function openEmbeddedEditor(set: {
+    id: number | string
+    name: string
+    items?: ConceptSetItem[]
+  }) {
+    currentSet.value = JSON.parse(
+      JSON.stringify({ id: set.id, name: set.name, items: set.items ?? [] })
+    ) as ConceptSet
+    editorOpen.value = true
+  }
+
+  /**
    * Close editor
    */
   function closeEditor() {
@@ -985,6 +1000,7 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     clearFilters,
     openCreateEditor,
     openEditEditor,
+    openEmbeddedEditor,
     closeEditor,
     clearError,
 

--- a/src/utils/concept-set-usages.ts
+++ b/src/utils/concept-set-usages.ts
@@ -1,0 +1,61 @@
+import type {
+  CohortEvent,
+  CriteriaGroup,
+  ConceptSetReference,
+  ExitCriteria,
+  InclusionRule,
+} from '@/models/cohort.types'
+
+interface ConceptSetUsageHost {
+  entryEvents: CohortEvent[]
+  additionalCriteria?: CriteriaGroup
+  inclusionRules: InclusionRule[]
+  exitCriteria?: ExitCriteria
+  censoringCriteria?: CohortEvent[]
+}
+
+export function updateConceptSetUsages(
+  cohort: ConceptSetUsageHost,
+  updated: ConceptSetReference
+): number {
+  let count = 0
+
+  function updateEvent(event: CohortEvent) {
+    if (event.conceptSet?.id === updated.id) {
+      event.conceptSet = { ...updated }
+      count++
+    }
+    for (const attribute of event.attributes ?? []) {
+      if (attribute.type === 'conceptSet' && attribute.conceptSet.id === updated.id) {
+        attribute.conceptSet = { ...attribute.conceptSet, name: updated.name }
+        count++
+      }
+    }
+    if (event.nestedCriteria) {
+      updateGroup(event.nestedCriteria)
+    }
+  }
+
+  function updateGroup(group: CriteriaGroup) {
+    group.events.forEach(updateEvent)
+    group.nestedGroups?.forEach(updateGroup)
+  }
+
+  cohort.entryEvents.forEach(updateEvent)
+  if (cohort.additionalCriteria) {
+    updateGroup(cohort.additionalCriteria)
+  }
+  for (const rule of cohort.inclusionRules) {
+    rule.criteriaGroups.forEach(updateGroup)
+  }
+  if (cohort.exitCriteria) {
+    if (cohort.exitCriteria.conceptSet?.id === updated.id) {
+      cohort.exitCriteria.conceptSet = { ...updated }
+      count++
+    }
+    cohort.exitCriteria.censoringEvents?.forEach(updateEvent)
+  }
+  cohort.censoringCriteria?.forEach(updateEvent)
+
+  return count
+}

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -975,22 +975,93 @@ describe('CohortBuilder', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // handleConceptSetSaved (relies on store.currentSet)
+  // handleEditConceptSet / handleConceptSetApplied (embedded editor flow)
   // ---------------------------------------------------------------------------
 
-  it('handleConceptSetSaved bails out early when context is null', async () => {
+  it('handleEditConceptSet opens the editor on a clone, leaving cohort items untouched', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    const items = [{ conceptId: 1, includeDescendants: false }]
+    await setup.handleEditConceptSet({ id: 5, name: 'Embedded', items })
+    const { useConceptSetsStore } = await import('@/stores/concept-sets')
+    const store = useConceptSetsStore()
+    expect(store.editorOpen).toBe(true)
+    store.currentSet!.items.push({ conceptId: 2 } as any)
+    store.currentSet!.items[0]!.includeDescendants = true
+    expect(items).toEqual([{ conceptId: 1, includeDescendants: false }])
+  })
+
+  it('handleConceptSetApplied is a no-op without a matching usage or pending context', async () => {
     const wrapper = createWrapper()
     await wrapper.vm.$nextTick()
     const setup = getSetup(wrapper)
     setup.selectedCriteriaContext = null
-    // Populate store.currentSet so the function reaches its early-return on context
-    const { useConceptSetsStore } = await import('@/stores/concept-sets')
-    const store = useConceptSetsStore()
-    store.currentSet = { id: 9, name: 'x', items: [] } as any
-    expect(() => setup.handleConceptSetSaved()).not.toThrow()
+    expect(() => setup.handleConceptSetApplied({ id: 9, name: 'x', items: [] })).not.toThrow()
   })
 
-  it('handleConceptSetSaved assigns the saved concept set to entry-event context', async () => {
+  it('handleConceptSetApplied updates every usage of the id and marks the cohort dirty', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.selectedCriteriaContext = null
+    setup.entryEvents = [
+      {
+        id: 'evt-1',
+        criteriaType: 'X',
+        attributes: [],
+        conceptSet: { id: 7, name: 'Old', items: [] },
+      },
+      {
+        id: 'evt-2',
+        criteriaType: 'X',
+        attributes: [],
+        conceptSet: { id: 8, name: 'Other', items: [] },
+      },
+    ]
+    setup.inclusionRules = [
+      {
+        id: 'rule-1',
+        name: 'r',
+        criteriaGroups: [
+          {
+            id: 'g-1',
+            logicType: 'ALL',
+            events: [
+              {
+                id: 'evt-3',
+                criteriaType: 'X',
+                attributes: [],
+                conceptSet: { id: 7, name: 'Old', items: [] },
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    setup.exitCriteria = {
+      strategy: 'CONTINUOUS_DRUG',
+      conceptSet: { id: 7, name: 'Old', items: [] },
+    }
+    await wrapper.vm.$nextTick()
+    setup.loadedSnapshot = setup.createStateSnapshot()
+    expect(setup.hasUnsavedChanges).toBe(false)
+
+    const newItems = [{ conceptId: 42 }]
+    setup.handleConceptSetApplied({ id: 7, name: 'Updated', items: newItems })
+
+    expect(setup.entryEvents[0].conceptSet).toEqual({ id: 7, name: 'Updated', items: newItems })
+    expect(setup.entryEvents[1].conceptSet).toEqual({ id: 8, name: 'Other', items: [] })
+    expect(setup.inclusionRules[0].criteriaGroups[0].events[0].conceptSet).toEqual({
+      id: 7,
+      name: 'Updated',
+      items: newItems,
+    })
+    expect(setup.exitCriteria.conceptSet).toEqual({ id: 7, name: 'Updated', items: newItems })
+    expect(setup.hasUnsavedChanges).toBe(true)
+  })
+
+  it('handleConceptSetApplied assigns the applied concept set to a pending entry-event context', async () => {
     const wrapper = createWrapper()
     await wrapper.vm.$nextTick()
     const setup = getSetup(wrapper)
@@ -1001,10 +1072,7 @@ describe('CohortBuilder', () => {
       groupIndex: 0,
       eventIndex: 0,
     }
-    const { useConceptSetsStore } = await import('@/stores/concept-sets')
-    const store = useConceptSetsStore()
-    store.currentSet = { id: 77, name: 'Saved Set', items: [] } as any
-    setup.handleConceptSetSaved()
+    setup.handleConceptSetApplied({ id: 77, name: 'Saved Set', items: [] })
     expect(setup.entryEvents[0].conceptSet).toMatchObject({ id: 77, name: 'Saved Set' })
   })
 

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -52,6 +52,15 @@ vi.mock('@/services/concept-search.service', async (importOriginal) => {
   }
 })
 
+vi.mock('@/services/concept-set-versions.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/concept-set-versions.service')>()
+  return {
+    ...actual,
+    getVersions: vi.fn().mockResolvedValue([]),
+  }
+})
+import { getVersions as mockedGetVersions } from '@/services/concept-set-versions.service'
+
 const vuetify = createVuetify({ components, directives })
 
 const mockConceptSet: ConceptSet = {
@@ -354,6 +363,82 @@ describe('ConceptSetEditor', () => {
       await closeBtn.trigger('click')
       expect((wrapper.vm as unknown as { showCloseConfirm: boolean }).showCloseConfirm).toBe(true)
     }
+  })
+
+  describe('embedded mode (#133)', () => {
+    const embeddedSet: ConceptSet = { id: 3, name: 'Embedded Set', items: [] }
+
+    function mountEmbedded(props = {}) {
+      return mountComponent({ conceptSet: embeddedSet, embedded: true, ...props })
+    }
+
+    it('renders Apply and Cancel instead of Save/Delete/Tags/Versions', () => {
+      const wrapper = mountEmbedded()
+      const buttons = wrapper.findAllComponents({ name: 'VBtn' })
+      expect(buttons.find(btn => btn.text().includes('Apply'))).toBeTruthy()
+      expect(buttons.find(btn => btn.text().includes('Cancel'))).toBeTruthy()
+      expect(buttons.find(btn => btn.text().includes('Save'))).toBeFalsy()
+      expect(buttons.find(btn => btn.text().includes('Delete'))).toBeFalsy()
+      expect(wrapper.find('[data-testid="cs-editor-tags-btn"]').exists()).toBe(false)
+      expect(buttons.find(btn => btn.props('icon') === 'mdi-history')).toBeFalsy()
+    })
+
+    it('does not fetch version history for the cohort-local id', async () => {
+      vi.mocked(mockedGetVersions).mockClear()
+      mountEmbedded()
+      await flushPromises()
+      expect(mockedGetVersions).not.toHaveBeenCalled()
+    })
+
+    it('Apply emits the edited set without any store persistence call', async () => {
+      const wrapper = mountEmbedded()
+      const store = useConceptSetsStore()
+      store.currentSet = { id: 3, name: 'Embedded Set', items: [mockConceptSet.items[0]!] }
+      const updateSpy = vi.spyOn(store, 'update')
+      const createSpy = vi.spyOn(store, 'create')
+
+      wrapper.vm.formValid = true
+      await wrapper.vm.$nextTick()
+      wrapper.vm.onApply()
+
+      expect(wrapper.emitted('apply')).toBeTruthy()
+      expect(wrapper.emitted('apply')![0]![0]).toMatchObject({
+        id: 3,
+        name: 'Embedded Set',
+        items: [expect.objectContaining({ conceptId: 313217 })],
+      })
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+      expect(updateSpy).not.toHaveBeenCalled()
+      expect(createSpy).not.toHaveBeenCalled()
+    })
+
+    it('Cancel with unsaved edits opens the confirm dialog; discarding closes without apply', async () => {
+      const wrapper = mountEmbedded()
+      const titleInput = wrapper.find('input.cs-editor__title-input')
+      ;(titleInput.element as HTMLInputElement).value = 'Modified'
+      await titleInput.trigger('input')
+
+      const buttons = wrapper.findAllComponents({ name: 'VBtn' })
+      const cancelBtn = buttons.find(btn => btn.text().includes('Cancel'))!
+      await cancelBtn.trigger('click')
+      expect((wrapper.vm as unknown as { showCloseConfirm: boolean }).showCloseConfirm).toBe(true)
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+      ;(wrapper.vm as unknown as { confirmClose: () => void }).confirmClose()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+      expect(wrapper.emitted('apply')).toBeFalsy()
+    })
+
+    it('Cancel with no edits closes immediately', async () => {
+      const wrapper = mountEmbedded()
+      const buttons = wrapper.findAllComponents({ name: 'VBtn' })
+      const cancelBtn = buttons.find(btn => btn.text().includes('Cancel'))!
+      await cancelBtn.trigger('click')
+
+      expect((wrapper.vm as unknown as { showCloseConfirm: boolean }).showCloseConfirm).toBe(false)
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+    })
   })
 
   it('should add concept to set when add-concept is emitted', async () => {

--- a/tests/unit/stores/concept-sets.spec.ts
+++ b/tests/unit/stores/concept-sets.spec.ts
@@ -424,6 +424,25 @@ describe('Concept Sets Store', () => {
       expect(store.currentSet).toBeNull()
       expect(store.error).toBeNull()
     })
+
+    it('openEmbeddedEditor opens on a clone so editor mutations never reach the source', () => {
+      const store = useConceptSetsStore()
+      const source = {
+        id: 2,
+        name: 'Embedded',
+        items: [{ conceptId: 1, includeDescendants: false }] as never[],
+      }
+
+      store.openEmbeddedEditor(source)
+
+      expect(store.editorOpen).toBe(true)
+      expect(store.currentSet).toEqual(source)
+      expect(store.currentSet!.items).not.toBe(source.items)
+
+      store.addConceptToSet({ conceptId: 9, conceptName: 'X' } as never)
+      store.toggleConceptFlag(1, 'includeDescendants')
+      expect(source.items).toEqual([{ conceptId: 1, includeDescendants: false }])
+    })
   })
 
   describe('clearError Action', () => {

--- a/tests/unit/utils/concept-set-usages.spec.ts
+++ b/tests/unit/utils/concept-set-usages.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import { updateConceptSetUsages } from '@/utils/concept-set-usages'
+import type {
+  CohortEvent,
+  CriteriaGroup,
+  ExitCriteria,
+  InclusionRule,
+} from '@/models/cohort.types'
+
+function event(id: string, conceptSetId?: number | string): CohortEvent {
+  return {
+    id,
+    criteriaType: 'ConditionOccurrence',
+    ...(conceptSetId !== undefined
+      ? { conceptSet: { id: conceptSetId, name: 'Old', items: [{ conceptId: 1 }] } }
+      : {}),
+  }
+}
+
+const updated = { id: 7, name: 'Updated', items: [{ conceptId: 42 }] }
+
+describe('updateConceptSetUsages', () => {
+  it('updates matching usages across all cohort locations and returns the count', () => {
+    const nested: CriteriaGroup = {
+      id: 'g-nested',
+      logicType: 'ALL',
+      events: [event('evt-nested', 7)],
+      nestedGroups: [
+        { id: 'g-deep', logicType: 'ANY', events: [event('evt-deep', 7)] },
+      ],
+    }
+    const cohort = {
+      entryEvents: [
+        { ...event('evt-1', 7), nestedCriteria: nested },
+        event('evt-2', 8),
+      ],
+      additionalCriteria: {
+        id: 'g-add',
+        logicType: 'ALL',
+        events: [event('evt-add', 7)],
+      } as CriteriaGroup,
+      inclusionRules: [
+        {
+          id: 'rule-1',
+          name: 'r',
+          criteriaGroups: [
+            { id: 'g-rule', logicType: 'ALL', events: [event('evt-rule', 7)] },
+          ],
+        },
+      ] as InclusionRule[],
+      exitCriteria: {
+        strategy: 'CONTINUOUS_DRUG',
+        conceptSet: { id: 7, name: 'Old', items: [] },
+        censoringEvents: [event('evt-censor-exit', 7)],
+      } as ExitCriteria,
+      censoringCriteria: [event('evt-censor', 7)],
+    }
+
+    const count = updateConceptSetUsages(cohort, updated)
+
+    expect(count).toBe(8)
+    expect(cohort.entryEvents[0]!.conceptSet).toEqual(updated)
+    expect(cohort.entryEvents[0]!.nestedCriteria!.events[0]!.conceptSet).toEqual(updated)
+    expect(cohort.entryEvents[0]!.nestedCriteria!.nestedGroups![0]!.events[0]!.conceptSet).toEqual(
+      updated
+    )
+    expect(cohort.additionalCriteria.events[0]!.conceptSet).toEqual(updated)
+    expect(cohort.inclusionRules[0]!.criteriaGroups[0]!.events[0]!.conceptSet).toEqual(updated)
+    expect(cohort.exitCriteria.conceptSet).toEqual(updated)
+    expect(cohort.exitCriteria.censoringEvents![0]!.conceptSet).toEqual(updated)
+    expect(cohort.censoringCriteria[0]!.conceptSet).toEqual(updated)
+  })
+
+  it('leaves non-matching usages untouched', () => {
+    const cohort = {
+      entryEvents: [event('evt-1', 8)],
+      inclusionRules: [],
+    }
+    const count = updateConceptSetUsages(cohort, updated)
+    expect(count).toBe(0)
+    expect(cohort.entryEvents[0]!.conceptSet).toEqual({
+      id: 8,
+      name: 'Old',
+      items: [{ conceptId: 1 }],
+    })
+  })
+
+  it('updates only the name on concept-set attributes', () => {
+    const cohort = {
+      entryEvents: [
+        {
+          ...event('evt-1'),
+          attributes: [
+            {
+              type: 'conceptSet' as const,
+              attributeKey: 'providerSpecialty' as never,
+              conceptSet: { id: 7, name: 'Old' },
+              isExclusion: true,
+            },
+          ],
+        },
+      ],
+      inclusionRules: [],
+    }
+    const count = updateConceptSetUsages(cohort, updated)
+    expect(count).toBe(1)
+    expect(cohort.entryEvents[0]!.attributes![0]).toEqual({
+      type: 'conceptSet',
+      attributeKey: 'providerSpecialty',
+      conceptSet: { id: 7, name: 'Updated' },
+      isExclusion: true,
+    })
+  })
+
+  it('treats id 0 as a real concept set id', () => {
+    const cohort = {
+      entryEvents: [event('evt-1', 0)],
+      inclusionRules: [],
+    }
+    const count = updateConceptSetUsages(cohort, { id: 0, name: 'Zero', items: [] })
+    expect(count).toBe(1)
+    expect(cohort.entryEvents[0]!.conceptSet).toEqual({ id: 0, name: 'Zero', items: [] })
+  })
+
+  it('replaces usages with independent copies, not a shared reference', () => {
+    const cohort = {
+      entryEvents: [event('evt-1', 7), event('evt-2', 7)],
+      inclusionRules: [],
+    }
+    updateConceptSetUsages(cohort, updated)
+    expect(cohort.entryEvents[0]!.conceptSet).not.toBe(cohort.entryEvents[1]!.conceptSet)
+  })
+})


### PR DESCRIPTION
Concept sets embedded in a cohort were edited with the standalone repository editor. Its Save button wrote to WebAPI `/conceptset/{id}` using the cohort-local codeset id, edits leaked into the cohort by array reference before any save, and "Discard changes" only closed the drawer without reverting anything.

The editor now has an embedded mode used by the cohort builder. It opens on a disposable clone of the embedded set and shows Apply/Cancel instead of Save: Apply writes the edited set into every usage of that codeset id (entry events, nested criteria, inclusion rules, exit criteria, censoring events) and marks the cohort dirty, so the changes persist only when the cohort itself is saved; Cancel discards the clone, making the unsaved-changes dialog's discard genuinely discard. Repository affordances (WebAPI save, delete, tags, version history) are hidden in this context, which also stops the version lookup that hit an unrelated repository concept set via the cohort-local id.

The standalone concepts editor keeps its current behavior.

Addresses the concept-set part of #133; the save-button color indicator is deferred.