### PR TITLE
Fix data sources clinical domain table showing raw ||-delimited hierarchy path

### DIFF
--- a/src/utils/datasource-formatters.ts
+++ b/src/utils/datasource-formatters.ts
@@ -144,7 +144,7 @@ export function transformClinicalDomainReport(
 
   const tableRows: PrevalenceTableRow[] = processedRaw.map(item => ({
     conceptId: item.conceptId,
-    conceptName: item.conceptPath,
+    conceptName: extractConceptDisplayName(item.conceptPath),
     personCount: item.numPersons,
     prevalence: item.percentPersons * 100, // percentPersons arrives as a 0..1 fraction
     metric: isEra ? item.lengthOfEra || 0 : item.recordsPerPerson || 0,

--- a/tests/unit/utils/datasource-formatters.spec.ts
+++ b/tests/unit/utils/datasource-formatters.spec.ts
@@ -103,6 +103,30 @@ describe('Data Source Formatters', () => {
       expect(result.tableRows[0].metric).toBe(30)
     })
 
+    it('should drop the leading "NA||NA||..." hierarchy prefix in tableRows, matching the treemap (issue #152)', () => {
+      const conceptPath =
+        'NA||NA||NA||Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO) 162673000: General examination of patient'
+      const raw = [{ conceptId: 1, conceptPath, numPersons: 100, percentPersons: 10, recordsPerPerson: 2 }]
+
+      const result = transformClinicalDomainReport(raw, 'conditionOccurrence')
+
+      const expected = 'Systematic Nomenclature of Medicine - Clinical Terms (IHTSDO) 162673000: General examination of patient'
+      expect(result.tableRows[0].conceptName).toBe(expected)
+      // Previously only the treemap parsed this; tableRows showed the raw,
+      // unparsed conceptPath (with all "||" separators visible). Keep both in sync.
+      expect(result.treemapNodes[0].name).toBe(expected)
+    })
+
+    it('falls back to the whole string when conceptPath has no "||" separator', () => {
+      const raw = [
+        { conceptId: 1, conceptPath: 'Plain Concept Name', numPersons: 100, percentPersons: 10, recordsPerPerson: 2 },
+      ]
+
+      const result = transformClinicalDomainReport(raw, 'conditionOccurrence')
+
+      expect(result.tableRows[0].conceptName).toBe('Plain Concept Name')
+    })
+
     it('should aggregate large datasets', () => {
       // Create 15000 items
       const raw = Array(15000).fill(null).map((_, i) => ({


### PR DESCRIPTION
Fixes #152.

`transformClinicalDomainReport` used the raw `conceptPath` as the table's `conceptName`, showing the full ancestor hierarchy joined by `||` instead of just the leaf label. The treemap view already parsed this correctly via `extractConceptDisplayName`; the table now uses the same helper so both views are consistent.

Covered by new cases in `tests/unit/utils/datasource-formatters.spec.ts`.
