### PR TITLE
Fix concept set Add button staying disabled after correcting a bad paste/source-code entry

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -239,7 +239,7 @@
               class="cs-editor__paste-btn"
               @click="showSourceCodeDialog = true"
             >
-              {{ t('cs.manager.importSourceCodes', 'Import codes') }}
+              {{ t('cs.manager.importSourceCodesButton', 'Import by source code') }}
             </AtlasButton>
 
             <AtlasButton
@@ -1170,6 +1170,16 @@ function applyConceptsToSet(concepts: Concept[]) {
 // Bulk paste IDs
 // ============================================================================
 
+// Re-resolving is required after any edit, so reset the resolved/unresolved
+// state when the textarea changes. Keeps the action button showing "Resolve"
+// until the user re-validates the (possibly corrected) input.
+watch(pasteInput, () => {
+  if (pasteResolved.value.length || pasteUnresolved.value.length) {
+    pasteResolved.value = []
+    pasteUnresolved.value = []
+  }
+})
+
 async function resolvePastedIds() {
   const ids = parsePastedIds(pasteInput.value)
   if (ids.length === 0) {
@@ -1213,6 +1223,14 @@ function closePasteDialog() {
 // ============================================================================
 // Import by source code
 // ============================================================================
+
+// Same reset as pasteInput above: a corrected code should re-enable resolving.
+watch(sourceCodeInput, () => {
+  if (sourceCodeResolved.value.length || sourceCodeUnresolved.value.length) {
+    sourceCodeResolved.value = []
+    sourceCodeUnresolved.value = []
+  }
+})
 
 async function resolvePastedSourceCodes() {
   const codes = parsePastedSourceCodes(sourceCodeInput.value)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2834,6 +2834,7 @@
       "pasteIdsResolveBtn": "Resolve",
       "pasteIdsAddBtn": "Add",
       "importSourceCodes": "Import codes",
+      "importSourceCodesButton": "Import by source code",
       "importSourceCodesTitle": "Import by source code",
       "importSourceCodesHint": "Separate source codes with commas, semicolons, or newlines. We resolve each code against the vocabulary before adding.",
       "importJson": "Import JSON",

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -583,6 +583,33 @@ describe('ConceptSetEditor', () => {
       expect(vm.pasteResolved).toHaveLength(1)
       expect(vm.pasteUnresolved).toEqual([999999])
     })
+
+    it('resets resolved/unresolved state when the input is edited after a failed resolve (issue #159)', async () => {
+      const webapi = useWebAPIStore()
+      vi.spyOn(webapi, 'getValidVocabularySource').mockReturnValue('MY_VOCAB')
+      vi.mocked(conceptSearchService.getConceptsByIds).mockResolvedValue([])
+
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as unknown as {
+        pasteInput: string
+        resolvePastedIds: () => Promise<void>
+        pasteResolved: Concept[]
+        pasteUnresolved: number[]
+      }
+
+      vm.pasteInput = '999999'
+      await vm.resolvePastedIds()
+      expect(vm.pasteUnresolved).toEqual([999999])
+
+      // Correcting the input previously left pasteUnresolved stale, so the
+      // dialog stayed stuck on a disabled "Add" button instead of reverting
+      // to "Resolve" for the user to re-validate.
+      vm.pasteInput = '201826'
+      await wrapper.vm.$nextTick()
+
+      expect(vm.pasteResolved).toEqual([])
+      expect(vm.pasteUnresolved).toEqual([])
+    })
   })
 
   describe('source code import (#95 Part A)', () => {
@@ -633,6 +660,32 @@ describe('ConceptSetEditor', () => {
 
       expect(vm.sourceCodeResolved).toHaveLength(1)
       // Must NOT be reported as unresolved just because of a case mismatch.
+      expect(vm.sourceCodeUnresolved).toEqual([])
+    })
+
+    it('resets resolved/unresolved state when the input is edited after a failed resolve (issue #159)', async () => {
+      const webapi = useWebAPIStore()
+      vi.spyOn(webapi, 'getValidVocabularySource').mockReturnValue('MY_VOCAB')
+      vi.mocked(conceptSearchService.getConceptsBySourceCodes).mockResolvedValue([])
+
+      const wrapper = mountComponent()
+      const vm = wrapper.vm as unknown as {
+        sourceCodeInput: string
+        resolvePastedSourceCodes: () => Promise<void>
+        sourceCodeResolved: Concept[]
+        sourceCodeUnresolved: string[]
+      }
+
+      vm.sourceCodeInput = 'BADCODE'
+      await vm.resolvePastedSourceCodes()
+      expect(vm.sourceCodeUnresolved).toEqual(['BADCODE'])
+
+      // Correcting the code previously left the dialog stuck showing a
+      // disabled "Add" button because sourceCodeUnresolved never cleared.
+      vm.sourceCodeInput = 'E11.9'
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sourceCodeResolved).toEqual([])
       expect(vm.sourceCodeUnresolved).toEqual([])
     })
   })


### PR DESCRIPTION
Fixes #159.

`resolvePastedIds` / `resolvePastedSourceCodes` left the resolved/unresolved state stuck after a failed lookup, so editing the textarea to correct the mistake never re-enabled the Resolve/Add flow — the Add button stayed disabled with no way to recover short of reopening the dialog.

Also renames the vague "Import codes" trigger button to "Import by source code".

Covered by new cases in `tests/unit/components/concepts/ConceptSetEditor.spec.ts`.
