### PR TITLE
Add filtering and within-table search to concept set compare (#157)

### DIFF
--- a/src/components/concepts/CompareTab.vue
+++ b/src/components/concepts/CompareTab.vue
@@ -42,7 +42,7 @@
           variant="ghost"
           size="sm"
           icon="mdi-download"
-          :disabled="store.comparison.length === 0 || store.loadingComparison"
+          :disabled="visibleRows.length === 0 || store.loadingComparison"
           data-testid="compare-export"
           @click="onExport"
         >
@@ -137,9 +137,30 @@
         </v-card-text>
       </v-card>
 
+      <div class="compare-tab__filters mb-4">
+        <AtlasTextField
+          v-model="searchText"
+          :placeholder="t('common.searchTable', 'Search table…').value"
+          prepend-inner-icon="mdi-magnify"
+          clearable
+          hide-details
+          variant="outlined"
+          data-testid="compare-search"
+          class="compare-tab__search"
+        />
+        <ConceptFacetFilters
+          :facets="compareFacets"
+          :facet-options="facetOptions"
+          :selected="selectedFacets"
+          :active-filter-count="activeFilterCount"
+          @update:facet="({ key, values }) => setFacet(key, values)"
+          @clear="clearFilters()"
+        />
+      </div>
+
       <AtlasDataTable
         :headers="headers"
-        :items="rows"
+        :items="visibleRows"
         :items-per-page="25"
         class="compare-tab__table"
       >
@@ -164,9 +185,15 @@
 </template>
 
 <script setup lang="ts">
-import { AtlasAlert, AtlasButton, AtlasChip, AtlasDataTable, AtlasProgressCircular } from '@/components/ui'
+import { AtlasAlert, AtlasButton, AtlasChip, AtlasDataTable, AtlasProgressCircular, AtlasTextField } from '@/components/ui'
 import { ref, computed, inject, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
+import {
+  CONCEPT_FACETS,
+  useConceptFacets,
+  type FacetDefinition,
+} from '@/composables/useConceptFacets'
+import ConceptFacetFilters from './ConceptFacetFilters.vue'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import type { ComparisonMode } from '@/stores/concept-sets'
 import { useWebAPIStore } from '@/stores/webapi'
@@ -231,6 +258,50 @@ const rows = computed<Row[]>(() =>
           ? leftLabel.value
           : rightLabel.value,
   }))
+)
+
+const searchText = ref('')
+
+const SEARCHABLE_FIELDS = [
+  'conceptId',
+  'conceptName',
+  'conceptCode',
+  'domainId',
+  'vocabularyId',
+  'conceptClassId',
+  'match',
+] as const satisfies readonly (keyof Row)[]
+
+const searchedRows = computed<Row[]>(() => {
+  const term = searchText.value?.trim().toLowerCase()
+  if (!term) return rows.value
+  return rows.value.filter(r =>
+    SEARCHABLE_FIELDS.some(f => String(r[f] ?? '').toLowerCase().includes(term))
+  )
+})
+
+const compareFacets = computed<FacetDefinition<Row>[]>(() => [
+  { key: 'match', label: 'Match', display: r => r.match },
+  ...CONCEPT_FACETS,
+])
+
+const {
+  facetOptions,
+  selected: selectedFacets,
+  filteredConcepts: visibleRows,
+  activeFilterCount,
+  setFacet,
+  clearFilters,
+} = useConceptFacets<Row>(searchedRows, compareFacets)
+
+// A fresh comparison changes the value space entirely, so stale text and
+// facet selections would silently hide rows the user just asked for.
+watch(
+  () => store.comparison,
+  () => {
+    searchText.value = ''
+    clearFilters()
+  }
 )
 
 const isSourceMode = computed(() => store.comparisonMode === 'source')
