### PR TITLE
Fix recommendations banner sticking after a source without PHOEBE tables

### DIFF
--- a/src/components/concepts/RecommendTab.vue
+++ b/src/components/concepts/RecommendTab.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="recommend-tab">
     <AtlasAlert
-      v-if="!store.isRecommendedAvailable"
+      v-if="store.recommendedError"
+      severity="danger"
+      :closable="true"
+      class="mb-4"
+      @close="store.recommendedError = null"
+    >
+      {{ store.recommendedError }}
+    </AtlasAlert>
+
+    <AtlasAlert
+      v-else-if="!store.isRecommendedAvailable"
       severity="info"
       class="mb-4"
       data-testid="recommend-not-available"
@@ -12,16 +22,6 @@
           'Recommendations are not available. The PHOEBE 2.0 vocabulary tables are required to generate recommendations.'
         )
       }}
-    </AtlasAlert>
-
-    <AtlasAlert
-      v-else-if="store.recommendedError"
-      severity="danger"
-      :closable="true"
-      class="mb-4"
-      @close="store.recommendedError = null"
-    >
-      {{ store.recommendedError }}
     </AtlasAlert>
 
     <AtlasAlert

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -615,6 +615,9 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
 
     loadingRecommended.value = true
     recommendedError.value = null
+    // A 501 from one source must not leave the "not available" banner up for
+    // every later set or source — re-establish availability on each attempt.
+    isRecommendedAvailable.value = true
 
     try {
       const result = await getRecommendedConcepts(sourceKey, seed)
@@ -627,8 +630,6 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
 
       const existingIds = new Set((currentSet.value?.items ?? []).map(item => item.conceptId))
       const candidates = result.concepts.filter(c => !existingIds.has(c.conceptId))
-
-      isRecommendedAvailable.value = true
 
       const ids = candidates.map(c => c.conceptId)
       const counts = await getConceptRecordCounts(sourceKey, ids)

--- a/tests/unit/stores/concept-sets.spec.ts
+++ b/tests/unit/stores/concept-sets.spec.ts
@@ -829,6 +829,62 @@ describe('Concept Sets Store', () => {
       expect(store.loadingRecommended).toBe(false)
     })
 
+    it('should clear a previous unavailable flag once a later load succeeds', async () => {
+      const store = useConceptSetsStore()
+      store.currentSet = { name: 'Test', items: [makeItem(1)] }
+
+      vi.mocked(getRecommendedConcepts).mockResolvedValue({ available: false, concepts: [] })
+      await store.loadRecommendedConcepts('NO_PHOEBE')
+      expect(store.isRecommendedAvailable).toBe(false)
+
+      vi.mocked(getRecommendedConcepts).mockResolvedValue({
+        available: true,
+        concepts: [makeRecommended(10)],
+      })
+      vi.mocked(getConceptRecordCounts).mockResolvedValue(new Map())
+      await store.loadRecommendedConcepts('HAS_PHOEBE')
+
+      expect(store.isRecommendedAvailable).toBe(true)
+      expect(store.recommendedConcepts.map((c) => c.conceptId)).toEqual([10])
+    })
+
+    it('should surface a later failure as an error rather than keeping the unavailable flag', async () => {
+      const store = useConceptSetsStore()
+      store.currentSet = { name: 'Test', items: [makeItem(1)] }
+
+      vi.mocked(getRecommendedConcepts).mockResolvedValue({ available: false, concepts: [] })
+      await store.loadRecommendedConcepts('NO_PHOEBE')
+      expect(store.isRecommendedAvailable).toBe(false)
+
+      vi.mocked(getRecommendedConcepts).mockRejectedValue(new Error('boom'))
+      await store.loadRecommendedConcepts('HAS_PHOEBE')
+
+      expect(store.isRecommendedAvailable).toBe(true)
+      expect(store.recommendedError).toContain('boom')
+    })
+
+    it('should drop a previous unavailable flag while the next load is in flight', async () => {
+      const store = useConceptSetsStore()
+      store.currentSet = { name: 'Test', items: [makeItem(1)] }
+
+      vi.mocked(getRecommendedConcepts).mockResolvedValue({ available: false, concepts: [] })
+      await store.loadRecommendedConcepts('NO_PHOEBE')
+      expect(store.isRecommendedAvailable).toBe(false)
+
+      let resolve: (v: { available: true; concepts: Concept[] }) => void = () => {}
+      const pending = new Promise<{ available: true; concepts: Concept[] }>((r) => {
+        resolve = r
+      })
+      vi.mocked(getRecommendedConcepts).mockReturnValue(pending)
+      vi.mocked(getConceptRecordCounts).mockResolvedValue(new Map())
+
+      const inFlight = store.loadRecommendedConcepts('HAS_PHOEBE')
+      expect(store.isRecommendedAvailable).toBe(true)
+
+      resolve({ available: true, concepts: [] })
+      await inFlight
+    })
+
     it('should toggle loadingRecommended true during call and false in finally', async () => {
       const store = useConceptSetsStore()
       store.currentSet = { name: 'Test', items: [makeItem(1)] }


### PR DESCRIPTION
The Recommend tab's "Recommendations are not available. The PHOEBE 2.0 vocabulary tables are required to generate recommendations." banner is driven by `isRecommendedAvailable`, which the concept sets store only ever set back to `true` on a *successful* response. A single 501 from one source therefore left the banner up for every concept set and every source visited afterwards — including sources whose vocabulary schema does have the tables — until some later load happened to succeed.

`loadRecommendedConcepts` now re-establishes availability at the start of each attempt, which is also what ATLAS 2.15 does (`ConceptSetStore.loadRecommended`). A second effect of the stale flag was that the informational banner outranked `recommendedError` in the template, so a genuine later failure (network error, 500, schema problem) was displayed to the user as "PHOEBE tables required" rather than as the actual error. With the flag reset the two states are mutually exclusive, and the alerts are ordered so a hard error wins regardless.

Note this does not change when the banner legitimately appears: it still shows only when WebAPI answers 501 `NOT_IMPLEMENTED` for `POST /vocabulary/{sourceKey}/lookup/recommended`, which is the same contract 2.15 uses.

Covered by three new cases in `tests/unit/stores/concept-sets.spec.ts`; two of them fail without the store change.