### PR TITLE
Right-align the add-new button on the search row across list screens

### DIFF
--- a/src/components/analysis/AnalysisListLayout.vue
+++ b/src/components/analysis/AnalysisListLayout.vue
@@ -5,7 +5,8 @@
          heading was dropped to avoid the duplicated nesting. -->
 
     <div class="analysis-list">
-      <!-- Toolbar: actions left, view-mode toggle right -->
+      <!-- Toolbar: search / filters left, view-mode toggle and the
+           primary "new" action right, all on one row. -->
       <div class="analysis-list__toolbar">
         <div class="analysis-list__actions">
           <slot name="actions" />
@@ -40,6 +41,8 @@
               <AtlasIcon>mdi-view-list</AtlasIcon>
             </AtlasButton>
           </v-btn-toggle>
+
+          <slot name="primary-action" />
         </div>
       </div>
 

--- a/src/components/cohort/CohortFilters.vue
+++ b/src/components/cohort/CohortFilters.vue
@@ -186,6 +186,13 @@
           </div>
         </AtlasCard>
       </AtlasMenu>
+
+      <div
+        v-if="$slots.actions"
+        class="cohort-filters__actions"
+      >
+        <slot name="actions" />
+      </div>
     </div>
 
     <!-- Active filter chips (shown below the bar so they don't crowd it). -->
@@ -402,6 +409,13 @@ function removeTag(tag: string) {
 
 .cohort-filters__menu-btn {
   flex-shrink: 0;
+}
+
+.cohort-filters__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-inline-start: auto;
 }
 
 .cohort-filters__menu-count {

--- a/src/components/concepts/ConceptSetFilters.vue
+++ b/src/components/concepts/ConceptSetFilters.vue
@@ -183,6 +183,13 @@
           </div>
         </AtlasCard>
       </AtlasMenu>
+
+      <div
+        v-if="$slots.actions"
+        class="concept-set-filters__actions"
+      >
+        <slot name="actions" />
+      </div>
     </div>
 
     <div
@@ -396,6 +403,13 @@ function handleModifiedToChange(date: Date) {
 
 .concept-set-filters__menu-btn {
   flex-shrink: 0;
+}
+
+.concept-set-filters__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-inline-start: auto;
 }
 
 .concept-set-filters__menu-count {

--- a/src/components/concepts/ConceptSetList.vue
+++ b/src/components/concepts/ConceptSetList.vue
@@ -11,26 +11,26 @@
         class="concept-set-list__filters"
         @update:filters="store.setFilters"
         @clear="store.clearFilters"
-      />
-
-      <AtlasChip
-        v-if="!store.loading && store.filteredSets.length > 0"
-        size="sm"
-        tone="primary"
-        class="concept-set-list__count"
       >
-        {{ countLabel }}
-      </AtlasChip>
+        <template #actions>
+          <AtlasChip
+            v-if="!store.loading && store.filteredSets.length > 0"
+            size="sm"
+            tone="primary"
+            class="concept-set-list__count"
+          >
+            {{ countLabel }}
+          </AtlasChip>
 
-      <AtlasSpacer />
-
-      <AtlasButton
-        icon="mdi-plus"
-        :disabled="!canCreate"
-        @click="onAddClick"
-      >
-        {{ t('components.conceptSetBuilder.newConceptSet', 'New concept set') }}
-      </AtlasButton>
+          <AtlasButton
+            icon="mdi-plus"
+            :disabled="!canCreate"
+            @click="onAddClick"
+          >
+            {{ t('components.conceptSetBuilder.newConceptSet', 'New concept set') }}
+          </AtlasButton>
+        </template>
+      </ConceptSetFilters>
     </div>
 
     <!-- Error Alert -->
@@ -166,7 +166,7 @@ import { formatDate } from '@/utils/date-format'
 import { tagColor, tagContrastColor } from '@/utils/tag-color'
 import type { ConceptSetListItem } from '@/models/concept-set.types'
 import ConceptSetFilters from './ConceptSetFilters.vue'
-import { AtlasAlert, AtlasButton, AtlasCard, AtlasChip, AtlasDataTable, AtlasIcon, AtlasIconButton, AtlasSkeleton, AtlasSpacer } from '@/components/ui'
+import { AtlasAlert, AtlasButton, AtlasCard, AtlasChip, AtlasDataTable, AtlasIcon, AtlasIconButton, AtlasSkeleton } from '@/components/ui'
 
 const { t } = useI18n()
 const { hasPermission } = usePermissions()

--- a/src/components/config/PermissionsSection.vue
+++ b/src/components/config/PermissionsSection.vue
@@ -16,6 +16,7 @@
           clearable
           class="permissions-section__search"
         />
+        <AtlasSpacer />
         <AtlasButton
           icon="mdi-plus"
           @click="showCreateDialog = true"
@@ -176,7 +177,7 @@
 </template>
 
 <script setup lang="ts">
-import { AtlasAlert, AtlasButton, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem, AtlasProgressLinear, AtlasTab, AtlasTabs, AtlasTextField } from '@/components/ui'
+import { AtlasAlert, AtlasButton, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem, AtlasProgressLinear, AtlasSpacer, AtlasTab, AtlasTabs, AtlasTextField } from '@/components/ui'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import { useRoles } from '@/composables/useRoles'

--- a/src/views/CharacterizationsView.vue
+++ b/src/views/CharacterizationsView.vue
@@ -16,6 +16,9 @@
         data-testid="characterizations-search"
         @update:model-value="(v: string | number) => handleSearchInput(v != null ? String(v) : null)"
       />
+    </template>
+
+    <template #primary-action>
       <AtlasButton
         icon="mdi-plus"
         :aria-label="t('cc.new', 'New Characterization').value"

--- a/src/views/CohortsView.vue
+++ b/src/views/CohortsView.vue
@@ -38,52 +38,51 @@
     </template>
 
     <div class="cohorts-view">
-      <!-- Toolbar: primary actions on the left, status chip + filters
-           toggle on the right. Sits flush on the page card surface
-           with no inner v-card wrapper. -->
+      <!-- Toolbar: search + filters on the left, status chip in the
+           middle, primary actions right-aligned on the same row. Sits
+           flush on the page card surface with no inner v-card wrapper. -->
       <div class="cohorts-view__toolbar">
-        <AtlasButton
-          icon="mdi-plus"
-          :aria-label="t('cohortDefinitions.newDefinitionTitle', 'Create new cohort').value"
-          :disabled="!canCreateCohort"
-          @click="handleCreateCohort"
+        <cohort-filters
+          :filters="filters"
+          :available-tags="availableTags"
+          :available-authors="availableAuthors"
+          :active-filter-count="activeFilterCount"
+          class="cohorts-view__filters"
+          @update:filters="filters = $event"
+          @clear="clearFilters"
         >
-          {{ t('cohortDefinitions.newDefinition', 'New cohort') }}
-        </AtlasButton>
+          <template #actions>
+            <AtlasChip
+              v-if="!loading && filteredCohorts.length > 0"
+              size="sm"
+              tone="primary"
+              class="cohorts-view__count"
+            >
+              {{ countLabel }}
+            </AtlasChip>
 
-        <AtlasButton
-          variant="secondary"
-          icon="mdi-upload-outline"
-          :aria-label="t('common.import', 'Import cohort from JSON').value"
-          :disabled="!canCreateCohort"
-          data-testid="import-cohort-btn"
-          @click="handleImportCohort"
-        >
-          {{ t('common.import', 'Import') }}
-        </AtlasButton>
+            <AtlasButton
+              variant="secondary"
+              icon="mdi-upload-outline"
+              :aria-label="t('common.import', 'Import cohort from JSON').value"
+              :disabled="!canCreateCohort"
+              data-testid="import-cohort-btn"
+              @click="handleImportCohort"
+            >
+              {{ t('common.import', 'Import') }}
+            </AtlasButton>
 
-        <AtlasChip
-          v-if="!loading && filteredCohorts.length > 0"
-          size="sm"
-          tone="primary"
-          class="cohorts-view__count"
-        >
-          {{ countLabel }}
-        </AtlasChip>
-
-        <AtlasSpacer />
+            <AtlasButton
+              icon="mdi-plus"
+              :aria-label="t('cohortDefinitions.newDefinitionTitle', 'Create new cohort').value"
+              :disabled="!canCreateCohort"
+              @click="handleCreateCohort"
+            >
+              {{ t('cohortDefinitions.newDefinition', 'New cohort') }}
+            </AtlasButton>
+          </template>
+        </cohort-filters>
       </div>
-
-      <!-- Filters -->
-      <cohort-filters
-        :filters="filters"
-        :available-tags="availableTags"
-        :available-authors="availableAuthors"
-        :active-filter-count="activeFilterCount"
-        class="cohorts-view__filters"
-        @update:filters="filters = $event"
-        @clear="clearFilters"
-      />
 
       <!-- Filtering indicator -->
       <div
@@ -776,7 +775,7 @@ onMounted(() => {
 }
 
 .cohorts-view__filters {
-  margin-bottom: 16px;
+  flex: 1 1 auto;
 }
 
 .cohorts-view__pagination {

--- a/src/views/FeatureAnalysesView.vue
+++ b/src/views/FeatureAnalysesView.vue
@@ -16,6 +16,9 @@
         data-testid="feature-analyses-search"
         @update:model-value="(v: string | number) => handleSearchInput(v != null ? String(v) : null)"
       />
+    </template>
+
+    <template #primary-action>
       <AtlasButton
         icon="mdi-plus"
         :aria-label="t('cc.tabs.featureAnalyses.newLabel', 'New Feature Analysis').value"

--- a/src/views/IncidenceRatesView.vue
+++ b/src/views/IncidenceRatesView.vue
@@ -15,6 +15,9 @@
         data-testid="incidence-rates-search"
         @update:model-value="(v: string | number) => handleSearchInput(v != null ? String(v) : null)"
       />
+    </template>
+
+    <template #primary-action>
       <AtlasButton
         icon="mdi-plus"
         data-testid="incidence-rates-create"

--- a/src/views/PathwaysView.vue
+++ b/src/views/PathwaysView.vue
@@ -15,6 +15,9 @@
         data-testid="pathways-search"
         @update:model-value="(v: string | number) => handleSearchInput(v != null ? String(v) : null)"
       />
+    </template>
+
+    <template #primary-action>
       <AtlasButton
         icon="mdi-plus"
         data-testid="pathways-create"

--- a/tests/unit/views/CohortsView.spec.ts
+++ b/tests/unit/views/CohortsView.spec.ts
@@ -91,7 +91,7 @@ vi.mock('@/components/cohort/CohortPagination.vue', () => ({
 vi.mock('@/components/cohort/CohortFilters.vue', () => ({
   default: {
     name: 'CohortFilters',
-    template: '<div class="cohort-filters-mock"></div>',
+    template: '<div class="cohort-filters-mock"><slot name="actions" /></div>',
     props: ['filters', 'availableTags', 'availableAuthors', 'activeFilterCount']
   }
 }))

--- a/tests/unit/views/CohortsView.viewmode.spec.ts
+++ b/tests/unit/views/CohortsView.viewmode.spec.ts
@@ -91,7 +91,7 @@ vi.mock('@/components/cohort/CohortPagination.vue', () => ({
 vi.mock('@/components/cohort/CohortFilters.vue', () => ({
   default: {
     name: 'CohortFilters',
-    template: '<div class="cohort-filters-mock"></div>',
+    template: '<div class="cohort-filters-mock"><slot name="actions" /></div>',
     props: ['filters', 'availableTags', 'availableAuthors', 'activeFilterCount']
   }
 }))


### PR DESCRIPTION
List screens placed the primary "new" action inconsistently — above the search on cohorts, directly beside it on the analysis tabs, and wrapped onto a second line on concept sets. Every list now has the same shape: search and filters on the left, primary action right-aligned on the same row.

## Changes

- `AnalysisListLayout` gains a `#primary-action` slot rendered after the spacer. Pathways, Characterizations, Feature Analyses and Incidence Rates moved their "New …" button out of `#actions` into it.
- `CohortFilters` and `ConceptSetFilters` gain an `#actions` slot inside the filter bar itself. Both components are `width: 100%`, so buttons placed as siblings in the parent's flex row always wrapped to a second line — the slot is what actually gets them onto the search row.
- Cohorts: the New/Import buttons and the count chip left their separate toolbar row above the filters. Import now sits left of New so the primary action is furthest right.
- Concept sets: same move. The chip and "New concept set" looked right-aligned before but sat on a wrapped second row.
- `PermissionsSection`: added a spacer so "New Role" is pushed right instead of hugging the search box. `RoleList` already used `justify-space-between` and is untouched.

Incidental: `CohortsView` used `<AtlasSpacer>` without importing it, which logged a resolve warning on every test run. That usage is gone.

## Verification

- Full unit suite passes: 509 files, 8849 tests.
- `npm run type-check` clean; eslint clean on the changed files.
- Two `CohortsView` spec mocks needed their `CohortFilters` stub to render `<slot name="actions" />`, since the buttons now live inside that child.
- Visually confirmed against a running dev server on Cohorts, Concept Sets, Cohort Pathways and Feature Analyses. The config permissions screen renders "no access" without an admin session, so that one is code-verified only.
