### PR TITLE
Fix data sources drilldown prevalence-by-month chart rendering out of order

### DIFF
--- a/src/services/report-mapper.ts
+++ b/src/services/report-mapper.ts
@@ -838,18 +838,24 @@ export function mapTrellisData(
 export function mapTimeSeriesData(
   raw: import('@/models/report.types').WebAPIPrevalenceByMonth[]
 ): import('@/models/report.types').TimeSeriesData[] {
-  return raw.map(item => {
-    // Convert YYYYMM to MM/YYYY format
-    const monthStr = item.xCalendarMonth.toString()
-    const month = monthStr.slice(-2)
-    const year = monthStr.slice(0, 4)
-    const dateString = `${month}/${year}`
+  // WebAPI doesn't guarantee prevalenceByMonth is ordered chronologically, so
+  // sort by the numeric YYYYMM key before mapping - otherwise the resulting
+  // series can render out of order on the chart.
+  return raw
+    .slice()
+    .sort((a, b) => (a.xCalendarMonth ?? 0) - (b.xCalendarMonth ?? 0))
+    .map(item => {
+      // Convert YYYYMM to MM/YYYY format
+      const monthStr = item.xCalendarMonth.toString()
+      const month = monthStr.slice(-2)
+      const year = monthStr.slice(0, 4)
+      const dateString = `${month}/${year}`
 
-    return {
-      date: dateString,
-      value: item.yPrevalence1000Pp,
-    }
-  })
+      return {
+        date: dateString,
+        value: item.yPrevalence1000Pp,
+      }
+    })
 }
 
 export function mapDrilldownReport(

--- a/tests/unit/services/report-mapper.spec.ts
+++ b/tests/unit/services/report-mapper.spec.ts
@@ -1283,6 +1283,39 @@ describe('report-mapper', () => {
     })
   })
 
+  describe('mapTimeSeriesData', () => {
+    // Regression test for issue #153: WebAPI doesn't guarantee prevalenceByMonth
+    // is ordered chronologically, and an out-of-order series renders as a
+    // jagged/wrong-looking line chart.
+    it('sorts entries by xCalendarMonth (YYYYMM) before mapping', () => {
+      const raw = [
+        { xCalendarMonth: 202003, yPrevalence1000Pp: 3 },
+        { xCalendarMonth: 202001, yPrevalence1000Pp: 1 },
+        { xCalendarMonth: 202002, yPrevalence1000Pp: 2 },
+      ]
+
+      const result = mapTimeSeriesData(raw)
+
+      expect(result).toEqual([
+        { date: '01/2020', value: 1 },
+        { date: '02/2020', value: 2 },
+        { date: '03/2020', value: 3 },
+      ])
+    })
+
+    it('does not mutate the input array', () => {
+      const raw = [
+        { xCalendarMonth: 202002, yPrevalence1000Pp: 2 },
+        { xCalendarMonth: 202001, yPrevalence1000Pp: 1 },
+      ]
+      const rawCopy = [...raw]
+
+      mapTimeSeriesData(raw)
+
+      expect(raw).toEqual(rawCopy)
+    })
+  })
+
   describe('mapDrilldownReport', () => {
     const base = { conceptId: 123, conceptName: 'Test', conceptPath: 'Root||Test' }
 


### PR DESCRIPTION
Fixes #153.

`mapTimeSeriesData` mapped WebAPI's `prevalenceByMonth` array in whatever order it arrived in instead of sorting by the numeric `YYYYMM` key, so the drill-down chart could render a jagged/out-of-order line when the API didn't already return the months in order.

Covered by new cases in `tests/unit/services/report-mapper.spec.ts`.
