### PR TITLE
Fix sortable column headers not re-sorting rows in AtlasDataTable

### DIFF
--- a/src/components/ui/AtlasDataTable.vue
+++ b/src/components/ui/AtlasDataTable.vue
@@ -1,12 +1,12 @@
 <!-- src/components/ui/AtlasDataTable.vue -->
 <template>
   <v-data-table
+    v-model:sort-by="sortByModel"
     :headers="headers"
     :items="items"
     :loading="loading"
     :items-per-page="itemsPerPage"
     :page="page"
-    :sort-by="sortBy"
     :height="height"
     :fixed-header="fixedHeader"
     :hide-default-footer="hideDefaultFooter"
@@ -17,7 +17,6 @@
     v-bind="forwardAttrs"
     @update:page="(v: number) => $emit('update:page', v)"
     @update:items-per-page="(v: number) => $emit('update:itemsPerPage', v)"
-    @update:sort-by="(v: SortItem[]) => $emit('update:sortBy', v)"
   >
     <template
       v-for="(_, name) in $slots"
@@ -32,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
+import { computed, ref, useAttrs } from 'vue'
 
 interface SortItem {
   key: string
@@ -64,11 +63,11 @@ interface Props {
   caption?: string
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   loading: false,
   itemsPerPage: 10,
   page: 1,
-  sortBy: () => [],
+  sortBy: undefined,
   height: undefined,
   fixedHeader: false,
   hideDefaultFooter: false,
@@ -77,13 +76,26 @@ withDefaults(defineProps<Props>(), {
   caption: undefined,
 })
 
-defineEmits<{
+const emit = defineEmits<{
   'update:page': [page: number]
   'update:itemsPerPage': [count: number]
   'update:sortBy': [sortBy: SortItem[]]
 }>()
 
 defineOptions({ inheritAttrs: false })
+
+// When a caller doesn't bind `sort-by` (the common case), fall back to
+// internal state so v-data-table still owns and applies its own sort
+// instead of being pinned to a static prop that never changes. Callers that
+// DO bind `sort-by`/`v-model:sort-by` keep full control, unchanged.
+const internalSortBy = ref<SortItem[]>([])
+const sortByModel = computed<SortItem[]>({
+  get: () => props.sortBy ?? internalSortBy.value,
+  set: v => {
+    internalSortBy.value = v
+    emit('update:sortBy', v)
+  },
+})
 
 const attrs = useAttrs()
 const forwardAttrs = computed(() => {

--- a/tests/component/ui/AtlasDataTable.spec.ts
+++ b/tests/component/ui/AtlasDataTable.spec.ts
@@ -105,4 +105,54 @@ describe('AtlasDataTable', () => {
     const ariaLabel = wrapper.findComponent({ name: 'VDataTable' }).attributes('aria-label')
     expect(ariaLabel === undefined || ariaLabel === '').toBe(true)
   })
+
+  // Regression test for issues #150 / #156: clicking a sortable column
+  // header did nothing when the caller only did a one-way `:sort-by`/no
+  // binding at all (the common case) - `sort-by` was always forced into a
+  // controlled prop, so v-data-table's own sort-state update was fed straight
+  // back into the exact same static prop value on every render and never
+  // took effect. When the caller doesn't bind sort-by, AtlasDataTable must
+  // now own that state itself so sorting works out of the box.
+  it('actually re-sorts displayed rows when the caller does not bind sortBy', async () => {
+    const headers = [
+      { key: 'name', title: 'Name', sortable: true },
+      { key: 'value', title: 'Value', sortable: true },
+    ]
+    const items = [
+      { name: 'beta', value: 2 },
+      { name: 'alpha', value: 1 },
+    ]
+    const wrapper = mount(AtlasDataTable, {
+      global: { plugins: [vuetify] },
+      props: { headers, items },
+    })
+
+    const firstRowName = () => wrapper.findAll('tbody tr')[0]?.findAll('td')[0]?.text()
+    expect(firstRowName()).toBe('beta')
+
+    const nameHeader = wrapper.findAll('th').find(th => th.text().includes('Name'))
+    expect(nameHeader).toBeTruthy()
+    await nameHeader!.trigger('click')
+
+    expect(firstRowName()).toBe('alpha')
+  })
+
+  it('still lets a caller with v-model:sort-by fully control sorting', async () => {
+    const headers = [{ key: 'name', title: 'Name', sortable: true }]
+    const items = [
+      { name: 'beta', value: 2 },
+      { name: 'alpha', value: 1 },
+    ]
+    const wrapper = mount(
+      {
+        components: { AtlasDataTable },
+        template: `<AtlasDataTable :headers="headers" :items="items" v-model:sort-by="sortBy" />`,
+        data: () => ({ headers, items, sortBy: [{ key: 'name', order: 'asc' }] }),
+      },
+      { global: { plugins: [vuetify] } },
+    )
+
+    expect(wrapper.findAll('tbody tr')[0].findAll('td')[0].text()).toBe('alpha')
+    expect((wrapper.vm as unknown as { sortBy: unknown }).sortBy).toEqual([{ key: 'name', order: 'asc' }])
+  })
 })


### PR DESCRIPTION
Fixes #150, #156.

`AtlasDataTable` always forced `sort-by` into a controlled `v-data-table` prop, even when the caller never bound it. Clicking a header computed a new sort order but had nowhere to land, so `v-data-table` kept re-rendering with the same static prop and the rows never actually re-sorted.

Callers that don't bind `sort-by` now get working, self-owned sort state; callers using `v-model:sort-by` keep full control as before.

This affects every `AtlasDataTable` consumer that doesn't bind `sort-by`, including the concept set compare table (#156) and the data sources domain report table (#150).

Covered by new cases in `tests/component/ui/AtlasDataTable.spec.ts`.