@@ -334,8 +405,8 @@ function onClearOther() {
 }
 
 function onExport() {
-  if (store.comparison.length === 0) return
-  const csv = arrayToCsv(rows.value, [
+  if (visibleRows.value.length === 0) return
+  const csv = arrayToCsv(visibleRows.value, [
     { key: 'match', label: 'Match' },
     { key: 'conceptId', label: 'Concept Id' },
     { key: 'conceptCode', label: 'Concept Code' },
@@ -378,5 +449,17 @@ function onExport() {
 .compare-tab__venn {
   max-width: 480px;
   width: 100%;
+}
+
+.compare-tab__filters {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.compare-tab__search {
+  max-width: 320px;
+  flex: 1 1 220px;
 }
 </style>

--- a/src/components/concepts/ConceptFacetFilters.vue
+++ b/src/components/concepts/ConceptFacetFilters.vue
@@ -48,7 +48,7 @@
             <AtlasAutocomplete
               v-for="facet in facets"
               :key="facet.key"
-              :model-value="selected[facet.key]"
+              :model-value="selectionFor(facet.key)"
               :items="itemsFor(facet.key)"
               item-title="label"
               item-value="value"
@@ -75,7 +75,7 @@
         :key="`chips-${facet.key}`"
       >
         <AtlasChip
-          v-for="value in selected[facet.key]"
+          v-for="value in selectionFor(facet.key)"
           :key="`${facet.key}-${value}`"
           size="sm"
           closable
@@ -99,13 +99,19 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useI18n } from '@/composables/useI18n'
-import { CONCEPT_FACETS, type FacetKey, type FacetOption } from '@/composables/useConceptFacets'
+import {
+  CONCEPT_FACETS,
+  type FacetDefinition,
+  type FacetKey,
+  type FacetOption,
+} from '@/composables/useConceptFacets'
 import { AtlasAutocomplete, AtlasButton, AtlasCard, AtlasChip, AtlasMenu, AtlasSpacer } from '@/components/ui'
 
 interface Props {
   facetOptions: Record<FacetKey, FacetOption[]>
   selected: Record<FacetKey, string[]>
   activeFilterCount: number
+  facets?: Pick<FacetDefinition, 'key' | 'label'>[]
 }
 
 interface Emits {
@@ -113,36 +119,43 @@ interface Emits {
   (e: 'clear'): void
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  facets: () => CONCEPT_FACETS,
+})
 const emit = defineEmits<Emits>()
 const { t } = useI18n()
 
-const facets = CONCEPT_FACETS
 const filtersLabel = t('common.filters', 'Filters')
 const clearAllLabel = t('search.clearAllSelections', 'Clear all')
 const menuOpen = ref(false)
 
 // Translate facet labels via the existing column i18n keys.
-const labelKeys: Record<FacetKey, [string, string]> = {
+const labelKeys: Record<string, [string, string]> = {
   vocabularyId: ['columns.vocabulary', 'Vocabulary'],
   domainId: ['columns.domain', 'Domain'],
   standardConcept: ['columns.standard', 'Standard'],
   conceptClassId: ['columns.class', 'Class'],
   invalidReason: ['columns.validity', 'Validity'],
+  match: ['common.match', 'Match'],
 }
 
 function facetLabel(key: FacetKey): string {
-  const [k, fallback] = labelKeys[key]
-  return t(k, fallback).value
+  const entry = labelKeys[key]
+  if (entry) return t(entry[0], entry[1]).value
+  return props.facets.find(f => f.key === key)?.label ?? key
+}
+
+function selectionFor(key: FacetKey): string[] {
+  return props.selected[key] ?? []
 }
 
 // Facet counts are cross-facet, so a still-selected value can drop out of
 // facetOptions[key] (count 0). Re-add such values so their menu chips keep
 // a resolvable title.
 function itemsFor(key: FacetKey) {
-  const options = props.facetOptions[key]
+  const options = props.facetOptions[key] ?? []
   const present = new Set(options.map(o => o.value))
-  const missing = props.selected[key]
+  const missing = selectionFor(key)
     .filter(v => !present.has(v))
     .map(v => ({ value: v, label: v, count: 0 }))
   return [...options, ...missing]
@@ -153,7 +166,7 @@ function onUpdate(key: FacetKey, values: string[]) {
 }
 
 function removeValue(key: FacetKey, value: string) {
-  emit('update:facet', { key, values: props.selected[key].filter(v => v !== value) })
+  emit('update:facet', { key, values: selectionFor(key).filter(v => v !== value) })
 }
 </script>
 

--- a/src/composables/useConceptFacets.ts
+++ b/src/composables/useConceptFacets.ts
@@ -1,27 +1,23 @@
 /**
  * useConceptFacets Composable
  * Derives per-column facets (distinct values + counts) from a list of
- * concepts and filters that list. AND across facets, OR within a facet.
+ * items and filters that list. AND across facets, OR within a facet.
  * Counts for each facet reflect the selections of all OTHER facets
- * (faceted-search behavior). Reusable across any concept table.
+ * (faceted-search behavior). Defaults to the standard concept columns but
+ * accepts custom definitions for any row shape.
  */
-import { ref, computed } from 'vue'
-import type { Ref } from 'vue'
+import { ref, computed, toValue } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { Concept } from '@/models/concept-set.types'
 
-export type FacetKey =
-  | 'vocabularyId'
-  | 'domainId'
-  | 'standardConcept'
-  | 'conceptClassId'
-  | 'invalidReason'
+export type FacetKey = string
 
-export interface FacetDefinition {
+export interface FacetDefinition<T = Concept> {
   key: FacetKey
   /** English default label; UI translates via i18n. */
   label: string
-  /** Map a concept to its display value for this facet. */
-  display: (concept: Concept) => string
+  /** Map an item to its display value for this facet. */
+  display: (item: T) => string
 }
 
 export interface FacetOption {
@@ -30,7 +26,7 @@ export interface FacetOption {
   count: number
 }
 
-export const CONCEPT_FACETS: FacetDefinition[] = [
+export const CONCEPT_FACETS: FacetDefinition<Concept>[] = [
   { key: 'vocabularyId', label: 'Vocabulary', display: c => c.vocabularyId || '' },
   { key: 'domainId', label: 'Domain', display: c => c.domainId || '' },
   {
@@ -47,26 +43,25 @@ export const CONCEPT_FACETS: FacetDefinition[] = [
   { key: 'invalidReason', label: 'Validity', display: c => (c.invalidReason ? 'Invalid' : 'Valid') },
 ]
 
-function emptySelection(): Record<FacetKey, string[]> {
-  return {
-    vocabularyId: [],
-    domainId: [],
-    standardConcept: [],
-    conceptClassId: [],
-    invalidReason: [],
+export function useConceptFacets<T = Concept>(
+  concepts: Ref<T[]>,
+  definitions: MaybeRefOrGetter<FacetDefinition<T>[]> = CONCEPT_FACETS as FacetDefinition<T>[]
+) {
+  const selected = ref<Record<FacetKey, string[]>>({})
+
+  const facets = computed(() => toValue(definitions))
+
+  function selectionFor(key: FacetKey): string[] {
+    return selected.value[key] ?? []
   }
-}
 
-export function useConceptFacets(concepts: Ref<Concept[]>) {
-  const selected = ref<Record<FacetKey, string[]>>(emptySelection())
-
-  /** Does a concept pass every facet's selection except the excluded one? */
-  function matchesExcept(concept: Concept, exceptKey: FacetKey | null): boolean {
-    for (const facet of CONCEPT_FACETS) {
+  /** Does an item pass every facet's selection except the excluded one? */
+  function matchesExcept(item: T, exceptKey: FacetKey | null): boolean {
+    for (const facet of facets.value) {
       if (facet.key === exceptKey) continue
-      const chosen = selected.value[facet.key]
+      const chosen = selectionFor(facet.key)
       if (chosen.length === 0) continue
-      if (!chosen.includes(facet.display(concept))) return false
+      if (!chosen.includes(facet.display(item))) return false
     }
     return true
   }
@@ -74,8 +69,8 @@ export function useConceptFacets(concepts: Ref<Concept[]>) {
   const filteredConcepts = computed(() => concepts.value.filter(c => matchesExcept(c, null)))
 
   const facetOptions = computed<Record<FacetKey, FacetOption[]>>(() => {
-    const result = {} as Record<FacetKey, FacetOption[]>
-    for (const facet of CONCEPT_FACETS) {
+    const result: Record<FacetKey, FacetOption[]> = {}
+    for (const facet of facets.value) {
       const counts = new Map<string, number>()
       for (const c of concepts.value) {
         if (!matchesExcept(c, facet.key)) continue
@@ -90,7 +85,7 @@ export function useConceptFacets(concepts: Ref<Concept[]>) {
   })
 
   const activeFilterCount = computed(() =>
-    CONCEPT_FACETS.reduce((n, f) => n + (selected.value[f.key].length > 0 ? 1 : 0), 0)
+    facets.value.reduce((n, f) => n + (selectionFor(f.key).length > 0 ? 1 : 0), 0)
   )
 
   function setFacet(key: FacetKey, values: string[]) {
@@ -98,7 +93,7 @@ export function useConceptFacets(concepts: Ref<Concept[]>) {
   }
 
   function clearFilters() {
-    selected.value = emptySelection()
+    selected.value = {}
   }
 
   return { selected, facetOptions, filteredConcepts, activeFilterCount, setFacet, clearFilters }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,7 @@
     "retry": "Retry",
     "save": "Save",
     "search": "Search",
+    "searchTable": "Search table…",
     "select": "Select",
     "selectAll": "Select All",
     "set": "Set",

--- a/tests/unit/components/concepts/CompareTab.filters.spec.ts
+++ b/tests/unit/components/concepts/CompareTab.filters.spec.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import { createPinia, setActivePinia } from 'pinia'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import CompareTab from '@/components/concepts/CompareTab.vue'
+import ConceptFacetFilters from '@/components/concepts/ConceptFacetFilters.vue'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import type { ComparisonResultItem } from '@/models/concept-set.types'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+const arrayToCsvMock = vi.fn(() => 'csv')
+const downloadCsvMock = vi.fn()
+vi.mock('@/utils/csv', () => ({
+  arrayToCsv: (rows: unknown[], cols: unknown[]) => arrayToCsvMock(rows, cols),
+  downloadCsv: (name: string, csv: string) => downloadCsvMock(name, csv),
+}))
+
+vi.mock('@/services/concept-set.service', () => ({
+  getConceptSetById: vi.fn(),
+}))
+
+vi.mock('@/stores/webapi', () => ({
+  useWebAPIStore: vi.fn(() => ({
+    getValidVocabularySource: () => 'SRC',
+    sources: [] as unknown[],
+    isLoadingSources: false,
+    fetchSources: vi.fn(),
+  })),
+}))
+
+const vuetify = createVuetify({ components, directives })
+
+function row(p: Partial<ComparisonResultItem>): ComparisonResultItem {
+  return {
+    conceptId: 1,
+    conceptIn1Only: 0,
+    conceptIn2Only: 0,
+    conceptIn1And2: 1,
+    conceptName: 'Concept',
+    conceptCode: 'code',
+    conceptClassId: 'Clinical Finding',
+    domainId: 'Condition',
+    vocabularyId: 'SNOMED',
+    standardConcept: 'S',
+    invalidReason: null,
+    validStartDate: null,
+    validEndDate: null,
+    nameMismatch: false,
+    ...p,
+  }
+}
+
+const RESULTS: ComparisonResultItem[] = [
+  row({ conceptId: 1, conceptName: 'Diabetes mellitus', vocabularyId: 'SNOMED', domainId: 'Condition', conceptIn1And2: 1 }),
+  row({ conceptId: 2, conceptName: 'Metformin', vocabularyId: 'RxNorm', domainId: 'Drug', conceptIn1And2: 0, conceptIn1Only: 1 }),
+  row({ conceptId: 3, conceptName: 'Insulin glargine', vocabularyId: 'RxNorm', domainId: 'Drug', conceptIn1And2: 0, conceptIn2Only: 1 }),
+]
+
+function mountComponent() {
+  return mount(CompareTab, {
+    props: { active: false },
+    global: {
+      plugins: [vuetify],
+      provide: { sourceKey: { value: 'SRC' } },
+      stubs: { ComparisonVennDiagram: true, ConceptSetChooserDialog: true },
+    },
+  })
+}
+
+function prime() {
+  const store = useConceptSetsStore()
+  store.currentSet = { id: 1, name: 'CS1', items: [] }
+  store.comparisonOtherSet = { id: 2, name: 'CS2', items: [] }
+  store.comparison = RESULTS
+  return store
+}
+
+function tableRows(wrapper: VueWrapper) {
+  return wrapper.findComponent({ name: 'AtlasDataTable' }).props('items') as { conceptId: number }[]
+}
+
+describe('CompareTab — result filtering (#157)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    arrayToCsvMock.mockClear()
+    downloadCsvMock.mockClear()
+  })
+
+  it('hides the filter controls until a comparison has results', async () => {
+    const wrapper = mountComponent()
+    expect(wrapper.findComponent(ConceptFacetFilters).exists()).toBe(false)
+    expect(wrapper.find('[data-testid="compare-search"]').exists()).toBe(false)
+  })
+
+  it('shows the facet bar and the within-table search once results exist', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findComponent(ConceptFacetFilters).exists()).toBe(true)
+    expect(wrapper.find('[data-testid="compare-search"]').exists()).toBe(true)
+    expect(tableRows(wrapper)).toHaveLength(3)
+  })
+
+  it('offers a Match facet built from the two concept set names', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    const options = wrapper.findComponent(ConceptFacetFilters).props('facetOptions') as
+      Record<string, { value: string }[]>
+    expect(options.match?.map(o => o.value).sort()).toEqual(['Both', 'CS1', 'CS2'])
+  })
+
+  it('filters rows by the Match facet', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptFacetFilters).vm.$emit('update:facet', { key: 'match', values: ['CS1'] })
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper).map(r => r.conceptId)).toEqual([2])
+  })
+
+  it('filters rows by a concept facet such as vocabulary', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptFacetFilters).vm.$emit('update:facet', {
+      key: 'vocabularyId',
+      values: ['RxNorm'],
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper).map(r => r.conceptId)).toEqual([2, 3])
+  })
+
+  it('narrows rows with the within-table search, case-insensitively', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="compare-search"] input').setValue('metformin')
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper).map(r => r.conceptId)).toEqual([2])
+  })
+
+  it('searches across code, domain and vocabulary as well as name', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="compare-search"] input').setValue('rxnorm')
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper).map(r => r.conceptId)).toEqual([2, 3])
+  })
+
+  it('combines the search with facet selections', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="compare-search"] input').setValue('in')
+    wrapper.findComponent(ConceptFacetFilters).vm.$emit('update:facet', { key: 'match', values: ['CS2'] })
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper).map(r => r.conceptId)).toEqual([3])
+  })
+
+  it('scopes facet counts to the current search text', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="compare-search"] input').setValue('metformin')
+    await wrapper.vm.$nextTick()
+
+    const options = wrapper.findComponent(ConceptFacetFilters).props('facetOptions') as
+      Record<string, { value: string }[]>
+    expect(options.vocabularyId?.map(o => o.value)).toEqual(['RxNorm'])
+  })
+
+  it('clears every facet when the filter bar emits clear', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    const filters = wrapper.findComponent(ConceptFacetFilters)
+    filters.vm.$emit('update:facet', { key: 'match', values: ['CS1'] })
+    await wrapper.vm.$nextTick()
+    expect(tableRows(wrapper)).toHaveLength(1)
+
+    filters.vm.$emit('clear')
+    await wrapper.vm.$nextTick()
+    expect(tableRows(wrapper)).toHaveLength(3)
+  })
+
+  it('exports only the rows left after filtering', async () => {
+    const wrapper = mountComponent()
+    prime()
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptFacetFilters).vm.$emit('update:facet', { key: 'match', values: ['CS1'] })
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="compare-export"]').trigger('click')
+
+    const exported = arrayToCsvMock.mock.calls[0]?.[0] as { conceptId: number }[]
+    expect(exported.map(r => r.conceptId)).toEqual([2])
+  })
+
+  it('resets the search box when a fresh comparison is run', async () => {
+    const wrapper = mountComponent()
+    const store = prime()
+    await wrapper.vm.$nextTick()
+
+    await wrapper.find('[data-testid="compare-search"] input').setValue('metformin')
+    await wrapper.vm.$nextTick()
+    expect(tableRows(wrapper)).toHaveLength(1)
+
+    store.comparison = [...RESULTS]
+    await wrapper.vm.$nextTick()
+
+    expect(tableRows(wrapper)).toHaveLength(3)
+  })
+})

