### PR TITLE
Let concepts be added with exclude / descendants / mapped chosen up front (#163)

### DIFF
--- a/src/components/concepts/ConceptAddOptions.vue
+++ b/src/components/concepts/ConceptAddOptions.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="concept-add-options">
+    <v-checkbox-btn
+      :model-value="modelValue.includeDescendants"
+      :label="t('cs.conceptAddBox.descendants', 'Descendants').value"
+      density="compact"
+      hide-details
+      data-testid="add-option-descendants"
+      @update:model-value="(v: boolean | null) => onToggle('includeDescendants', v)"
+    />
+    <v-checkbox-btn
+      :model-value="modelValue.includeMapped"
+      :label="t('cs.conceptAddBox.mapped', 'Mapped').value"
+      density="compact"
+      hide-details
+      data-testid="add-option-mapped"
+      @update:model-value="(v: boolean | null) => onToggle('includeMapped', v)"
+    />
+    <v-checkbox-btn
+      :model-value="modelValue.isExcluded"
+      :label="t('cs.conceptAddBox.exclude', 'Exclude').value"
+      density="compact"
+      hide-details
+      data-testid="add-option-exclude"
+      @update:model-value="(v: boolean | null) => onToggle('isExcluded', v)"
+    />
+    <AtlasButton
+      size="sm"
+      icon="mdi-plus"
+      :disabled="selectedCount === 0 || disabled"
+      data-testid="add-selected"
+      @click="emit('add')"
+    >
+      {{ t('cs.conceptAddBox.addToConceptSet', 'Add To Concept Set') }}
+      <span
+        v-if="selectedCount > 0"
+        class="ml-1"
+      >({{ selectedCount }})</span>
+    </AtlasButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AtlasButton } from '@/components/ui'
+import { useI18n } from '@/composables/useI18n'
+import type { ConceptAddFlags } from '@/models/concept-set.types'
+
+interface Props {
+  modelValue: Required<ConceptAddFlags>
+  selectedCount: number
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), { disabled: false })
+
+const emit = defineEmits<{
+  'update:modelValue': [flags: Required<ConceptAddFlags>]
+  add: []
+}>()
+
+const { t } = useI18n()
+
+function onToggle(key: keyof ConceptAddFlags, value: boolean | null) {
+  emit('update:modelValue', { ...props.modelValue, [key]: !!value })
+}
+</script>
+
+<style scoped>
+.concept-add-options {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+</style>

--- a/src/components/concepts/ConceptSearch.vue
+++ b/src/components/concepts/ConceptSearch.vue
@@ -54,8 +54,17 @@
       @clear="store.clearFacets()"
     />
 
+    <ConceptAddOptions
+      v-if="!store.isEmpty"
+      v-model="addFlags"
+      :selected-count="selected.length"
+      class="concept-search__add-options"
+      @add="onAddSelected"
+    />
+
     <!-- Results Table -->
     <ConceptTable
+      v-model:selected="selected"
       :concepts="store.concepts"
       :loading="store.loading"
       :loading-record-counts="store.loadingRecordCounts"
@@ -65,6 +74,7 @@
       :linkable="true"
       :source-key="selectedSourceKey"
       :show-add-button="true"
+      :selectable="true"
       :concepts-in-set="conceptsInSet"
       @update:page="onPageChange"
       @update:items-per-page="onItemsPerPageChange"
@@ -90,7 +100,8 @@ import { useWebAPIStore } from '@/stores/webapi'
 import { getSourceKey } from '@/config/webapi'
 import ConceptTable from './ConceptTable.vue'
 import ConceptFacetFilters from './ConceptFacetFilters.vue'
-import type { Concept } from '@/models/concept-set.types'
+import ConceptAddOptions from './ConceptAddOptions.vue'
+import type { Concept, ConceptAddFlags } from '@/models/concept-set.types'
 
 const { t } = useI18n()
 
@@ -119,6 +130,15 @@ const conceptsInSet = computed(() => {
 
 const searchInput = ref<string>('')
 const feedback = ref<{ open: boolean; text: string }>({ open: false, text: '' })
+const selected = ref<number[]>([])
+
+// Sticky across searches on purpose: the point of the add box is to set the
+// intent once and then collect concepts over several queries.
+const addFlags = ref<Required<ConceptAddFlags>>({
+  isExcluded: false,
+  includeDescendants: false,
+  includeMapped: false,
+})
 
 // ============================================================================
 // Computed
@@ -177,18 +197,48 @@ function onAddConcept(concept: Concept) {
   if (!conceptSetsStore.currentSet) {
     conceptSetsStore.openCreateEditor()
   }
-  conceptSetsStore.addConceptToSet(concept)
+  conceptSetsStore.addConceptToSet(concept, addFlags.value)
 
-  const setName =
-    conceptSetsStore.currentSet?.name ||
-    t('components.conceptSetBuilder.newConceptSet', 'New concept set').value
   feedback.value = {
     open: true,
     text: t('search.addedToSet', 'Added “{concept}” → {set}', {
       concept: concept.conceptName,
-      set: setName,
+      set: currentSetName(),
     }).value,
   }
+}
+
+function onAddSelected() {
+  const ids = new Set(selected.value)
+  if (ids.size === 0) return
+
+  if (!conceptSetsStore.currentSet) {
+    conceptSetsStore.openCreateEditor()
+  }
+
+  // Concepts already in the set are skipped by the store, so count what
+  // actually landed rather than what was ticked.
+  const before = conceptSetsStore.currentSet?.items.length ?? 0
+  for (const concept of store.allConcepts.filter(c => ids.has(c.conceptId))) {
+    conceptSetsStore.addConceptToSet(concept, addFlags.value)
+  }
+  const added = (conceptSetsStore.currentSet?.items.length ?? 0) - before
+  selected.value = []
+
+  feedback.value = {
+    open: true,
+    text: t('search.addedCountToSet', 'Added {count} concepts → {set}', {
+      count: added,
+      set: currentSetName(),
+    }).value,
+  }
+}
+
+function currentSetName(): string {
+  return (
+    conceptSetsStore.currentSet?.name ||
+    t('components.conceptSetBuilder.newConceptSet', 'New concept set').value
+  )
 }
 
 function onRemoveConcept(concept: Concept) {

--- a/src/components/concepts/ConceptSearchInline.vue
+++ b/src/components/concepts/ConceptSearchInline.vue
@@ -37,14 +37,24 @@
       {{ store.error }}
     </AtlasAlert>
 
+    <ConceptAddOptions
+      v-if="!store.isEmpty"
+      v-model="addFlags"
+      :selected-count="selected.length"
+      class="mb-4"
+      @add="onAddSelected"
+    />
+
     <!-- Results Table with Add/Remove buttons -->
     <ConceptTable
+      v-model:selected="selected"
       :concepts="store.concepts"
       :loading="store.loading"
       :total-items="store.totalCount"
       :page="store.page"
       :items-per-page="store.itemsPerPage"
       :show-add-button="true"
+      :selectable="true"
       :concepts-in-set="conceptsInSet"
       @update:page="onPageChange"
       @update:items-per-page="onItemsPerPageChange"
@@ -62,7 +72,8 @@ import { useI18n } from '@/composables/useI18n'
 import { useConceptSearchStore } from '@/stores/concept-search'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import ConceptTable from './ConceptTable.vue'
-import type { Concept } from '@/models/concept-set.types'
+import ConceptAddOptions from './ConceptAddOptions.vue'
+import type { Concept, ConceptAddFlags } from '@/models/concept-set.types'
 
 const { t, tv } = useI18n()
 
@@ -78,7 +89,8 @@ const conceptSetsStore = useConceptSetsStore()
 // ============================================================================
 
 const emit = defineEmits<{
-  'add-concept': [concept: Concept]
+  'add-concept': [concept: Concept, flags: Required<ConceptAddFlags>]
+  'add-concepts': [concepts: Concept[], flags: Required<ConceptAddFlags>]
   'remove-concept': [concept: Concept]
   'view-concept': [payload: { conceptId: number; sourceKey: string }]
 }>()
@@ -88,6 +100,15 @@ const emit = defineEmits<{
 // ============================================================================
 
 const searchInput = ref<string>('')
+const selected = ref<number[]>([])
+
+// Sticky across searches on purpose: the point of the add box is to set the
+// intent once and then collect concepts over several queries.
+const addFlags = ref<Required<ConceptAddFlags>>({
+  isExcluded: false,
+  includeDescendants: false,
+  includeMapped: false,
+})
 
 // ============================================================================
 // Computed
@@ -151,7 +172,19 @@ function onItemsPerPageChange(itemsPerPage: number) {
 }
 
 function onAddConcept(concept: Concept) {
-  emit('add-concept', concept)
+  emit('add-concept', concept, addFlags.value)
+}
+
+function onAddSelected() {
+  const ids = new Set(selected.value)
+  if (ids.size === 0) return
+
+  emit(
+    'add-concepts',
+    store.allConcepts.filter(c => ids.has(c.conceptId)),
+    addFlags.value
+  )
+  selected.value = []
 }
 
 function onRemoveConcept(concept: Concept) {

--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -295,6 +295,7 @@
               <v-window-item value="search">
                 <ConceptSearchInline
                   @add-concept="onAddConcept"
+                  @add-concepts="onAddConcepts"
                   @remove-concept="onRemoveConcept"
                   @view-concept="onViewConcept"
                 />
@@ -667,7 +668,7 @@ import { useConceptSetsStore } from '@/stores/concept-sets'
 import { useNotifications } from '@/stores/notifications'
 import { usePermissions } from '@/composables/usePermissions'
 import { useEntityAccess } from '@/composables/useEntityAccess'
-import type { ConceptSet, Concept, ConceptSetItem } from '@/models/concept-set.types'
+import type { ConceptSet, Concept, ConceptSetItem, ConceptAddFlags } from '@/models/concept-set.types'
 import type { VersionsConfig, VersionsTableItem, User } from '@/components/versions/types'
 import TagSelectionDialog from '@/components/tags/TagSelectionDialog.vue'
 import type { Tag } from '@/models/cohort.types'
@@ -1118,8 +1119,15 @@ function confirmDelete() {
 // Concept Building Methods
 // ============================================================================
 
-function onAddConcept(concept: Concept) {
-  store.addConceptToSet(concept)
+function onAddConcept(concept: Concept, flags?: ConceptAddFlags) {
+  store.addConceptToSet(concept, flags)
+  hasUnsavedChanges.value = true
+}
+
+function onAddConcepts(concepts: Concept[], flags?: ConceptAddFlags) {
+  for (const concept of concepts) {
+    store.addConceptToSet(concept, flags)
+  }
   hasUnsavedChanges.value = true
 }
 

--- a/src/components/concepts/RecommendTab.vue
+++ b/src/components/concepts/RecommendTab.vue
@@ -63,37 +63,12 @@
       </div>
 
       <div class="recommend-tab__bar-right">
-        <v-checkbox-btn
-          v-model="addDescendants"
-          :label="t('cs.conceptAddBox.descendants', 'Descendants').value"
-          density="compact"
-          hide-details
+        <ConceptAddOptions
+          v-model="addFlags"
+          :selected-count="selected.length"
+          :disabled="store.loadingRecommended"
+          @add="onAddSelected"
         />
-        <v-checkbox-btn
-          v-model="addMapped"
-          :label="t('cs.conceptAddBox.mapped', 'Mapped').value"
-          density="compact"
-          hide-details
-        />
-        <v-checkbox-btn
-          v-model="addExclude"
-          :label="t('cs.conceptAddBox.exclude', 'Exclude').value"
-          density="compact"
-          hide-details
-        />
-        <AtlasButton
-          size="sm"
-          icon="mdi-plus"
-          :disabled="selected.length === 0 || store.loadingRecommended"
-          data-testid="recommend-add-selected"
-          @click="onAddSelected"
-        >
-          {{ t('cs.conceptPicker.addSelected', 'Add Selected') }}
-          <span
-            v-if="selected.length > 0"
-            class="ml-1"
-          >({{ selected.length }})</span>
-        </AtlasButton>
       </div>
     </div>
 
@@ -144,7 +119,8 @@ import { useI18n } from '@/composables/useI18n'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import { useWebAPIStore } from '@/stores/webapi'
 import ConceptTable from './ConceptTable.vue'
-import type { Concept } from '@/models/concept-set.types'
+import ConceptAddOptions from './ConceptAddOptions.vue'
+import type { Concept, ConceptAddFlags } from '@/models/concept-set.types'
 
 const { t } = useI18n()
 
@@ -172,9 +148,11 @@ const selected = ref<number[]>([])
 const page = ref(1)
 const itemsPerPage = ref(60)
 
-const addDescendants = ref(false)
-const addMapped = ref(false)
-const addExclude = ref(false)
+const addFlags = ref<Required<ConceptAddFlags>>({
+  isExcluded: false,
+  includeDescendants: false,
+  includeMapped: false,
+})
 
 const hasSeed = computed(() => {
   const items = store.currentSet?.items ?? []
@@ -219,15 +197,8 @@ function onAddSelected() {
   let added = 0
   for (const concept of picked) {
     const beforeCount = store.currentSet?.items.length ?? 0
-    store.addConceptToSet(concept)
-    const afterCount = store.currentSet?.items.length ?? 0
-    if (afterCount === beforeCount) continue
-
-    // toggleConceptFlag flips; freshly-added items have flags=false, so one
-    // toggle sets them true.
-    if (addDescendants.value) store.toggleConceptFlag(concept.conceptId, 'includeDescendants')
-    if (addMapped.value) store.toggleConceptFlag(concept.conceptId, 'includeMapped')
-    if (addExclude.value) store.toggleConceptFlag(concept.conceptId, 'isExcluded')
+    store.addConceptToSet(concept, addFlags.value)
+    if ((store.currentSet?.items.length ?? 0) === beforeCount) continue
     added += 1
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2707,6 +2707,7 @@
     }
   },
   "search": {
+    "addedCountToSet": "Added {count} concepts → {set}",
     "addedToSet": "Added “{concept}” → {set}",
     "advancedOptions": "Advanced Options",
     "buttonTitle": "Search",
@@ -2771,6 +2772,12 @@
         "export": "Export",
         "list": "List"
       }
+    },
+    "conceptAddBox": {
+      "addToConceptSet": "Add To Concept Set",
+      "descendants": "Descendants",
+      "exclude": "Exclude",
+      "mapped": "Mapped"
     },
     "manager": {
       "attemptingToFindMessage": "Attempting to find an optimal definition for this concept set...",

--- a/src/models/concept-set.types.ts
+++ b/src/models/concept-set.types.ts
@@ -73,6 +73,10 @@ export interface ConceptSetItem {
   includeMapped: boolean // Include mapped concepts from other vocabularies
 }
 
+export type ConceptAddFlags = Partial<
+  Pick<ConceptSetItem, 'isExcluded' | 'includeDescendants' | 'includeMapped'>
+>
+
 export const ConceptSetItemSchema = z.object({
   conceptId: z.number().int().positive(),
   conceptName: z.string(),

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -17,6 +17,7 @@ import type {
   ConceptSet,
   ConceptSetListItem,
   ConceptSetItem,
+  ConceptAddFlags,
   ComparisonResultItem,
   ConceptSetExpression,
 } from '@/models/concept-set.types'
@@ -443,7 +444,7 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
   /**
    * Add a concept to the current concept set
    */
-  function addConceptToSet(concept: Concept) {
+  function addConceptToSet(concept: Concept, flags?: ConceptAddFlags) {
     if (!currentSet.value) {
       error.value = 'No concept set selected'
       return
@@ -456,7 +457,7 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
       return
     }
 
-    const item: ConceptSetItem = conceptToConceptSetItem(concept)
+    const item: ConceptSetItem = conceptToConceptSetItem(concept, flags)
     currentSet.value.items.push(item)
     error.value = null
   }

--- a/tests/unit/components/concepts/ConceptAddOptions.spec.ts
+++ b/tests/unit/components/concepts/ConceptAddOptions.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import ConceptAddOptions from '@/components/concepts/ConceptAddOptions.vue'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+const vuetify = createVuetify({ components, directives })
+
+const NONE = { isExcluded: false, includeDescendants: false, includeMapped: false }
+
+function mountOptions(props: Record<string, unknown> = {}) {
+  return mount(ConceptAddOptions, {
+    global: { plugins: [vuetify] },
+    props: { modelValue: NONE, selectedCount: 0, ...props },
+  })
+}
+
+function checkbox(wrapper: ReturnType<typeof mountOptions>, testid: string) {
+  return wrapper.find(`[data-testid="${testid}"] input`)
+}
+
+describe('ConceptAddOptions', () => {
+  it('renders the three Atlas add-box toggles', () => {
+    const wrapper = mountOptions()
+    expect(wrapper.find('[data-testid="add-option-descendants"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="add-option-mapped"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="add-option-exclude"]').exists()).toBe(true)
+  })
+
+  it('reflects the incoming flags', () => {
+    const wrapper = mountOptions({ modelValue: { ...NONE, includeDescendants: true } })
+    expect((checkbox(wrapper, 'add-option-descendants').element as HTMLInputElement).checked).toBe(true)
+    expect((checkbox(wrapper, 'add-option-exclude').element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('emits the whole flag set when a toggle changes', async () => {
+    const wrapper = mountOptions()
+    await checkbox(wrapper, 'add-option-exclude').setValue(true)
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([
+      { isExcluded: true, includeDescendants: false, includeMapped: false },
+    ])
+  })
+
+  it('disables the add button when nothing is selected', () => {
+    const wrapper = mountOptions({ selectedCount: 0 })
+    expect(wrapper.findComponent({ name: 'AtlasButton' }).props('disabled')).toBe(true)
+  })
+
+  it('enables the add button and shows the selection count', () => {
+    const wrapper = mountOptions({ selectedCount: 3 })
+    const btn = wrapper.findComponent({ name: 'AtlasButton' })
+    expect(btn.props('disabled')).toBe(false)
+    expect(wrapper.text()).toContain('3')
+  })
+
+  it('stays disabled while the caller reports itself busy', () => {
+    const wrapper = mountOptions({ selectedCount: 3, disabled: true })
+    expect(wrapper.findComponent({ name: 'AtlasButton' }).props('disabled')).toBe(true)
+  })
+
+  it('emits add when the button is clicked', async () => {
+    const wrapper = mountOptions({ selectedCount: 2 })
+    await wrapper.find('[data-testid="add-selected"]').trigger('click')
+    expect(wrapper.emitted('add')).toHaveLength(1)
+  })
+})

--- a/tests/unit/components/concepts/ConceptSearch.add-options.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearch.add-options.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * ConceptSearch — choosing how concepts are added (#163)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { setActivePinia, createPinia } from 'pinia'
+import ConceptSearch from '@/components/concepts/ConceptSearch.vue'
+import ConceptTable from '@/components/concepts/ConceptTable.vue'
+import ConceptAddOptions from '@/components/concepts/ConceptAddOptions.vue'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import { useConceptSearchStore } from '@/stores/concept-search'
+import type { Concept } from '@/models/concept-set.types'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+vi.mock('@/services/concept-search.service', () => ({
+  searchConcepts: vi.fn().mockResolvedValue({ concepts: [], totalCount: 0 }),
+  getConceptById: vi.fn(),
+  getConceptsByIds: vi.fn(),
+  getConceptsBySourceCodes: vi.fn(),
+  getRecommendedConcepts: vi.fn().mockResolvedValue({ available: true, concepts: [] }),
+  getConceptRecordCounts: vi.fn().mockResolvedValue(new Map()),
+  compareConceptSets: vi.fn().mockResolvedValue([]),
+  resolveConceptSetExpression: vi.fn().mockResolvedValue([]),
+  getMappedSourceCodes: vi.fn().mockResolvedValue([]),
+}))
+
+const vuetify = createVuetify({ components, directives })
+
+function concept(overrides: Partial<Concept> = {}): Concept {
+  return {
+    conceptId: 313217,
+    conceptName: 'Atrial fibrillation',
+    conceptCode: '49436004',
+    domainId: 'Condition',
+    vocabularyId: 'SNOMED',
+    conceptClassId: 'Clinical Finding',
+    standardConcept: 'S',
+    invalidReason: null,
+    ...overrides,
+  }
+}
+
+const A = concept()
+const B = concept({ conceptId: 4154290, conceptName: 'Paroxysmal atrial fibrillation' })
+
+function mountSearch() {
+  return mount(ConceptSearch, {
+    global: { plugins: [vuetify], stubs: { ConceptTable: true } },
+  })
+}
+
+function setResults(list: Concept[]) {
+  useConceptSearchStore().allConcepts = list
+}
+
+describe('ConceptSearch — add options', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('makes the results table selectable so several concepts can be added at once', () => {
+    const wrapper = mountSearch()
+    expect(wrapper.findComponent(ConceptTable).props('selectable')).toBe(true)
+  })
+
+  it('hides the add-options bar until a search has returned something', async () => {
+    const wrapper = mountSearch()
+    expect(wrapper.findComponent(ConceptAddOptions).exists()).toBe(false)
+
+    setResults([A])
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent(ConceptAddOptions).exists()).toBe(true)
+  })
+
+  it('applies the chosen flags to a row added with the Add button', async () => {
+    const wrapper = mountSearch()
+    setResults([A])
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('update:modelValue', {
+      isExcluded: false,
+      includeDescendants: true,
+      includeMapped: false,
+    })
+    await wrapper.vm.$nextTick()
+
+    await wrapper.findComponent(ConceptTable).vm.$emit('add-concept', A)
+
+    const sets = useConceptSetsStore()
+    expect(sets.currentSet?.items[0]).toMatchObject({
+      conceptId: A.conceptId,
+      includeDescendants: true,
+      isExcluded: false,
+    })
+  })
+
+  it('adds every selected concept with the chosen flags in one go', async () => {
+    const wrapper = mountSearch()
+    setResults([A, B])
+    await wrapper.vm.$nextTick()
+
+    const table = wrapper.findComponent(ConceptTable)
+    table.vm.$emit('update:selected', [A.conceptId, B.conceptId])
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('update:modelValue', {
+      isExcluded: true,
+      includeDescendants: true,
+      includeMapped: false,
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    const sets = useConceptSetsStore()
+    expect(sets.currentSet?.items).toHaveLength(2)
+    for (const item of sets.currentSet?.items ?? []) {
+      expect(item).toMatchObject({ isExcluded: true, includeDescendants: true, includeMapped: false })
+    }
+  })
+
+  it('counts only the concepts that actually landed, not the ones ticked', async () => {
+    const wrapper = mountSearch()
+    setResults([A, B])
+    await wrapper.vm.$nextTick()
+
+    const table = wrapper.findComponent(ConceptTable)
+    await table.vm.$emit('add-concept', A)
+
+    table.vm.$emit('update:selected', [A.conceptId, B.conceptId])
+    await wrapper.vm.$nextTick()
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    const sets = useConceptSetsStore()
+    expect(sets.currentSet?.items).toHaveLength(2)
+    expect(wrapper.findComponent({ name: 'AtlasSnackbar' }).props('text')).toContain('Added 1')
+  })
+
+  it('reports the selection count to the add-options bar', async () => {
+    const wrapper = mountSearch()
+    setResults([A, B])
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptTable).vm.$emit('update:selected', [A.conceptId])
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findComponent(ConceptAddOptions).props('selectedCount')).toBe(1)
+  })
+
+  it('clears the selection after a bulk add', async () => {
+    const wrapper = mountSearch()
+    setResults([A, B])
+    await wrapper.vm.$nextTick()
+
+    const table = wrapper.findComponent(ConceptTable)
+    table.vm.$emit('update:selected', [A.conceptId, B.conceptId])
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(table.props('selected')).toEqual([])
+  })
+
+  it('creates a set on a bulk add when none is open yet', async () => {
+    const wrapper = mountSearch()
+    const sets = useConceptSetsStore()
+    expect(sets.currentSet).toBeNull()
+
+    setResults([A])
+    await wrapper.vm.$nextTick()
+    wrapper.findComponent(ConceptTable).vm.$emit('update:selected', [A.conceptId])
+    await wrapper.vm.$nextTick()
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(sets.editorOpen).toBe(true)
+    expect(sets.currentSet?.items).toHaveLength(1)
+  })
+
+  it('keeps the chosen flags across successive searches', async () => {
+    const wrapper = mountSearch()
+    setResults([A])
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('update:modelValue', {
+      isExcluded: true,
+      includeDescendants: false,
+      includeMapped: false,
+    })
+    await wrapper.vm.$nextTick()
+
+    setResults([B])
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findComponent(ConceptAddOptions).props('modelValue')).toMatchObject({
+      isExcluded: true,
+    })
+  })
+})

--- a/tests/unit/components/concepts/ConceptSearchInline.add-options.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearchInline.add-options.spec.ts
@@ -10,7 +10,6 @@ import { setActivePinia, createPinia } from 'pinia'
 import ConceptSearchInline from '@/components/concepts/ConceptSearchInline.vue'
 import ConceptAddOptions from '@/components/concepts/ConceptAddOptions.vue'
 import { useConceptSearchStore } from '@/stores/concept-search'
-import { useConceptSetsStore } from '@/stores/concept-sets'
 import { createMockConcept } from '@/../tests/helpers/mock-factories'
 
 vi.mock('@/composables/useI18n', async () => {
@@ -130,97 +129,5 @@ describe('ConceptSearchInline — add options', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.emitted('add-concepts')).toBeUndefined()
-  })
-})
-
-describe('ConceptSearchInline — search box and table wiring', () => {
-  let wrapper: VueWrapper
-
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    wrapper = mount(ConceptSearchInline, { global: { plugins: [vuetify] } })
-  })
-
-  it('rejects a term shorter than three characters', async () => {
-    const store = useConceptSearchStore()
-    const spy = vi.spyOn(store, 'search')
-
-    await wrapper.find('input').setValue('ab')
-    await wrapper.find('input').trigger('keyup.enter')
-
-    expect(spy).not.toHaveBeenCalled()
-    expect(wrapper.text()).toContain('Please enter at least 3 characters')
-  })
-
-  it('searches the trimmed term on Enter and on the append button', async () => {
-    const store = useConceptSearchStore()
-    const spy = vi.spyOn(store, 'search')
-
-    await wrapper.find('input').setValue('  diabetes  ')
-    await wrapper.find('input').trigger('keyup.enter')
-    expect(spy).toHaveBeenLastCalledWith('diabetes')
-
-    await wrapper.findComponent({ name: 'AtlasButton' }).trigger('click')
-    expect(spy).toHaveBeenLastCalledWith('diabetes')
-  })
-
-  it('clears the store when the input is emptied', async () => {
-    const store = useConceptSearchStore()
-    const spy = vi.spyOn(store, 'clearSearch')
-
-    await wrapper.find('input').setValue('diabetes')
-    await wrapper.find('input').setValue('')
-
-    expect(spy).toHaveBeenCalled()
-  })
-
-  it('resets the box and the store via the clear affordance', async () => {
-    const store = useConceptSearchStore()
-    const spy = vi.spyOn(store, 'clearSearch')
-
-    await wrapper.find('input').setValue('diabetes')
-    wrapper.findComponent({ name: 'AtlasTextField' }).vm.$emit('click:clear')
-    await wrapper.vm.$nextTick()
-
-    expect(spy).toHaveBeenCalled()
-    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
-  })
-
-  it('surfaces a store error', async () => {
-    useConceptSearchStore().error = 'boom'
-    await wrapper.vm.$nextTick()
-    expect(wrapper.text()).toContain('boom')
-  })
-
-  it('forwards pagination changes to the store', async () => {
-    const store = useConceptSearchStore()
-    const spy = vi.spyOn(store, 'updatePagination')
-
-    table(wrapper).vm.$emit('update:page', 3)
-    expect(spy).toHaveBeenLastCalledWith(3, store.itemsPerPage)
-
-    table(wrapper).vm.$emit('update:itemsPerPage', 50)
-    expect(spy).toHaveBeenLastCalledWith(1, 50)
-  })
-
-  it('re-emits remove and view events from the table', async () => {
-    table(wrapper).vm.$emit('remove-concept', A)
-    table(wrapper).vm.$emit('view-concept', { conceptId: 1, sourceKey: 'SYNPUF1K' })
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.emitted('remove-concept')?.[0]).toEqual([A])
-    expect(wrapper.emitted('view-concept')?.[0]).toEqual([{ conceptId: 1, sourceKey: 'SYNPUF1K' }])
-  })
-
-  it('marks concepts already in the open set', async () => {
-    const sets = useConceptSetsStore()
-    sets.currentSet = {
-      id: 7,
-      name: 'Set',
-      items: [{ ...A, isExcluded: false, includeDescendants: false, includeMapped: false }],
-    }
-    await wrapper.vm.$nextTick()
-
-    expect([...(table(wrapper).props('conceptsInSet') as Set<number>)]).toEqual([A.conceptId])
   })
 })

--- a/tests/unit/components/concepts/ConceptSearchInline.add-options.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearchInline.add-options.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * ConceptSearchInline — choosing how concepts are added (#163)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { setActivePinia, createPinia } from 'pinia'
+import ConceptSearchInline from '@/components/concepts/ConceptSearchInline.vue'
+import ConceptAddOptions from '@/components/concepts/ConceptAddOptions.vue'
+import { useConceptSearchStore } from '@/stores/concept-search'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import { createMockConcept } from '@/../tests/helpers/mock-factories'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+vi.mock('@/services/concept-search.service', () => ({
+  searchConcepts: vi.fn().mockResolvedValue({ concepts: [], totalCount: 0 }),
+  getConceptRecordCounts: vi.fn().mockResolvedValue(new Map()),
+}))
+
+vi.mock('@/config/webapi', () => ({ getSourceKey: () => 'SYNPUF1K' }))
+
+vi.mock('@/stores/webapi', () => ({
+  useWebAPIStore: () => ({
+    getValidVocabularySource: () => 'SYNPUF1K',
+    sources: [],
+    selectedSource: null,
+    vocabularySources: [],
+  }),
+}))
+
+vi.mock('@/components/concepts/ConceptTable.vue', () => ({
+  default: {
+    name: 'ConceptTable',
+    template: '<div />',
+    props: ['concepts', 'loading', 'totalItems', 'page', 'itemsPerPage', 'showAddButton', 'conceptsInSet', 'selectable', 'selected'],
+    emits: ['update:page', 'update:itemsPerPage', 'update:selected', 'add-concept', 'remove-concept', 'view-concept'],
+  },
+}))
+
+const vuetify = createVuetify({ components, directives })
+
+const A = createMockConcept({ conceptId: 1, conceptName: 'Diabetes' })
+const B = createMockConcept({ conceptId: 2, conceptName: 'Metformin' })
+
+function table(wrapper: VueWrapper) {
+  return wrapper.findComponent({ name: 'ConceptTable' })
+}
+
+describe('ConceptSearchInline — add options', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    wrapper = mount(ConceptSearchInline, { global: { plugins: [vuetify] } })
+  })
+
+  function setResults(list = [A, B]) {
+    useConceptSearchStore().allConcepts = list
+    return wrapper.vm.$nextTick()
+  }
+
+  it('hides the add-options bar until results exist', async () => {
+    expect(wrapper.findComponent(ConceptAddOptions).exists()).toBe(false)
+    await setResults()
+    expect(wrapper.findComponent(ConceptAddOptions).exists()).toBe(true)
+  })
+
+  it('makes the results table selectable', async () => {
+    await setResults()
+    expect(table(wrapper).props('selectable')).toBe(true)
+  })
+
+  it('emits the chosen flags alongside a single add', async () => {
+    await setResults()
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('update:modelValue', {
+      isExcluded: false,
+      includeDescendants: true,
+      includeMapped: false,
+    })
+    await wrapper.vm.$nextTick()
+
+    table(wrapper).vm.$emit('add-concept', A)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('add-concept')?.[0]).toEqual([
+      A,
+      { isExcluded: false, includeDescendants: true, includeMapped: false },
+    ])
+  })
+
+  it('emits every selected concept with the chosen flags on a bulk add', async () => {
+    await setResults()
+    table(wrapper).vm.$emit('update:selected', [A.conceptId, B.conceptId])
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('update:modelValue', {
+      isExcluded: true,
+      includeDescendants: false,
+      includeMapped: true,
+    })
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('add-concepts')?.[0]).toEqual([
+      [A, B],
+      { isExcluded: true, includeDescendants: false, includeMapped: true },
+    ])
+  })
+
+  it('clears the selection after a bulk add', async () => {
+    await setResults()
+    table(wrapper).vm.$emit('update:selected', [A.conceptId])
+    await wrapper.vm.$nextTick()
+
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(table(wrapper).props('selected')).toEqual([])
+  })
+
+  it('does not emit a bulk add when nothing is selected', async () => {
+    await setResults()
+    wrapper.findComponent(ConceptAddOptions).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('add-concepts')).toBeUndefined()
+  })
+})
+
+describe('ConceptSearchInline — search box and table wiring', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    wrapper = mount(ConceptSearchInline, { global: { plugins: [vuetify] } })
+  })
+
+  it('rejects a term shorter than three characters', async () => {
+    const store = useConceptSearchStore()
+    const spy = vi.spyOn(store, 'search')
+
+    await wrapper.find('input').setValue('ab')
+    await wrapper.find('input').trigger('keyup.enter')
+
+    expect(spy).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Please enter at least 3 characters')
+  })
+
+  it('searches the trimmed term on Enter and on the append button', async () => {
+    const store = useConceptSearchStore()
+    const spy = vi.spyOn(store, 'search')
+
+    await wrapper.find('input').setValue('  diabetes  ')
+    await wrapper.find('input').trigger('keyup.enter')
+    expect(spy).toHaveBeenLastCalledWith('diabetes')
+
+    await wrapper.findComponent({ name: 'AtlasButton' }).trigger('click')
+    expect(spy).toHaveBeenLastCalledWith('diabetes')
+  })
+
+  it('clears the store when the input is emptied', async () => {
+    const store = useConceptSearchStore()
+    const spy = vi.spyOn(store, 'clearSearch')
+
+    await wrapper.find('input').setValue('diabetes')
+    await wrapper.find('input').setValue('')
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('resets the box and the store via the clear affordance', async () => {
+    const store = useConceptSearchStore()
+    const spy = vi.spyOn(store, 'clearSearch')
+
+    await wrapper.find('input').setValue('diabetes')
+    wrapper.findComponent({ name: 'AtlasTextField' }).vm.$emit('click:clear')
+    await wrapper.vm.$nextTick()
+
+    expect(spy).toHaveBeenCalled()
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('surfaces a store error', async () => {
+    useConceptSearchStore().error = 'boom'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('boom')
+  })
+
+  it('forwards pagination changes to the store', async () => {
+    const store = useConceptSearchStore()
+    const spy = vi.spyOn(store, 'updatePagination')
+
+    table(wrapper).vm.$emit('update:page', 3)
+    expect(spy).toHaveBeenLastCalledWith(3, store.itemsPerPage)
+
+    table(wrapper).vm.$emit('update:itemsPerPage', 50)
+    expect(spy).toHaveBeenLastCalledWith(1, 50)
+  })
+
+  it('re-emits remove and view events from the table', async () => {
+    table(wrapper).vm.$emit('remove-concept', A)
+    table(wrapper).vm.$emit('view-concept', { conceptId: 1, sourceKey: 'SYNPUF1K' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('remove-concept')?.[0]).toEqual([A])
+    expect(wrapper.emitted('view-concept')?.[0]).toEqual([{ conceptId: 1, sourceKey: 'SYNPUF1K' }])
+  })
+
+  it('marks concepts already in the open set', async () => {
+    const sets = useConceptSetsStore()
+    sets.currentSet = {
+      id: 7,
+      name: 'Set',
+      items: [{ ...A, isExcluded: false, includeDescendants: false, includeMapped: false }],
+    }
+    await wrapper.vm.$nextTick()
+
+    expect([...(table(wrapper).props('conceptsInSet') as Set<number>)]).toEqual([A.conceptId])
+  })
+})

--- a/tests/unit/components/concepts/ConceptSearchInline.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearchInline.spec.ts
@@ -234,7 +234,10 @@ describe('ConceptSearchInline search box and table wiring', () => {
     table().vm.$emit('view-concept', { conceptId: 1, sourceKey: 'SYNPUF1K' })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.emitted('add-concept')?.[0]).toEqual([concept])
+    expect(wrapper.emitted('add-concept')?.[0]).toEqual([
+      concept,
+      { isExcluded: false, includeDescendants: false, includeMapped: false },
+    ])
     expect(wrapper.emitted('remove-concept')?.[0]).toEqual([concept])
     expect(wrapper.emitted('view-concept')?.[0]).toEqual([{ conceptId: 1, sourceKey: 'SYNPUF1K' }])
   })

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -450,7 +450,33 @@ describe('ConceptSetEditor', () => {
     // Component is stubbed, so we can manually call the handler
     await wrapper.vm.onAddConcept(mockConcept)
 
-    expect(addConceptSpy).toHaveBeenCalledWith(mockConcept)
+    expect(addConceptSpy).toHaveBeenCalledWith(mockConcept, undefined)
+  })
+
+  it('should pass add-time flags straight through to the store', async () => {
+    const wrapper = mountComponent({ conceptSet: mockConceptSet })
+    const store = useConceptSetsStore()
+    store.currentSet = mockConceptSet
+    const addConceptSpy = vi.spyOn(store, 'addConceptToSet')
+    const flags = { isExcluded: true, includeDescendants: true, includeMapped: false }
+
+    await wrapper.vm.onAddConcept(mockConcept, flags)
+
+    expect(addConceptSpy).toHaveBeenCalledWith(mockConcept, flags)
+  })
+
+  it('should add every concept of a bulk add with the same flags', async () => {
+    const wrapper = mountComponent({ conceptSet: mockConceptSet })
+    const store = useConceptSetsStore()
+    store.currentSet = mockConceptSet
+    const addConceptSpy = vi.spyOn(store, 'addConceptToSet')
+    const second = { ...mockConcept, conceptId: mockConcept.conceptId + 1 }
+    const flags = { isExcluded: false, includeDescendants: true, includeMapped: false }
+
+    await wrapper.vm.onAddConcepts([mockConcept, second], flags)
+
+    expect(addConceptSpy).toHaveBeenNthCalledWith(1, mockConcept, flags)
+    expect(addConceptSpy).toHaveBeenNthCalledWith(2, second, flags)
   })
 
   it('should remove concept from set when remove-concept is emitted', async () => {

--- a/tests/unit/stores/concept-sets.add-flags.spec.ts
+++ b/tests/unit/stores/concept-sets.add-flags.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import type { Concept } from '@/models/concept-set.types'
+
+vi.mock('@/services/concept-set.service', () => ({
+  getConceptSets: vi.fn().mockResolvedValue([]),
+  getConceptSetById: vi.fn(),
+  createConceptSet: vi.fn(),
+  updateConceptSet: vi.fn(),
+  deleteConceptSet: vi.fn(),
+  getConceptSetExpression: vi.fn(),
+  getConceptSetItems: vi.fn(),
+  saveConceptSetItems: vi.fn(),
+  checkConceptSetName: vi.fn(),
+}))
+
+vi.mock('@/services/concept-search.service', () => ({
+  getRecommendedConcepts: vi.fn(),
+  getConceptRecordCounts: vi.fn(),
+  compareConceptSets: vi.fn(),
+  resolveConceptSetExpression: vi.fn(),
+  getMappedSourceCodes: vi.fn(),
+}))
+
+vi.mock('@/stores/webapi', () => ({
+  useWebAPIStore: vi.fn(() => ({ getValidVocabularySource: () => 'SRC', sources: [] })),
+}))
+
+const concept: Concept = {
+  conceptId: 313217,
+  conceptName: 'Atrial fibrillation',
+  conceptCode: '49436004',
+  domainId: 'Condition',
+  vocabularyId: 'SNOMED',
+  conceptClassId: 'Clinical Finding',
+  standardConcept: 'S',
+  invalidReason: null,
+}
+
+describe('addConceptToSet — add-time flags (#163)', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  function store() {
+    const s = useConceptSetsStore()
+    s.currentSet = { name: 'Test', items: [] }
+    return s
+  }
+
+  it('defaults every flag to false when none are given', () => {
+    const s = store()
+    s.addConceptToSet(concept)
+
+    expect(s.currentSet?.items[0]).toMatchObject({
+      isExcluded: false,
+      includeDescendants: false,
+      includeMapped: false,
+    })
+  })
+
+  it('applies descendants at add time', () => {
+    const s = store()
+    s.addConceptToSet(concept, { includeDescendants: true })
+
+    expect(s.currentSet?.items[0]).toMatchObject({
+      isExcluded: false,
+      includeDescendants: true,
+      includeMapped: false,
+    })
+  })
+
+  it('applies exclude and mapped at add time', () => {
+    const s = store()
+    s.addConceptToSet(concept, { isExcluded: true, includeMapped: true })
+
+    expect(s.currentSet?.items[0]).toMatchObject({
+      isExcluded: true,
+      includeDescendants: false,
+      includeMapped: true,
+    })
+  })
+
+  it('applies all three together', () => {
+    const s = store()
+    s.addConceptToSet(concept, {
+      isExcluded: true,
+      includeDescendants: true,
+      includeMapped: true,
+    })
+
+    expect(s.currentSet?.items[0]).toMatchObject({
+      isExcluded: true,
+      includeDescendants: true,
+      includeMapped: true,
+    })
+  })
+
+  it('still rejects a duplicate regardless of the flags supplied', () => {
+    const s = store()
+    s.addConceptToSet(concept, { includeDescendants: true })
+    s.addConceptToSet(concept, { isExcluded: true })
+
+    expect(s.currentSet?.items).toHaveLength(1)
+    expect(s.currentSet?.items[0]?.includeDescendants).toBe(true)
+    expect(s.currentSet?.items[0]?.isExcluded).toBe(false)
+    expect(s.error).toBe('Concept already exists in this set')
+  })
+
+  it('keeps flags independent per concept', () => {
+    const s = store()
+    s.addConceptToSet(concept, { includeDescendants: true })
+    s.addConceptToSet({ ...concept, conceptId: 999 }, { isExcluded: true })
+
+    expect(s.currentSet?.items[0]).toMatchObject({ includeDescendants: true, isExcluded: false })
+    expect(s.currentSet?.items[1]).toMatchObject({ includeDescendants: false, isExcluded: true })
+  })
+})


### PR DESCRIPTION
Fixes #163.

Search results offered a bare Add button, so the only way to mark a concept as excluded, or to pull in its descendants or mapped codes, was to add it first and then flip the flags one row at a time in the editor. Across several searches that means remembering the intent for every concept you collected — which is exactly the failure mode the issue describes.

This restores Atlas 2's add box: set the intent once, then collect concepts.

### Changes

- **`addConceptToSet(concept, flags?)`** — new `ConceptAddFlags` type. `conceptToConceptSetItem` already accepted the options; the store was dropping them.
- **New `ConceptAddOptions.vue`** — Descendants / Mapped / Exclude toggles plus a bulk **Add To Concept Set (N)** button.
- **Both search surfaces** (the standalone Concept Search page and the concept set editor's Search tab) render it with row selection enabled, so a whole selection can be added under one set of flags. The per-row Add button applies the same flags, and they persist across searches deliberately.
- **RecommendTab de-duplicated** — it carried its own copy of the three toggles and faked the flags by adding a concept and then calling `toggleConceptFlag` three times. It now shares the component and passes them directly, so that file gets smaller.
- Registers the `cs.conceptAddBox.*` keys, which RecommendTab had been referencing without them existing in `en.json`.

### Tests

`concept-sets.add-flags` (6), `ConceptAddOptions` (7), `ConceptSearch.add-options` (9), `ConceptSearchInline.add-options` (6), plus two new `ConceptSetEditor` cases for flag pass-through and bulk add. All written before the implementation.
