### PR TITLE
fix: retry transient trexsql cache-status errors and persist tags added on save

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -1036,6 +1036,13 @@ async function onSave() {
   try {
     let result
 
+    // Snapshot before the save: persisting mutates the store's concept set, which
+    // re-runs the props.conceptSet watcher and resets both refs to the still
+    // tag-less persisted value. Reading them after the await would diff nothing,
+    // so a newly added tag would never be assigned.
+    const tagsBeforeSave = [...loadedTags.value]
+    const tagsToPersist = [...selectedTags.value]
+
     if (isEditMode.value && props.conceptSet?.id) {
       result = await store.update({
         ...props.conceptSet,
@@ -1052,13 +1059,13 @@ async function onSave() {
     if (result) {
       const savedId = result?.id
       if (savedId !== undefined && savedId !== null) {
-        const tagResult = await store.syncTags(savedId, loadedTags.value, selectedTags.value)
+        const tagResult = await store.syncTags(savedId, tagsBeforeSave, tagsToPersist)
         if (!tagResult.success) {
           notify.danger(tv('conceptSets.tagUpdateFailed', 'Failed to update tags'), {
             message: tagResult.error,
           })
         }
-        loadedTags.value = [...selectedTags.value]
+        loadedTags.value = [...tagsToPersist]
       }
       hasUnsavedChanges.value = false
       emit('save')

--- a/src/services/trexsql.service.ts
+++ b/src/services/trexsql.service.ts
@@ -128,7 +128,18 @@ function mapCacheStatusResponse(
   }
 }
 
-export async function getCacheStatus(sourceKey: string): Promise<TrexSQLCacheStatus> {
+// `cacheExists && !cacheAttached` reports as "error", but that combination is
+// also the momentary state during a benign attach retry, when the cache is built
+// and about to become healthy. Treating it as terminal makes every consumer — the
+// data-source list, the live count gate, the config page — give up on a cache that
+// works seconds later. Re-check a bounded number of times before believing it.
+const CACHE_STATUS_ERROR_RETRIES = 5
+const CACHE_STATUS_RETRY_DELAY_MS = 2500
+
+export async function getCacheStatus(
+  sourceKey: string,
+  attempt = 0
+): Promise<TrexSQLCacheStatus> {
   const url = `${getBaseUrl()}/trexsql/${sourceKey}/cache/status`
 
   try {
@@ -164,12 +175,14 @@ export async function getCacheStatus(sourceKey: string): Promise<TrexSQLCacheSta
     const data = await response.json()
 
     const result = TrexSQLCacheStatusSchema.safeParse(data)
-    if (result.success) {
-      return result.data
+    const status = result.success ? result.data : mapCacheStatusResponse(sourceKey, data)
+
+    if (status.status === 'error' && attempt < CACHE_STATUS_ERROR_RETRIES) {
+      await new Promise(resolve => setTimeout(resolve, CACHE_STATUS_RETRY_DELAY_MS))
+      return getCacheStatus(sourceKey, attempt + 1)
     }
 
-    const mappedStatus = mapCacheStatusResponse(sourceKey, data)
-    return mappedStatus
+    return status
   } catch (error) {
     logger.error('TrexSQL', 'Failed to get cache status', { sourceKey, error })
     throw error

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -853,5 +853,35 @@ describe('ConceptSetEditor', () => {
         expect.objectContaining({ message: 'Tag "protected" may only be assigned once' })
       )
     })
+
+    it('assigns a newly added tag even though saving re-seeds the tag refs', async () => {
+      const store = useConceptSetsStore()
+      const newTag = { id: 42, name: 'cardiology' }
+      vi.spyOn(store, 'syncTags').mockResolvedValue({ success: true })
+
+      const wrapper = mountComponent({ conceptSet: { ...mockConceptSet, tags: [] } })
+      await flushPromises()
+
+      // Persisting hands back a concept set that does not carry the pending tag
+      // yet. In the app that value flows straight back into props.conceptSet, so
+      // the seeding watcher runs mid-save and clears both refs — reading them
+      // after the await would diff nothing and silently drop the tag.
+      vi.spyOn(store, 'update').mockImplementation(async () => {
+        const persisted = { ...mockConceptSet, tags: [] }
+        await wrapper.setProps({ conceptSet: persisted })
+        return persisted
+      })
+
+      const vm = wrapper.vm as unknown as {
+        formValid: boolean
+        selectedTags: typeof newTag[]
+        onSave: () => Promise<void>
+      }
+      vm.selectedTags = [newTag]
+      vm.formValid = true
+      await vm.onSave()
+
+      expect(store.syncTags).toHaveBeenCalledWith(mockConceptSet.id, [], [newTag])
+    })
   })
 })

--- a/tests/unit/services/trexsql.service.spec.ts
+++ b/tests/unit/services/trexsql.service.spec.ts
@@ -218,10 +218,59 @@ describe('TrexSQLService', () => {
         })
       } as Response)
 
-      const result = await getCacheStatus('CDM_SOURCE')
+      // A persistent error is retried before it is believed; drive the backoff
+      // with fake timers so the assertion does not wait out the real delays.
+      vi.useFakeTimers()
+      try {
+        const pending = getCacheStatus('CDM_SOURCE')
+        await vi.runAllTimersAsync()
+        const result = await pending
 
-      expect(result.status).toBe('error')
-      expect(result.errorMessage).toBe('Cache attachment failed')
+        expect(result.status).toBe('error')
+        expect(result.errorMessage).toBe('Cache attachment failed')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('re-checks a transient error and returns the recovered status', async () => {
+      const errorResponse = {
+        ok: true,
+        json: async () => ({
+          sourceKey: 'CDM_SOURCE',
+          cacheExists: true,
+          cacheAttached: false,
+          activeJob: false,
+          errorMessage: 'Cache attachment failed'
+        })
+      } as Response
+      const readyResponse = {
+        ok: true,
+        json: async () => ({
+          sourceKey: 'CDM_SOURCE',
+          cacheExists: true,
+          cacheAttached: true,
+          activeJob: false
+        })
+      } as Response
+
+      // trexsql reports cacheExists && !cacheAttached mid attach-retry; the next
+      // poll shows it healthy, and that recovery is what callers must observe.
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(errorResponse)
+        .mockResolvedValue(readyResponse)
+
+      vi.useFakeTimers()
+      try {
+        const pending = getCacheStatus('CDM_SOURCE')
+        await vi.runAllTimersAsync()
+        const result = await pending
+
+        expect(result.status).toBe('ready')
+        expect(vi.mocked(global.fetch).mock.calls.length).toBeGreaterThan(1)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('throws on other errors', async () => {


### PR DESCRIPTION
Two independent bugs, one commit each.

**Transient cache-status error** — `getCacheStatus` maps `cacheExists && !cacheAttached` to `error`, but that is also the momentary state while an attach is being retried, when the cache is built and healthy moments later. Treating it as terminal makes the data-source list, the live count gate and the config page all give up on a cache that is about to work. Now re-checked with a bounded backoff.

**Tags added on save were dropped** — `ConceptSetEditor` passed `loadedTags`/`selectedTags` to `syncTags` after awaiting the save. Persisting feeds the stored concept set back into `props.conceptSet`, which re-runs the seeding watcher and resets both refs to the still tag-less persisted value, so the diff came out empty. Both refs are now snapshotted before the await.

Each fix has a test. The tag one fails without the change; the cache-status suite uses fake timers so the backoff does not slow it down.