--- a/tests/unit/composables/useConceptFacets.custom.spec.ts
+++ b/tests/unit/composables/useConceptFacets.custom.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useConceptFacets, type FacetDefinition } from '@/composables/useConceptFacets'
+
+interface Row {
+  id: number
+  match: string
+  vocabularyId: string
+}
+
+const rows: Row[] = [
+  { id: 1, match: 'Both', vocabularyId: 'SNOMED' },
+  { id: 2, match: 'CS1', vocabularyId: 'SNOMED' },
+  { id: 3, match: 'CS2', vocabularyId: 'RxNorm' },
+]
+
+const DEFS: FacetDefinition<Row>[] = [
+  { key: 'match', label: 'Match', display: r => r.match },
+  { key: 'vocabularyId', label: 'Vocabulary', display: r => r.vocabularyId },
+]
+
+describe('useConceptFacets with custom definitions', () => {
+  it('facets an arbitrary item type using the supplied definitions', () => {
+    const { filteredConcepts, facetOptions } = useConceptFacets(ref(rows), DEFS)
+
+    expect(filteredConcepts.value).toHaveLength(3)
+    expect(facetOptions.value.match?.map(o => o.value)).toEqual(['Both', 'CS1', 'CS2'])
+    expect(facetOptions.value.vocabularyId?.map(o => o.value)).toEqual(['RxNorm', 'SNOMED'])
+  })
+
+  it('filters on a custom facet key', () => {
+    const { setFacet, filteredConcepts, activeFilterCount } = useConceptFacets(ref(rows), DEFS)
+
+    setFacet('match', ['Both'])
+    expect(filteredConcepts.value.map(r => r.id)).toEqual([1])
+    expect(activeFilterCount.value).toBe(1)
+  })
+
+  it('only exposes the supplied facet keys', () => {
+    const { facetOptions } = useConceptFacets(ref(rows), DEFS)
+    expect(Object.keys(facetOptions.value).sort()).toEqual(['match', 'vocabularyId'])
+  })
+
+  it('re-derives facets when a reactive definition list changes', () => {
+    const defs = ref<FacetDefinition<Row>[]>(DEFS)
+    const { facetOptions } = useConceptFacets(ref(rows), defs)
+
+    expect(facetOptions.value.match).toBeDefined()
+
+    defs.value = [{ key: 'vocabularyId', label: 'Vocabulary', display: r => r.vocabularyId }]
+    expect(facetOptions.value.match).toBeUndefined()
+    expect(facetOptions.value.vocabularyId?.map(o => o.value)).toEqual(['RxNorm', 'SNOMED'])
+  })
+
+  it('keeps cross-facet counts scoped to the supplied definitions', () => {
+    const { setFacet, facetOptions } = useConceptFacets(ref(rows), DEFS)
+
+    setFacet('vocabularyId', ['SNOMED'])
+    // match counts respect the vocabulary selection...
+    expect(facetOptions.value.match?.map(o => o.value)).toEqual(['Both', 'CS1'])
+    // ...while vocabulary options ignore their own selection
+    expect(facetOptions.value.vocabularyId?.map(o => o.value)).toEqual(['RxNorm', 'SNOMED'])
+  })
+})


