### PR TITLE
Fix wrong embedded concept sets for cohorts using concept set id 0

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -1044,7 +1044,10 @@ async function buildCohortExpression() {
       qualifyingLimit: qualifyingLimit.value,
       primaryCriteriaLimit: primaryCriteriaLimit.value,
       inclusionQualifyingLimit: inclusionQualifyingLimit.value,
-      conceptSets: conceptSetsWithItems.filter(cs => cs.id !== 0),
+      // 0 is a valid concept-set id (nextConceptSetId starts there), so a
+      // single-concept-set cohort must not have its only set filtered out
+      // while criteria still reference CodesetId 0.
+      conceptSets: conceptSetsWithItems,
       ...(additionalCriteria.value !== undefined ? { additionalCriteria: additionalCriteria.value } : {}),
     }
 
@@ -1805,9 +1808,11 @@ async function handleConceptSetSelected(conceptSet: {
 }) {
   if (!conceptSet || (!selectedCriteriaContext.value && !pendingConceptSetCallback.value)) return
 
-  // Fetch the full concept set with items if we only have a reference
   let fullConceptSet: { id: number | string; name: string; items?: unknown[] } = conceptSet
-  if (conceptSet.id && (!conceptSet.items || conceptSet.items.length === 0)) {
+  // Definedness, not truthiness: id 0 is valid, and a truthy check would skip
+  // the fetch and leave the partial reference in place.
+  const hasUsableId = conceptSet.id !== undefined && conceptSet.id !== null && conceptSet.id !== ''
+  if (hasUsableId && (!conceptSet.items || conceptSet.items.length === 0)) {
     await conceptSetsStore.fetchOne(conceptSet.id)
     if (conceptSetsStore.currentSet && conceptSetsStore.currentSet.id !== undefined) {
       fullConceptSet = {
@@ -2272,6 +2277,12 @@ function applyImportedExpression(importedCohort: Partial<CohortDefinition>) {
   qualifyingLimit.value = importedCohort.qualifyingLimit || 'ALL'
   primaryCriteriaLimit.value = importedCohort.primaryCriteriaLimit
   inclusionQualifyingLimit.value = importedCohort.inclusionQualifyingLimit || 'ALL'
+  // The Concepts dialog and unused-set badge read the store list directly
+  // rather than the refs above, so it would otherwise keep showing the
+  // previous cohort's sets after an Apply.
+  if (cohortStore.currentCohort) {
+    cohortStore.currentCohort.conceptSets = importedCohort.conceptSets || []
+  }
 
   // Trigger validation (composable handles debouncing)
   triggerValidation()

--- a/src/composables/useCohortValidation.ts
+++ b/src/composables/useCohortValidation.ts
@@ -187,7 +187,8 @@ export function useCohortValidation(options: CohortValidationOptions): CohortVal
             return ref
           }
 
-          if (ref.id) {
+          // Avoid a falsy check: id 0 is a valid concept-set id.
+          if (ref.id !== undefined && ref.id !== null) {
             const fullConceptSet = await getConceptSetById(ref.id)
             if (fullConceptSet && fullConceptSet.items) {
               return {

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -158,6 +158,7 @@ vi.mock('@/services/atlas-converter', () => ({
 }))
 
 import CohortBuilder from '@/components/cohort/CohortBuilder.vue'
+import { convertInternalToAtlas } from '@/services/atlas-converter'
 
 const vuetify = createVuetify({
   components,
@@ -790,6 +791,29 @@ describe('CohortBuilder', () => {
     expect(def.qualifyingLimit).toBe('ALL')
   })
 
+  it('buildCohortExpression keeps a concept set whose id is 0 (single concept-set cohort)', async () => {
+    // Regression test for #144: dropping the id-0 set leaves criteria
+    // referencing CodesetId 0 against an empty ConceptSets.
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.entryEvents = [
+      {
+        id: 'e1',
+        criteriaType: 'DrugExposure',
+        attributes: [],
+        conceptSet: { id: 0, name: 'Solo Concept Set', items: [{ concept: { CONCEPT_ID: 1 } }] },
+      },
+    ]
+    await setup.buildCohortExpression()
+
+    const lastCall = (convertInternalToAtlas as unknown as { mock: { calls: any[][] } }).mock.calls.at(
+      -1
+    )
+    expect(lastCall?.[0].conceptSets).toHaveLength(1)
+    expect(lastCall?.[0].conceptSets[0].id).toBe(0)
+  })
+
   it('exportFilename slugifies the cohort name', async () => {
     const wrapper = createWrapper()
     await wrapper.vm.$nextTick()
@@ -1145,6 +1169,33 @@ describe('CohortBuilder', () => {
     await setup.handleConceptSetSelected({ id: 6, name: 'NeedsFetch' })
     expect(fetchSpy).toHaveBeenCalledWith(6)
     expect(setup.entryEvents[0].conceptSet).toMatchObject({ id: 0, name: 'Fetched' })
+  })
+
+  it('handleConceptSetSelected fetches items from store even when the selected concept set id is 0 (issue #144)', async () => {
+    // Regression test for #144: a truthy guard skips the fetch for id 0 and
+    // leaves the partial reference, showing the wrong embedded concept set.
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.entryEvents = [{ id: 'evt-1', criteriaType: 'X', attributes: [] }]
+    setup.selectedCriteriaContext = {
+      eventId: 'evt-1',
+      ruleIndex: -1,
+      groupIndex: 0,
+      eventIndex: 0,
+    }
+    const { useConceptSetsStore } = await import('@/stores/concept-sets')
+    const store = useConceptSetsStore()
+    const fetchSpy = vi.spyOn(store, 'fetchOne').mockImplementation(async (id: number | string) => {
+      store.currentSet = { id, name: 'FirstSet', items: [{ concept: { CONCEPT_ID: 42 } }] } as any
+    })
+    await setup.handleConceptSetSelected({ id: 0, name: 'FirstSet' })
+    expect(fetchSpy).toHaveBeenCalledWith(0)
+    expect(setup.entryEvents[0].conceptSet).toMatchObject({
+      id: 0,
+      name: 'FirstSet',
+      items: [{ concept: { CONCEPT_ID: 42 } }],
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -1726,6 +1777,7 @@ describe('CohortBuilder', () => {
     exitCriteria: { strategy: 'CONTINUOUS_OBSERVATION' },
     observationPeriod: { priorDays: 365, postDays: 30 },
     qualifyingLimit: 'FIRST',
+    conceptSets: [{ id: 7, name: 'Coronary Artery Bypass', items: [] }],
   })
 
   /** Emit `apply` from the stubbed CohortJsonDialog, as the real dialog does. */
@@ -1785,6 +1837,45 @@ describe('CohortBuilder', () => {
 
     // The pasted JSON has no InclusionRules, so the loaded rule is gone.
     expect(setup.inclusionRules).toEqual([])
+  })
+
+  // Regression test for #144: applying JSON refreshed the entry events but
+  // not the store list the embedded concept sets dialog reads from.
+  it('applying JSON refreshes the store concept-sets list backing the Concepts dialog', async () => {
+    const wrapper = createWrapper({ id: '42' })
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    const { useCohortStore } = await import('@/stores/cohort')
+    const store = useCohortStore()
+    // Loaded cohort mock has no concept sets yet.
+    expect(store.currentCohort?.conceptSets).toEqual([])
+
+    importFromAtlasSpy.mockResolvedValueOnce(importedProcedureCohort())
+    await applyJson(wrapper, '{"PrimaryCriteria":{}}')
+
+    expect(store.currentCohort?.conceptSets).toEqual([
+      { id: 7, name: 'Coronary Artery Bypass', items: [] },
+    ])
+  })
+
+  it('applying JSON that omits concept sets clears the store list too', async () => {
+    const wrapper = createWrapper({ id: '42' })
+    await new Promise(r => setTimeout(r, 0))
+    await wrapper.vm.$nextTick()
+
+    const { useCohortStore } = await import('@/stores/cohort')
+    const store = useCohortStore()
+    // Seed a leftover concept set as if a prior expression had loaded one.
+    if (store.currentCohort) {
+      store.currentCohort.conceptSets = [{ id: 0, name: 'Stale Set', items: [] }]
+    }
+
+    const { conceptSets: _omit, ...withoutConceptSets } = importedProcedureCohort()
+    importFromAtlasSpy.mockResolvedValueOnce(withoutConceptSets)
+    await applyJson(wrapper, '{}')
+
+    expect(store.currentCohort?.conceptSets).toEqual([])
   })
 
   it('applying JSON closes the dialog and reports success', async () => {


### PR DESCRIPTION
Fixes #144.

Three separate defects combined to show the wrong embedded concept sets for a cohort, most visibly one with a single concept set:

- `buildCohortExpression()` filtered out any concept set with id 0 before building the Atlas expression. 0 is a valid id — `nextConceptSetId` starts numbering there — so a single-concept-set cohort had its only set stripped from `ConceptSets` while criteria still referenced `CodesetId 0`.
- `handleConceptSetSelected()` used a `conceptSet.id &&` truthy guard to decide whether to fetch the full set, silently skipping the fetch for id 0 and leaving a partial/stale reference in the cohort. `useCohortValidation` had the same falsy check when fetching items.
- `applyImportedExpression()` updated the criteria but never refreshed the cohort store's own `conceptSets` list. The embedded concept sets dialog and the save payload read that list directly, so after applying pasted or imported JSON they kept showing and persisting the previously loaded cohort's concept sets.

Covered by new cases in `tests/component/cohort/CohortBuilder.spec.ts`.
