### PR TITLE
Fix search badge chips showing a pointer cursor with no click action

### DIFF
--- a/src/components/ui/AtlasChip.vue
+++ b/src/components/ui/AtlasChip.vue
@@ -7,7 +7,7 @@
     :prepend-icon="prependIcon"
     density="compact"
     v-bind="forwardAttrs"
-    @click="$emit('click', $event)"
+    v-on="clickListeners"
     @click:close="$emit('close', $event)"
   >
     <slot />
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
+import { computed, useAttrs, getCurrentInstance } from 'vue'
 
 export type AtlasChipTone = 'neutral' | 'primary' | 'info' | 'success' | 'warning' | 'danger'
 export type AtlasChipSize = 'xs' | 'sm' | 'md'
@@ -36,12 +36,23 @@ const props = withDefaults(defineProps<Props>(), {
   prependIcon: undefined,
 })
 
-defineEmits<{
+const emit = defineEmits<{
   click: [event: MouseEvent | KeyboardEvent]
   close: [event: MouseEvent | KeyboardEvent]
 }>()
 
 defineOptions({ inheritAttrs: false })
+
+// Vuetify's v-chip renders itself as clickable (pointer cursor + ripple) whenever a
+// click listener is bound, even a no-op one. Only forward the listener when the
+// consumer actually listens for 'click', so purely informational chips (e.g.
+// vocabulary/domain badges) don't look interactive when they aren't.
+const instance = getCurrentInstance()
+const clickListeners = computed(() =>
+  instance?.vnode.props?.onClick
+    ? { click: (event: MouseEvent | KeyboardEvent) => emit('click', event) }
+    : {},
+)
 
 const TONE_COLOR: Record<AtlasChipTone, string | undefined> = {
   neutral: undefined,

--- a/tests/component/ui/AtlasChip.spec.ts
+++ b/tests/component/ui/AtlasChip.spec.ts
@@ -63,9 +63,22 @@ describe('AtlasChip', () => {
     expect(wrapper.findComponent({ name: 'VChip' }).props('size')).toBe('default')
   })
 
-  it('emits click', async () => {
-    const wrapper = mountWith()
+  it('emits click when a consumer listens for click', async () => {
+    const wrapper = mount(AtlasChip, {
+      global: { plugins: [vuetify] },
+      attrs: { onClick: () => {} },
+      slots: { default: 'tag' },
+    })
     await wrapper.findComponent({ name: 'VChip' }).trigger('click')
     expect(wrapper.emitted('click')).toBeTruthy()
+  })
+
+  it('does not forward a click listener to v-chip when no consumer listens for click', () => {
+    // Regression test for #160: purely informational chips (no @click on AtlasChip)
+    // must not render with a pointer cursor / ripple, since Vuetify treats the mere
+    // presence of a click listener on v-chip as making it "clickable".
+    const wrapper = mountWith()
+    const chip = wrapper.findComponent({ name: 'VChip' })
+    expect(chip.vm.$attrs.onClick).toBeUndefined()
   })
 })


### PR DESCRIPTION
Fixes #160.

`AtlasChip` always bound a click listener onto the underlying `v-chip`, which makes Vuetify treat it as clickable (pointer cursor, ripple) even when no consumer listens for the click event. Purely informational badges such as the concept detail vocabulary/domain chips looked interactive but did nothing when clicked.

The listener is now only forwarded when a consumer actually provides one.

Covered by new cases in `tests/component/ui/AtlasChip.spec.ts`.
