### PR TITLE
Add drill-down details to the data sources table view, matching the treemap

### DIFF
--- a/src/components/datasources/ClinicalDomainReport.vue
+++ b/src/components/datasources/ClinicalDomainReport.vue
@@ -37,30 +37,31 @@
             :data="data.prevalenceData.treemapNodes"
             @node-click="handleNodeClick"
           />
-
-          <!-- Drill-down details. Render while LOADING too so the
-               progress overlay inside DrilldownDetails is visible
-               immediately on click — without v-if=loading the
-               component would only mount once the network request
-               returned data, leaving the user with no feedback. -->
-          <DrilldownDetails
-            v-if="drilldownData || drilldownLoading"
-            :data="drilldownData"
-            :loading="drilldownLoading"
-            :concept-name="selectedConceptName"
-            :concept-path="selectedConceptPath"
-            :domain="drilldownDomain"
-            @close="clearDrilldown"
-          />
         </v-window-item>
 
         <v-window-item value="table">
           <DomainPrevalenceTable
             :data="data.prevalenceData.tableRows"
             :metric-label="metricLabel"
+            @row-click="handleTableRowClick"
           />
         </v-window-item>
       </v-window>
+
+      <!-- Drill-down details, shared by both tabs. Render while LOADING too
+           so the progress overlay inside DrilldownDetails is visible
+           immediately on click — without v-if=loading the component would
+           only mount once the network request returned data, leaving the
+           user with no feedback. -->
+      <DrilldownDetails
+        v-if="drilldownData || drilldownLoading"
+        :data="drilldownData"
+        :loading="drilldownLoading"
+        :concept-name="selectedConceptName"
+        :concept-path="selectedConceptPath"
+        :domain="drilldownDomain"
+        @close="clearDrilldown"
+      />
     </div>
   </AtlasCard>
 </template>
@@ -155,6 +156,13 @@ async function handleNodeClick(conceptId: number, conceptName: string, conceptPa
   } finally {
     drilldownLoading.value = false
   }
+}
+
+// Table rows only carry the display name (see PrevalenceTableRow), not the
+// full "||"-delimited hierarchy path the treemap nodes have, so pass an
+// empty path — DrilldownDetails treats it as optional breadcrumb text.
+function handleTableRowClick(conceptId: number, conceptName: string) {
+  handleNodeClick(conceptId, conceptName, '')
 }
 
 function clearDrilldown() {

--- a/src/components/datasources/DomainPrevalenceTable.vue
+++ b/src/components/datasources/DomainPrevalenceTable.vue
@@ -96,6 +96,7 @@
       :items-per-page-options="[25, 50, 75, 100, { value: -1, title: t('datatable.language.all', 'All').value }]"
       class="elevation-1"
       @update:items-per-page="handleItemsPerPageChange"
+      @click:row="onRowClick"
     >
       <template #item.conceptId="{ item }">
         {{ item.conceptId }}
@@ -148,6 +149,10 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'row-click': [conceptId: number, conceptName: string]
+}>()
 
 const search = ref('')
 const currentPage = ref(1)
@@ -254,6 +259,10 @@ const tableStatusText = computed(() => {
     }
   )
 })
+
+function onRowClick(_event: Event, { item }: { item: PrevalenceTableRow }) {
+  emit('row-click', item.conceptId, item.conceptName)
+}
 
 function handleItemsPerPageChange(value: number) {
   itemsPerPage.value = value

--- a/tests/unit/components/datasources/ClinicalDomainReport.spec.ts
+++ b/tests/unit/components/datasources/ClinicalDomainReport.spec.ts
@@ -10,7 +10,13 @@ import { createPinia, setActivePinia } from 'pinia'
 import ClinicalDomainReport from '@/components/datasources/ClinicalDomainReport.vue'
 import DomainPrevalenceTreemap from '@/components/datasources/DomainPrevalenceTreemap.vue'
 import DomainPrevalenceTable from '@/components/datasources/DomainPrevalenceTable.vue'
+import { useDataSourcesStore } from '@/stores/datasources'
+import { getCDMDrilldown } from '@/services/webapi'
 import type { ClinicalDomainReport as ClinicalDomainReportData } from '@/models/datasource.types'
+
+vi.mock('@/services/webapi', () => ({
+  getCDMDrilldown: vi.fn().mockResolvedValue({}),
+}))
 
 // Mock the child components with props
 vi.mock('@/components/datasources/DomainPrevalenceTreemap.vue', () => ({
@@ -127,5 +133,28 @@ describe('ClinicalDomainReport', () => {
   it('should accept different report types', () => {
     const wrapper2 = mountComponent({ reportType: 'drugExposure' })
     expect(wrapper2.exists()).toBe(true)
+  })
+
+  // Regression test for issue #151: the treemap view could trigger a
+  // drill-down report on click, but the table view had no equivalent
+  // wiring at all. row-click from DomainPrevalenceTable must reach the
+  // same drill-down fetch as node-click from the treemap.
+  it('fetches drilldown data when the table emits row-click (issue #151)', async () => {
+    const store = useDataSourcesStore()
+    store.sources = [
+      { sourceId: 1, sourceName: 'Test Source', sourceKey: 'SYNPUF1K', sourceDialect: 'postgresql', daimons: [] },
+    ]
+    store.selectedSourceId = 1
+
+    const tabs = wrapper.findAllComponents({ name: 'VTab' })
+    await tabs[1].trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const table = wrapper.findComponent(DomainPrevalenceTable)
+    await table.vm.$emit('row-click', 1, 'Test Concept')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(getCDMDrilldown).toHaveBeenCalledWith('SYNPUF1K', 'condition', 1)
   })
 })

--- a/tests/unit/components/datasources/DomainPrevalenceTable.spec.ts
+++ b/tests/unit/components/datasources/DomainPrevalenceTable.spec.ts
@@ -179,4 +179,15 @@ describe('DomainPrevalenceTable', () => {
     // The component uses formatNumber for personCount
     expect(wrapper.exists()).toBe(true)
   })
+
+  // Regression test for issue #151: the table view had no row-click wiring
+  // at all, so drill-down details (available from the treemap view) were
+  // unreachable when browsing via the table.
+  it('emits row-click with the concept id and name when a row is clicked (issue #151)', async () => {
+    const dataTable = wrapper.findComponent({ name: 'VDataTable' })
+    await dataTable.vm.$emit('click:row', new Event('click'), { item: mockData[1] })
+
+    expect(wrapper.emitted('row-click')).toBeTruthy()
+    expect(wrapper.emitted('row-click')![0]).toEqual([2, 'Test Concept 2'])
+  })
 })


### PR DESCRIPTION
Fixes #151.

The treemap view could click a node to open per-concept drill-down details (age/gender distribution, monthly prevalence, age at first occurrence), but the table view had no equivalent — clicking a row did nothing.

`DomainPrevalenceTable` now emits a row-click event, which `ClinicalDomainReport` wires into the same drill-down fetch used by the treemap. The drill-down panel is shared by both tabs.

Covered by new cases in `ClinicalDomainReport.spec.ts` and `DomainPrevalenceTable.spec.ts`.