### PR DESCRIPTION
Fixes #157.

The compare table had no way to narrow its results, so comparing two large concept sets meant reading the whole thing top to bottom. This adds the three controls the issue asks for:

- **Concept facets** — the existing filter bar (vocabulary, domain, standard, class, validity), with the same cross-facet counts as concept search.
- **Match filter** — a `Match` facet built from the two concept set names (`Both` / `CS1` / `CS2`).
- **Within-table search** — case-insensitive, across concept id, name, code, domain, vocabulary, class and the match label.

The search feeds the facets, so facet counts reflect the current search text. Both reset when a fresh comparison is run, since stale filters would otherwise silently hide rows the user just asked for.

### Implementation

`useConceptFacets` was concept-specific: a hard-coded five-key union over a fixed `CONCEPT_FACETS` list. It is now generic over the row type and takes its definitions as a `MaybeRefOrGetter`, so the Match facet re-derives when the set names change. `ConceptFacetFilters` gained an optional `facets` prop defaulting to `CONCEPT_FACETS`, so concept search is untouched.

### Behaviour changes worth a look

- **Export writes the filtered rows**, not the whole comparison, and the button disables when filtering leaves nothing. Exporting rows you cannot see seemed the more surprising option, but this does change an existing feature.
- **`FacetKey` widened from a five-value union to `string`** — the cost of making the composable reusable. The concept facet list itself stays strongly typed as `FacetDefinition<Concept>[]`.
- **The Venn diagram still reports the full comparison.** It is the overview of the two sets rather than a view of the filtered rows, and redrawing it on every keystroke would be jarring. Easy to change if the opposite is preferred.

### Tests

- `tests/unit/components/concepts/CompareTab.filters.spec.ts` — 12 cases: controls hidden until results exist, Match facet values, filtering by match and by concept facet, search matching name and other columns, search combined with facets, facet counts scoped to the search, clear, export respecting filters, reset on re-compare.
- `tests/unit/composables/useConceptFacets.custom.spec.ts` — 5 cases for custom and reactive facet definitions.

Full unit suite green (501 files / 8729 tests), type-check and lint clean.
