### PR TITLE
fix(config): stop double-listing cache builds

### DIFF
--- a/src/components/config/CacheFilesSection.vue
+++ b/src/components/config/CacheFilesSection.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from '@/composables/useI18n'
+import { logger } from '@/utils/logger'
+import { AtlasAlert, AtlasDialog, AtlasProgressLinear, AtlasSpacer } from '@/components/ui'
+import { listCacheFiles, deleteCacheFile, type CacheFile } from '@/services/trexsql.service'
+
+const { t } = useI18n()
+
+const files = ref<CacheFile[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const deleting = ref<string | null>(null)
+const confirming = ref<CacheFile | null>(null)
+
+const totalBytes = computed(() => files.value.reduce((sum, f) => sum + (f.sizeBytes || 0), 0))
+const orphanCount = computed(() => files.value.filter(f => f.orphaned).length)
+const orphanBytes = computed(() =>
+  files.value.filter(f => f.orphaned).reduce((sum, f) => sum + (f.sizeBytes || 0), 0)
+)
+
+function formatBytes(bytes: number | null): string {
+  if (!bytes) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit++
+  }
+  return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`
+}
+
+function formatDate(ms: number | null): string {
+  if (!ms) return '—'
+  return new Date(ms).toLocaleString()
+}
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    files.value = await listCacheFiles()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+    logger.error('CacheFiles', 'Failed to list cache files', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function confirmDelete() {
+  const target = confirming.value
+  if (!target) return
+  confirming.value = null
+  deleting.value = target.databaseCode
+  try {
+    await deleteCacheFile(target.databaseCode)
+    await load()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+    logger.error('CacheFiles', `Failed to delete ${target.databaseCode}`, err)
+  } finally {
+    deleting.value = null
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="cache-files-section">
+    <v-card>
+      <v-card-title class="d-flex align-center">
+        <AtlasIcon
+          start
+          color="primary"
+        >
+          mdi-database-cog
+        </AtlasIcon>
+        {{ t('trexsql.cacheFilesTitle', 'Cache files on disk') }}
+        <AtlasSpacer />
+        <AtlasButton
+          variant="ghost"
+          :loading="loading"
+          data-testid="cache-files-refresh"
+          @click="load"
+        >
+          {{ t('common.refresh', 'Refresh') }}
+        </AtlasButton>
+      </v-card-title>
+
+      <v-card-text>
+        <p class="text-body-2 mb-4">
+          {{
+            t(
+              'trexsql.cacheFilesDescription',
+              'Every cache on disk, including caches whose dataset has been deleted. Those are no longer reachable from the dataset list and can be reclaimed here.'
+            )
+          }}
+        </p>
+
+        <AtlasAlert
+          v-if="error"
+          severity="danger"
+          class="mb-4"
+          data-testid="cache-files-error"
+        >
+          {{ error }}
+        </AtlasAlert>
+
+        <div
+          v-if="files.length"
+          class="summary mb-3"
+          data-testid="cache-files-summary"
+        >
+          <span>{{ files.length }} {{ t('trexsql.cacheFilesCount', 'files') }}</span>
+          <span>{{ formatBytes(totalBytes) }}</span>
+          <span v-if="orphanCount">
+            {{ orphanCount }}
+            {{ t('trexsql.cacheFilesOrphaned', 'orphaned') }}
+            ({{ formatBytes(orphanBytes) }})
+          </span>
+        </div>
+
+        <AtlasProgressLinear
+          v-if="loading && !files.length"
+          indeterminate
+        />
+
+        <v-table
+          v-else-if="files.length"
+          density="compact"
+          data-testid="cache-files-table"
+        >
+          <thead>
+            <tr>
+              <th>{{ t('trexsql.cacheFileName', 'Cache') }}</th>
+              <th class="text-right">
+                {{ t('trexsql.cacheFileSize', 'Size') }}
+              </th>
+              <th>{{ t('trexsql.cacheFileModified', 'Last modified') }}</th>
+              <th>{{ t('common.status', 'Status') }}</th>
+              <th class="text-right">
+                {{ t('common.actions', 'Actions') }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="file in files"
+              :key="file.fileName"
+              :data-testid="`cache-file-${file.databaseCode}`"
+            >
+              <td class="mono">
+                {{ file.databaseCode }}
+              </td>
+              <td class="text-right">
+                {{ formatBytes(file.sizeBytes) }}
+              </td>
+              <td>{{ formatDate(file.lastModified) }}</td>
+              <td>
+                <AtlasChip
+                  v-if="file.protected"
+                  size="sm"
+                  tone="default"
+                >
+                  {{ t('trexsql.cacheFileProtected', 'System') }}
+                </AtlasChip>
+                <AtlasChip
+                  v-else-if="file.orphaned"
+                  size="sm"
+                  tone="warning"
+                >
+                  {{ t('trexsql.cacheFileOrphaned', 'No dataset') }}
+                </AtlasChip>
+                <AtlasChip
+                  v-else-if="file.attached"
+                  size="sm"
+                  tone="primary"
+                >
+                  {{ t('trexsql.cacheFileAttached', 'Attached') }}
+                </AtlasChip>
+                <span v-else>—</span>
+              </td>
+              <td class="text-right">
+                <AtlasButton
+                  variant="ghost"
+                  tone="danger"
+                  size="sm"
+                  :disabled="file.protected"
+                  :loading="deleting === file.databaseCode"
+                  :data-testid="`cache-file-delete-${file.databaseCode}`"
+                  @click="confirming = file"
+                >
+                  {{ t('common.delete', 'Delete') }}
+                </AtlasButton>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+
+        <p
+          v-else-if="!loading"
+          class="text-body-2"
+        >
+          {{ t('trexsql.cacheFilesEmpty', 'No cache files found.') }}
+        </p>
+      </v-card-text>
+    </v-card>
+
+    <AtlasDialog
+      :model-value="confirming !== null"
+      :title="t('trexsql.cacheFileDeleteTitle', 'Delete cache?').value"
+      max-width="480"
+      @update:model-value="confirming = null"
+    >
+      <template v-if="confirming">
+        <p class="mb-2">
+          <span class="mono">{{ confirming.databaseCode }}</span>
+          &mdash; {{ formatBytes(confirming.sizeBytes) }}
+        </p>
+        <p class="text-body-2">
+          {{
+            confirming.orphaned
+              ? t(
+                'trexsql.cacheFileDeleteOrphan',
+                'No dataset references this cache. Deleting it frees the space and cannot be undone.'
+              )
+              : t(
+                'trexsql.cacheFileDeleteActive',
+                'This cache belongs to a dataset that is still registered. It will have to be rebuilt before that dataset can be queried again.'
+              )
+          }}
+        </p>
+      </template>
+      <template #actions>
+        <AtlasButton
+          variant="ghost"
+          @click="confirming = null"
+        >
+          {{ t('common.cancel', 'Cancel') }}
+        </AtlasButton>
+        <AtlasButton
+          tone="danger"
+          data-testid="cache-file-delete-confirm"
+          @click="confirmDelete"
+        >
+          {{ t('common.delete', 'Delete') }}
+        </AtlasButton>
+      </template>
+    </AtlasDialog>
+  </div>
+</template>
+
+<style scoped>
+.summary {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.6);
+}
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+</style>

--- a/src/components/config/CacheManagementSection.vue
+++ b/src/components/config/CacheManagementSection.vue
@@ -78,6 +78,9 @@
 
     <!-- TrexSQL Cache Section -->
     <TrexSQLCacheSection />
+
+    <!-- Caches on disk, including ones whose dataset is gone -->
+    <CacheFilesSection class="mt-4" />
   </div>
 </template>
 
@@ -89,6 +92,7 @@ import { useI18n } from '@/composables/useI18n'
 import { useConfigStore } from '@/stores/config'
 import { logger } from '@/utils/logger'
 import TrexSQLCacheSection from './TrexSQLCacheSection.vue'
+import CacheFilesSection from './CacheFilesSection.vue'
 
 const { t, tv } = useI18n()
 const configStore = useConfigStore()

--- a/src/services/jobs.service.ts
+++ b/src/services/jobs.service.ts
@@ -12,104 +12,8 @@ import {
   JobExecutionListSchema,
   type Job,
   type JobExecution,
-  type JobStatus,
   transformJobExecution,
 } from '@/models/jobs.types'
-
-/**
- * Bao cache-build job. Returned by `GET /WebAPI/trexsql/cache/jobs`.
- * Source: bao plugin tracks each cache build in `_cache_jobs.cache_generation_info`.
- */
-interface CacheJobApi {
-  databaseCode?: string
-  sourceKey?: string
-  status?: string
-  startTime?: string | null
-  endTime?: string | null
-  totalTables?: number | null
-  completedTables?: number | null
-  error?: string | null
-}
-
-const CACHE_STATUS_MAP: Record<string, JobStatus> = {
-  RUNNING: 'RUNNING',
-  COMPLETE: 'COMPLETED',
-  COMPLETED: 'COMPLETED',
-  ERROR: 'FAILED',
-  FAILED: 'FAILED',
-  CANCELED: 'STOPPED',
-  CANCELLED: 'STOPPED',
-  STOPPED: 'STOPPED',
-}
-
-function parseTimestamp(s: string | null | undefined): Date | null {
-  if (!s) return null
-  // bao serializes LocalDateTime as a microseconds-since-epoch string for some
-  // builds and as ISO-8601 for others — tolerate both.
-  const trimmed = String(s).trim()
-  if (!trimmed) return null
-  if (/^\d+$/.test(trimmed)) {
-    const n = Number(trimmed)
-    // Heuristic: > 1e15 → microseconds, > 1e12 → milliseconds, else seconds.
-    if (n > 1e15) return new Date(Math.floor(n / 1000))
-    if (n > 1e12) return new Date(n)
-    return new Date(n * 1000)
-  }
-  const d = new Date(trimmed)
-  return isNaN(d.getTime()) ? null : d
-}
-
-/**
- * Convert a bao cache job into the unified `Job` shape used by the UI.
- * `executionId` is synthesized from a hash of the database-code so the table
- * has a stable per-cache-build identifier (cache jobs aren't in Spring Batch).
- */
-function transformCacheJob(c: CacheJobApi): Job | null {
-  const dbCode = c.databaseCode ?? c.sourceKey
-  if (!dbCode) return null
-  const startTime = parseTimestamp(c.startTime)
-  const endTime = parseTimestamp(c.endTime)
-  const status: JobStatus = CACHE_STATUS_MAP[String(c.status ?? '').toUpperCase()] ?? 'UNKNOWN'
-  // Stable synthetic id from databaseCode + startTime. Use a small hash so the
-  // numeric id stays compact for display.
-  const idStr = `${dbCode}|${c.startTime ?? ''}`
-  let h = 0
-  for (let i = 0; i < idStr.length; i++) h = ((h << 5) - h + idStr.charCodeAt(i)) | 0
-  const id = Math.abs(h)
-  const total = c.totalTables ?? 0
-  const completed = c.completedTables ?? 0
-  const progressSuffix = total > 0 ? ` (${completed}/${total} tables)` : ''
-  return {
-    id,
-    executionId: id,
-    type: 'cacheGeneration',
-    name: `Cache build — ${dbCode}${progressSuffix}`,
-    status,
-    author: '',
-    startTime,
-    endTime,
-    duration: startTime && endTime ? endTime.getTime() - startTime.getTime() : null,
-    entityId: null,
-    sourceKey: c.sourceKey ?? dbCode,
-    exitMessage: c.error ?? null,
-  }
-}
-
-async function fetchCacheJobs(): Promise<Job[]> {
-  try {
-    const data = await httpGet<unknown>('/trexsql/cache/jobs')
-    const list = (data && typeof data === 'object' && 'jobs' in data
-      ? (data as { jobs?: unknown }).jobs
-      : null) as CacheJobApi[] | null
-    if (!Array.isArray(list)) return []
-    return list.map(transformCacheJob).filter((j): j is Job => j !== null)
-  } catch (err) {
-    // Cache-job tracking is optional — never let a bao failure break the
-    // rest of the jobs view.
-    logger.debug('JobsService', 'Cache jobs fetch failed (non-fatal)', err)
-    return []
-  }
-}
 
 /**
  * Extract job executions from the response
@@ -140,13 +44,13 @@ function extractExecutions(data: unknown): JobExecution[] {
  */
 export async function getJobs(): Promise<ApiResult<Job[]>> {
   try {
-    // Pull Spring Batch executions and bao cache-build jobs in parallel.
-    // Cache-build jobs run outside Spring Batch (in bao's own _cache_jobs
-    // tracking) so they need a separate fetch + merge.
-    const [batchData, cacheJobs] = await Promise.all([
-      httpGet<unknown>('/job/execution?comprehensivePage=true'),
-      fetchCacheJobs(),
-    ])
+    // Cache builds now write a Spring Batch execution of their own
+    // (job_name "cacheGeneration"), on every dialect rather than only the
+    // JDBC ones, so they arrive with every other job. Merging bao's
+    // /trexsql/cache/jobs on top would list each build twice. That endpoint
+    // is still the source for per-table progress and cache errors — the
+    // cache view reads it directly.
+    const batchData = await httpGet<unknown>('/job/execution?comprehensivePage=true')
 
     // Validate Spring Batch response with Zod
     const parsed = JobExecutionListSchema.safeParse(batchData)
@@ -159,8 +63,7 @@ export async function getJobs(): Promise<ApiResult<Job[]>> {
     // Extract executions from response (handles both array and paginated formats)
     const executions = extractExecutions(parsed.data)
 
-    // Transform to normalized Job format and merge with cache jobs
-    const jobs = [...executions.map(transformJobExecution), ...cacheJobs]
+    const jobs = executions.map(transformJobExecution)
 
     // Sort by start time descending (most recent first)
     jobs.sort((a, b) => {

--- a/src/services/trexsql.service.ts
+++ b/src/services/trexsql.service.ts
@@ -272,6 +272,55 @@ export async function getPatientCount(
   }
 }
 
+export interface CacheFile {
+  fileName: string
+  databaseCode: string
+  sizeBytes: number
+  lastModified: number | null
+  attached: boolean
+  /** No data source references this cache any more — safe to reclaim. */
+  orphaned: boolean
+  /** Not a dataset cache (job registry, FHIR database); listed but undeletable. */
+  protected: boolean
+}
+
+/**
+ * Every cache file on disk, including ones whose dataset has been deleted.
+ * Keyed by file rather than by source, which is the only way orphans surface —
+ * the per-source endpoints can't resolve them and answer 404.
+ */
+export async function listCacheFiles(): Promise<CacheFile[]> {
+  const url = `${getBaseUrl()}/trexsql/cache/files`
+  const authHeader = await getAuthHeader()
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', ...authHeader },
+  })
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    throw new Error(`Failed to list cache files: ${response.status} ${detail}`.trim())
+  }
+
+  const data = (await response.json()) as { files?: unknown }
+  return Array.isArray(data.files) ? (data.files as CacheFile[]) : []
+}
+
+/** Delete a cache by database code. Works whether or not a source still exists. */
+export async function deleteCacheFile(databaseCode: string): Promise<void> {
+  const url = `${getBaseUrl()}/trexsql/cache/files/${encodeURIComponent(databaseCode)}`
+  const authHeader = await getAuthHeader()
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', ...authHeader },
+  })
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '')
+    throw new Error(`Failed to delete cache: ${response.status} ${detail}`.trim())
+  }
+}
+
 export async function getAllCacheStatuses(): Promise<TrexSQLCacheStatus[]> {
   try {
     const { listDataSources } = await import('./datasource.service')

--- a/tests/component/config/CacheFilesSection.spec.ts
+++ b/tests/component/config/CacheFilesSection.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * CacheFilesSection tests
+ *
+ * Covers the behaviour that only exists because caches outlive their datasets:
+ * orphans are listed and deletable, protected files are listed and are not,
+ * and a delete only happens once confirmed.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+const listCacheFiles = vi.fn()
+const deleteCacheFile = vi.fn()
+
+vi.mock('@/services/trexsql.service', () => ({
+  listCacheFiles: (...args: unknown[]) => listCacheFiles(...args),
+  deleteCacheFile: (...args: unknown[]) => deleteCacheFile(...args),
+}))
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import CacheFilesSection from '@/components/config/CacheFilesSection.vue'
+
+const vuetify = createVuetify({ components, directives })
+
+const orphan = {
+  fileName: '_gone.db',
+  databaseCode: '_gone',
+  sizeBytes: 12288,
+  lastModified: 1754400000000,
+  attached: false,
+  orphaned: true,
+  protected: false,
+}
+
+const live = {
+  fileName: 'cdm_demo.db',
+  databaseCode: 'cdm_demo',
+  sizeBytes: 52428800,
+  lastModified: 1754400000000,
+  attached: true,
+  orphaned: false,
+  protected: false,
+}
+
+const jobsDb = {
+  fileName: '_cache_jobs.db',
+  databaseCode: '_cache_jobs',
+  sizeBytes: 12288,
+  lastModified: 1754400000000,
+  attached: false,
+  orphaned: false,
+  protected: true,
+}
+
+function makeStubs() {
+  const passthrough = { template: '<div><slot /></div>' }
+  return {
+    AtlasIcon: { template: '<i><slot /></i>' },
+    AtlasChip: passthrough,
+    AtlasSpacer: { template: '<span />' },
+    AtlasAlert: { template: '<div class="alert"><slot /></div>' },
+    AtlasProgressLinear: { template: '<div class="progress" />' },
+    AtlasDialog: {
+      props: ['modelValue'],
+      template:
+        '<div v-if="modelValue" class="dialog"><slot /><slot name="actions" /></div>',
+    },
+    AtlasButton: {
+      name: 'AtlasButton',
+      props: ['loading', 'disabled'],
+      emits: ['click'],
+      template:
+        '<button :disabled="disabled" v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+    },
+  }
+}
+
+function mountSection() {
+  return mount(CacheFilesSection, {
+    global: { plugins: [vuetify], stubs: makeStubs() },
+  })
+}
+
+describe('CacheFilesSection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    listCacheFiles.mockResolvedValue([orphan, live, jobsDb])
+    deleteCacheFile.mockResolvedValue(undefined)
+  })
+
+  it('lists every cache on disk, including one no dataset claims', async () => {
+    const wrapper = mountSection()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="cache-file-_gone"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="cache-file-cdm_demo"]').exists()).toBe(true)
+    // The orphan count and its reclaimable size are the point of the view.
+    expect(wrapper.find('[data-testid="cache-files-summary"]').text()).toContain('1')
+  })
+
+  it('will not offer to delete a protected file', async () => {
+    const wrapper = mountSection()
+    await flushPromises()
+
+    const button = wrapper.find('[data-testid="cache-file-delete-_cache_jobs"]')
+    expect(button.exists()).toBe(true)
+    expect(button.attributes('disabled')).toBeDefined()
+  })
+
+  it('deletes only after confirmation, then reloads', async () => {
+    const wrapper = mountSection()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="cache-file-delete-_gone"]').trigger('click')
+    await flushPromises()
+    // Opening the dialog must not delete anything on its own.
+    expect(deleteCacheFile).not.toHaveBeenCalled()
+
+    await wrapper.find('[data-testid="cache-file-delete-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(deleteCacheFile).toHaveBeenCalledWith('_gone')
+    expect(listCacheFiles).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces why a delete was refused', async () => {
+    deleteCacheFile.mockRejectedValue(new Error('Refusing to delete protected file'))
+    const wrapper = mountSection()
+    await flushPromises()
+
+    await wrapper.find('[data-testid="cache-file-delete-_gone"]').trigger('click')
+    await flushPromises()
+    await wrapper.find('[data-testid="cache-file-delete-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="cache-files-error"]').text()).toContain(
+      'Refusing to delete protected file'
+    )
+  })
+
+  it('shows the listing error instead of an empty table', async () => {
+    listCacheFiles.mockRejectedValue(new Error('bao unavailable'))
+    const wrapper = mountSection()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="cache-files-error"]').text()).toContain('bao unavailable')
+    expect(wrapper.find('[data-testid="cache-files-table"]').exists()).toBe(false)
+  })
+})

--- a/tests/unit/services/jobs.service.spec.ts
+++ b/tests/unit/services/jobs.service.spec.ts
@@ -199,109 +199,29 @@ describe('JobsService', () => {
     })
   })
 
-  describe('cache jobs merge', () => {
-    it('merges bao cache jobs into the results when the cache endpoint returns { jobs: [...] }', async () => {
+  describe('cache builds', () => {
+    it('lists a cache build once, from the Spring Batch endpoint only', async () => {
       const { httpGet } = await import('@/services/http-client')
-      // First call: /job/execution returns an empty list.
-      // Second call: /trexsql/cache/jobs returns a cache job that should be
-      // transformed into a synthetic Job entry.
-      vi.mocked(httpGet)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce({
-          jobs: [
-            {
-              databaseCode: 'SYNPUF1K',
-              sourceKey: 'SYNPUF1K',
-              status: 'COMPLETE',
-              startTime: '2024-01-01T00:00:00Z',
-              endTime: '2024-01-01T01:00:00Z',
-              totalTables: 10,
-              completedTables: 10,
-            },
-          ],
-        })
+      // bao now writes a cacheGeneration execution for every dialect, so the
+      // build arrives with the other jobs. Fetching /trexsql/cache/jobs as
+      // well would list it twice.
+      vi.mocked(httpGet).mockResolvedValueOnce([
+        {
+          executionId: 42,
+          jobInstance: { name: 'cacheGeneration' },
+          status: 'COMPLETED',
+          startDate: '2026-08-06T10:00:00Z',
+        },
+      ])
 
       const result = await getJobs()
 
       expect(result.success).toBe(true)
       expect(result.data).toHaveLength(1)
-      expect(result.data![0].type).toBe('cacheGeneration')
-      expect(result.data![0].status).toBe('COMPLETED')
-      expect(result.data![0].name).toContain('SYNPUF1K')
-    })
-
-    it('skips cache jobs that are missing databaseCode / sourceKey', async () => {
-      const { httpGet } = await import('@/services/http-client')
-      vi.mocked(httpGet)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce({
-          jobs: [
-            // No databaseCode / sourceKey → transformCacheJob returns null.
-            { status: 'RUNNING' },
-            // Valid one.
-            { databaseCode: 'DB1', status: 'RUNNING' },
-          ],
-        })
-
-      const result = await getJobs()
-      expect(result.success).toBe(true)
-      expect(result.data).toHaveLength(1)
-      expect(result.data![0].name).toContain('DB1')
-    })
-
-    it('parses numeric (microsecond / millisecond / second) timestamps on cache jobs', async () => {
-      const { httpGet } = await import('@/services/http-client')
-      vi.mocked(httpGet)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce({
-          jobs: [
-            {
-              databaseCode: 'DB-US', // microseconds
-              status: 'RUNNING',
-              startTime: '1700000000000000',
-            },
-            {
-              databaseCode: 'DB-MS', // milliseconds
-              status: 'RUNNING',
-              startTime: '1700000000000',
-            },
-            {
-              databaseCode: 'DB-S', // seconds
-              status: 'RUNNING',
-              startTime: '1700000000',
-            },
-            {
-              databaseCode: 'DB-EMPTY', // empty timestamp
-              status: 'RUNNING',
-              startTime: '   ',
-            },
-          ],
-        })
-
-      const result = await getJobs()
-      expect(result.success).toBe(true)
-      expect(result.data).toHaveLength(4)
-    })
-
-    it('treats a failing cache-jobs fetch as non-fatal and still returns batch jobs', async () => {
-      const { httpGet } = await import('@/services/http-client')
-      vi.mocked(httpGet)
-        .mockResolvedValueOnce([
-          {
-            executionId: 1,
-            status: 'COMPLETED',
-            startDate: Date.now(),
-            jobInstance: { name: 'generateCohort' },
-          },
-        ])
-        .mockRejectedValueOnce(new Error('bao down'))
-
-      const result = await getJobs()
-      expect(result.success).toBe(true)
-      expect(result.data).toHaveLength(1)
+      expect(vi.mocked(httpGet)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(httpGet).mock.calls[0][0]).toContain('/job/execution')
     })
   })
-
   describe('jobsService singleton', () => {
     it('exports getJobs function', () => {
       expect(jobsService.getJobs).toBe(getJobs)

--- a/tests/unit/services/trexsql.service.spec.ts
+++ b/tests/unit/services/trexsql.service.spec.ts
@@ -12,7 +12,9 @@ import {
   getAllCacheStatuses,
   isCacheReady,
   cancelCountRequest,
-  cancelAllCountRequests
+  cancelAllCountRequests,
+  listCacheFiles,
+  deleteCacheFile
 } from '@/services/trexsql.service'
 
 // Mock logger
@@ -598,6 +600,73 @@ describe('TrexSQLService', () => {
       await first
       expect(firstAborted).toBe(true)
       expect(second.entryEventCount).toBe(1)
+    })
+  })
+
+  describe('cache files', () => {
+    it('returns the files the endpoint reports', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          cachePath: '/usr/src/data/cache',
+          files: [
+            {
+              fileName: 'orphan.db',
+              databaseCode: 'orphan',
+              sizeBytes: 12288,
+              lastModified: 1,
+              attached: false,
+              orphaned: true,
+              protected: false
+            }
+          ]
+        })
+      } as Response)
+
+      const files = await listCacheFiles()
+
+      expect(files).toHaveLength(1)
+      expect(files[0].orphaned).toBe(true)
+      expect(vi.mocked(global.fetch).mock.calls[0][0]).toContain('/trexsql/cache/files')
+    })
+
+    it('returns an empty list when the payload has no files array', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      } as Response)
+
+      await expect(listCacheFiles()).resolves.toEqual([])
+    })
+
+    it('surfaces the server body when listing fails', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'boom'
+      } as Response)
+
+      await expect(listCacheFiles()).rejects.toThrow(/500 boom/)
+    })
+
+    it('deletes by database code', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response)
+
+      await deleteCacheFile('cdm_demo')
+
+      const [url, init] = vi.mocked(global.fetch).mock.calls[0]
+      expect(url).toContain('/trexsql/cache/files/cdm_demo')
+      expect((init as RequestInit).method).toBe('DELETE')
+    })
+
+    it('rejects when the delete is refused', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'Refusing to delete protected file: FHIR.db'
+      } as Response)
+
+      await expect(deleteCacheFile('FHIR')).rejects.toThrow(/protected file/)
     })
   })
 })


### PR DESCRIPTION
Pairs with OHDSI/trex#213.

## Jobs overview

bao only wrote a Spring Batch execution for JDBC dialects, so cache builds on postgres/mysql/bigquery were invisible in the overview and had to be fetched separately from `/trexsql/cache/jobs` and merged in.

trex#213 records that execution on every dialect, so a cache build now arrives like any other job — with a real execution id instead of a synthesized hash. Keeping the merge would list each build **twice**.

The endpoint itself stays: it carries per-table progress and the cache error message, which the Spring Batch row does not. Only the overview merge goes, along with the transform and timestamp helpers that existed solely to feed it.

## Cache files

Deleting a dataset left its cache behind, and nothing in the UI could see it: every existing view is keyed by data source, so a cache whose dataset is gone is unreachable and its bytes stay on disk. On develop, most 12KB caches have no dataset row left at all.

The new section lists every cache bao reports, with its real size (database plus WAL), last modified, whether it is attached, and whether any dataset still claims it. Orphans are called out with the space they hold, and each row can be deleted behind a confirmation that says which case it is.

Files bao marks protected — the job registry and the FHIR server's database, which merely share the directory — are shown so the totals add up, but cannot be deleted.

## Verification

`vue-tsc` clean, eslint clean, 139 tests pass across the config and service suites.

The four `cache jobs merge` tests asserted behaviour this removes; they are replaced by one pinning the new contract — a `cacheGeneration` execution appears once and `/trexsql/cache/jobs` is not fetched by the overview.