### PR TITLE
feat(theme): make the accent color and chart palettes configurable

### DIFF
--- a/src/components/cohort-builder/GroupCriteriaUI.vue
+++ b/src/components/cohort-builder/GroupCriteriaUI.vue
@@ -557,7 +557,7 @@ defineExpose({
 
 /* ANY - Orange */
 .vertical-label-container:has(.match-type-label[data-type='ANY']) {
-  border: 1px solid #eb6622;
+  border: 1px solid var(--atlas-color-accent);
 }
 .vertical-label-container:has(.match-type-label[data-type='ANY'])::before {
   content: '';
@@ -566,11 +566,11 @@ defineExpose({
   top: 0;
   bottom: 0;
   width: 30%;
-  background: #eb6622;
+  background: var(--atlas-color-accent);
   border-radius: 0 0 0 6px;
 }
 .match-type-label[data-type='ANY'] {
-  color: #eb6622;
+  color: var(--atlas-color-accent);
 }
 
 /* AT_LEAST - Light Blue */
@@ -629,7 +629,7 @@ defineExpose({
   color: #1f425a !important;
 }
 .match-chip--any.v-btn--variant-tonal {
-  color: #eb6622 !important;
+  color: var(--atlas-color-accent) !important;
 }
 .match-chip--at_least.v-btn--variant-tonal {
   color: #4a90ba !important;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { createApp, watch } from 'vue'
 import { createPinia } from 'pinia'
 import router from './router'
 import { createVuetifyInstance } from './plugins/vuetify'
+import { setChartPalette } from './ui/chart-config'
 import { pluginConfigService } from './services/PluginConfigService'
 import App from './App.vue'
 import { setupAuthInterceptor } from './services/auth/authInterceptor'
@@ -93,6 +94,22 @@ async function initializeApp() {
     primaryColor = pluginConfigService.getPrimaryColor()
     if (primaryColor) {
       logger.info('Main', 'Using custom primary color from plugins.json:', primaryColor)
+    }
+
+    // Accent lives in CSS (--atlas-color-accent), not the Vuetify theme, so set it
+    // on the root element where it wins over the :root defaults in tokens.css.
+    const accentColor = pluginConfigService.getAccentColor()
+    if (accentColor) {
+      document.documentElement.style.setProperty('--atlas-color-accent', accentColor)
+      logger.info('Main', 'Using custom accent color from plugins.json:', accentColor)
+    }
+
+    // Applied before the app mounts, so the first chart already renders branded.
+    const chartColors = pluginConfigService.getChartColors()
+    const treemapGradient = pluginConfigService.getTreemapGradient()
+    if (chartColors || treemapGradient) {
+      setChartPalette({ chartColors, treemapGradient })
+      logger.info('Main', 'Using custom chart palette from plugins.json')
     }
   } catch (error) {
     logger.warn('Main', 'Failed to load plugin config for theme, using defaults:', error)

--- a/src/models/PluginModels.ts
+++ b/src/models/PluginModels.ts
@@ -108,9 +108,12 @@ export interface PluginManifest {
     }
     theme?: {
       primaryColor?: string // Primary theme color override (hex color code, e.g., '#1f425a')
+      accentColor?: string // Accent color override (hex color code); drives --atlas-color-accent
       logoUrl?: string // Custom logo URL/path (replaces default OHDSI + ATLAS logos)
       logoNavigateTo?: string // Route to navigate to when clicking the logo (default: '/')
       landingLogoUrl?: string // Custom landing-page hero logo URL/path (replaces bundled atlas-loading.svg)
+      chartColors?: string[] // Categorical chart palette override; multi-series charts cycle through it
+      treemapGradient?: string[] // Color-by-value gradient override (light -> dark), used by treemaps
     }
     header?: {
       showNavBar?: boolean // Show/hide the entire navigation bar (default: true)
@@ -324,9 +327,21 @@ export const PluginManifestSchema = z.object({
             .string()
             .regex(hexColorRegex, 'Invalid hex color for primaryColor')
             .optional(),
+          accentColor: z
+            .string()
+            .regex(hexColorRegex, 'Invalid hex color for accentColor')
+            .optional(),
           logoUrl: z.string().optional(),
           logoNavigateTo: z.string().optional(),
           landingLogoUrl: z.string().optional(),
+          chartColors: z
+            .array(z.string().regex(hexColorRegex, 'Invalid hex color in chartColors'))
+            .nonempty()
+            .optional(),
+          treemapGradient: z
+            .array(z.string().regex(hexColorRegex, 'Invalid hex color in treemapGradient'))
+            .nonempty()
+            .optional(),
         })
         .optional(),
       header: z

--- a/src/services/PluginConfigService.ts
+++ b/src/services/PluginConfigService.ts
@@ -117,6 +117,20 @@ export class PluginConfigService {
     return this.manifest?.settings?.theme?.primaryColor || null
   }
 
+  getAccentColor(): string | null {
+    return this.manifest?.settings?.theme?.accentColor || null
+  }
+
+  getChartColors(): string[] | null {
+    const colors = this.manifest?.settings?.theme?.chartColors
+    return colors && colors.length > 0 ? colors : null
+  }
+
+  getTreemapGradient(): string[] | null {
+    const gradient = this.manifest?.settings?.theme?.treemapGradient
+    return gradient && gradient.length > 0 ? gradient : null
+  }
+
   getLogoUrl(): string | null {
     const logoUrl = this.manifest?.settings?.theme?.logoUrl || null
     logger.debug('PluginConfig', 'getLogoUrl called, returning', logoUrl)

--- a/src/ui/chart-config.ts
+++ b/src/ui/chart-config.ts
@@ -95,7 +95,7 @@ function formatSINumber(value: number): string {
  * Charts that pick a single color use CHART_COLORS[0]; multi-series
  * charts cycle through the array.
  */
-export const CHART_COLORS = [
+const DEFAULT_CHART_COLORS: readonly string[] = [
   '#4e79a7', // blue
   '#f28e2c', // orange
   '#e15759', // red
@@ -107,6 +107,12 @@ export const CHART_COLORS = [
   '#9c755f', // taupe
   '#bab0ab', // warm grey
 ]
+
+// Deployments that brand Atlas override these via settings.theme (see
+// setChartPalette). Every read happens inside the option builders below, at
+// render time, so a palette applied during startup is picked up by charts
+// mounted afterwards.
+export let CHART_COLORS: readonly string[] = DEFAULT_CHART_COLORS
 
 /**
  * Single-hue gradient used by treemaps and other "color-by-value"
@@ -122,7 +128,24 @@ export const CHART_COLORS = [
  * the Atlas brand navy `#1f425a` so the gradient tails into the
  * surrounding chrome.
  */
-export const TREEMAP_GRADIENT = ['#7e9bbf', '#4e79a7', '#1f425a'] as const
+const DEFAULT_TREEMAP_GRADIENT: readonly string[] = ['#7e9bbf', '#4e79a7', '#1f425a']
+
+export let TREEMAP_GRADIENT: readonly string[] = DEFAULT_TREEMAP_GRADIENT
+
+/**
+ * Override the chart palettes from `settings.theme` (chartColors /
+ * treemapGradient). Passing null or an empty array restores the default, so a
+ * deployment can override one palette without pinning the other.
+ */
+export function setChartPalette(palette: {
+  chartColors?: readonly string[] | null
+  treemapGradient?: readonly string[] | null
+}): void {
+  CHART_COLORS = palette.chartColors?.length ? [...palette.chartColors] : DEFAULT_CHART_COLORS
+  TREEMAP_GRADIENT = palette.treemapGradient?.length
+    ? [...palette.treemapGradient]
+    : DEFAULT_TREEMAP_GRADIENT
+}
 
 /**
  * Default bar chart configuration

--- a/tests/unit/services/PluginConfigService.spec.ts
+++ b/tests/unit/services/PluginConfigService.spec.ts
@@ -294,6 +294,44 @@ describe('PluginConfigService', () => {
     })
   })
 
+  describe('accent and chart palette settings', () => {
+    const loadTheme = async (theme: Record<string, unknown>) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ version: '1.0', plugins: [], settings: { theme } }),
+      })
+      await service.loadConfig()
+    }
+
+    it('returns null for each when the theme omits them', async () => {
+      await loadTheme({ primaryColor: '#FF5733' })
+
+      expect(service.getAccentColor()).toBeNull()
+      expect(service.getChartColors()).toBeNull()
+      expect(service.getTreemapGradient()).toBeNull()
+    })
+
+    it('returns the configured accent and palettes', async () => {
+      await loadTheme({
+        accentColor: '#ff5e59',
+        chartColors: ['#000080', '#ff5e59'],
+        treemapGradient: ['#c3cce8', '#4a5fb0', '#000080'],
+      })
+
+      expect(service.getAccentColor()).toBe('#ff5e59')
+      expect(service.getChartColors()).toEqual(['#000080', '#ff5e59'])
+      expect(service.getTreemapGradient()).toEqual(['#c3cce8', '#4a5fb0', '#000080'])
+    })
+
+    it('treats an empty palette as unset so the default survives', async () => {
+      await loadTheme({ chartColors: [], treemapGradient: [] })
+
+      expect(service.getChartColors()).toBeNull()
+      expect(service.getTreemapGradient()).toBeNull()
+    })
+  })
+
   describe('getLogoUrl', () => {
     it('should return null before loading', () => {
       expect(service.getLogoUrl()).toBeNull()

--- a/tests/unit/ui/chart-config.spec.ts
+++ b/tests/unit/ui/chart-config.spec.ts
@@ -1,5 +1,63 @@
-import { describe, it, expect } from 'vitest'
-import { parseYyyymm, dashboardObservationMonthLineOptions } from '@/ui/chart-config'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  parseYyyymm,
+  dashboardObservationMonthLineOptions,
+  setChartPalette,
+  CHART_COLORS,
+  TREEMAP_GRADIENT,
+} from '@/ui/chart-config'
+
+describe('setChartPalette', () => {
+  afterEach(() => {
+    setChartPalette({ chartColors: null, treemapGradient: null })
+  })
+
+  it('overrides both palettes', () => {
+    setChartPalette({
+      chartColors: ['#000080', '#ff5e59'],
+      treemapGradient: ['#c3cce8', '#000080'],
+    })
+
+    expect([...CHART_COLORS]).toEqual(['#000080', '#ff5e59'])
+    expect([...TREEMAP_GRADIENT]).toEqual(['#c3cce8', '#000080'])
+  })
+
+  it('restores the defaults when passed null or an empty array', () => {
+    const defaultColors = [...CHART_COLORS]
+    const defaultGradient = [...TREEMAP_GRADIENT]
+
+    setChartPalette({ chartColors: ['#000080'], treemapGradient: ['#000080'] })
+    setChartPalette({ chartColors: null, treemapGradient: [] })
+
+    expect([...CHART_COLORS]).toEqual(defaultColors)
+    expect([...TREEMAP_GRADIENT]).toEqual(defaultGradient)
+  })
+
+  it('overrides one palette without disturbing the other', () => {
+    const defaultGradient = [...TREEMAP_GRADIENT]
+
+    setChartPalette({ chartColors: ['#000080'] })
+
+    expect([...CHART_COLORS]).toEqual(['#000080'])
+    expect([...TREEMAP_GRADIENT]).toEqual(defaultGradient)
+  })
+
+  // The builders read the palette at call time; charts would otherwise keep
+  // whatever was captured when the module first evaluated.
+  it('reaches options built after the override', () => {
+    setChartPalette({ chartColors: ['#000080', '#ff5e59'] })
+
+    const options = dashboardObservationMonthLineOptions({
+      categories: ['01/2003'],
+      monthCodes: [200301],
+      series: [{ name: 'Observations', data: [10] }],
+      xAxisLabel: 'Month',
+      yAxisLabel: 'Observations',
+    }) as { series?: Array<Record<string, unknown>> }
+
+    expect(JSON.stringify(options.series)).toContain('#000080')
+  })
+})
 
 describe('parseYyyymm', () => {
   it('parses a YYYYMM integer to a UTC timestamp', () => {


### PR DESCRIPTION
`settings.theme` already exposes `primaryColor`, `logoUrl` and `landingLogoUrl`, but the accent color and the two chart palettes were compile-time constants. A deployment that brands Atlas has no way to reach them except by string-replacing hex codes in the built bundle — which silently stops matching the moment a palette is edited or the build remangles, leaving the default colors in place with no error.

## Adds

| setting | overrides |
|---|---|
| `theme.accentColor` | `--atlas-color-accent` |
| `theme.chartColors` | categorical palette — multi-series charts cycle through it |
| `theme.treemapGradient` | color-by-value gradient used by treemaps |

Each falls back to today's value when unset, and an empty array counts as unset, so one palette can be overridden without pinning the other.

## Notes

`CHART_COLORS` / `TREEMAP_GRADIENT` become overridable at startup via `setChartPalette`. Every read already happens inside the option builders at render time, so charts mounted after the override pick it up — there's a test asserting the color reaches built chart options, not just the exported array.

`GroupCriteriaUI` hardcoded the accent in four CSS rules, which no `accentColor` setting could have reached. Those now use `var(--atlas-color-accent)`.

Both palettes are consumed only inside `chart-config.ts`, so nothing outside it had to change.

## Verification

`vue-tsc --noEmit` clean; 65 tests pass across the two touched specs.