### PR TITLE
Fix search result concept links opening the app front page in a new tab

### DIFF
--- a/src/components/concepts/ConceptTable.vue
+++ b/src/components/concepts/ConceptTable.vue
@@ -73,10 +73,10 @@
         #item.conceptName="{ item }"
       >
         <a
-          href="#"
+          :href="conceptDetailHref(item)"
           :data-testid="`concept-name-link-${item.conceptId}`"
           class="concept-name-link"
-          @click.prevent="openConceptDetail(item)"
+          @click="onConceptNameClick($event, item)"
         >
           {{ item.conceptName }}
         </a>
@@ -316,6 +316,24 @@ function openConceptDetail(concept: Concept) {
     return
   }
   conceptDrawer.open(resolvedSourceKey.value, concept.conceptId)
+}
+
+// Real deep-link href to the concept detail route (matches the
+// `/concept/:sourceKey/:conceptId` route in router/routes.ts) so that
+// right-click "open in new tab" / "copy link" / ctrl-click work as expected
+// instead of landing on `#` (the app's front page). A plain left-click still
+// intercepts navigation and opens the fast in-app detail drawer/panel.
+function conceptDetailHref(concept: Concept): string {
+  if (!resolvedSourceKey.value) return '#'
+  return `#/concept/${encodeURIComponent(resolvedSourceKey.value)}/${concept.conceptId}`
+}
+
+function onConceptNameClick(event: MouseEvent, concept: Concept) {
+  if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return
+  }
+  event.preventDefault()
+  openConceptDetail(concept)
 }
 
 // ============================================================================

--- a/tests/component/concepts/ConceptTable.linkable.spec.ts
+++ b/tests/component/concepts/ConceptTable.linkable.spec.ts
@@ -60,6 +60,50 @@ describe('ConceptTable linkable mode', () => {
     expect(open).toHaveBeenCalledWith('SYNPUF1K', 201826)
   })
 
+  it('renders a real deep-link href so right-click/ctrl-click "open in new tab" targets the concept detail route (#162)', async () => {
+    const vuetify = createVuetify({ components, directives })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/concept/:sourceKey/:conceptId', component: { template: '<div />' } }],
+    })
+
+    const wrapper = mount(ConceptTable, {
+      props: { concepts, linkable: true, sourceKey: 'SYNPUF1K', loading: false, totalItems: 1 },
+      global: { plugins: [vuetify, router] },
+    })
+    await wrapper.vm.$nextTick()
+
+    const link = wrapper.find('a[data-testid="concept-name-link-201826"]')
+    expect(link.exists()).toBe(true)
+    // Previously this was href="#", so opening the link in a new tab (or
+    // right-click > copy link) landed on the app's front page instead of
+    // the concept. It must now resolve to the real concept detail route.
+    expect(link.attributes('href')).toBe('#/concept/SYNPUF1K/201826')
+
+    // A plain left-click still opens the fast in-app drawer instead of a
+    // full navigation.
+    await link.trigger('click')
+    expect(open).toHaveBeenCalledWith('SYNPUF1K', 201826)
+  })
+
+  it('does not intercept ctrl/cmd/middle-clicks, letting the browser open the real href in a new tab', async () => {
+    const vuetify = createVuetify({ components, directives })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/concept/:sourceKey/:conceptId', component: { template: '<div />' } }],
+    })
+
+    const wrapper = mount(ConceptTable, {
+      props: { concepts, linkable: true, sourceKey: 'SYNPUF1K', loading: false, totalItems: 1 },
+      global: { plugins: [vuetify, router] },
+    })
+    await wrapper.vm.$nextTick()
+
+    const link = wrapper.find('a[data-testid="concept-name-link-201826"]')
+    await link.trigger('click', { ctrlKey: true })
+    expect(open).not.toHaveBeenCalled()
+  })
+
   it('renders concept name as plain text when linkable=false', () => {
     const vuetify = createVuetify({ components, directives })
     const router = createRouter({ history: createMemoryHistory(), routes: [] })


### PR DESCRIPTION
Fixes #162.

Concept name links in search results used `href="#"` with a `click.prevent` handler, so browser features that rely on a real href — open in new tab, copy link address, ctrl/cmd-click — landed on `#`, the app's default route, instead of the concept.

The link now resolves to the real `/concept/:sourceKey/:conceptId` route, while a plain left-click still opens the fast in-app detail drawer.

Covered by new cases in `tests/component/concepts/ConceptTable.linkable.spec.ts`.
