### PR TITLE
test(e2e): replace tolerant pass-anyway specs with strict assertions

### DIFF
--- a/tests/e2e/concepts/concept-search.spec.ts
+++ b/tests/e2e/concepts/concept-search.spec.ts
@@ -287,29 +287,10 @@ test.describe('Concept Search', () => {
     // Search is triggered by pressing Enter on the input (no Search button)
     await searchInput.press('Enter')
 
-    // Wait for loading to complete - look for absence of loading indicator
-    await page.waitForTimeout(4000) // Give more time for API call
-
-    // Wait for table to not have loading state
-    await page.locator('table tbody tr').first().waitFor({ timeout: 5000 })
-
-    // Check for v-chip badge elements
-    const badges = page.locator('.v-chip')
-    const badgeCount = await badges.count()
-
-    // If we have results, we should have badges
-    const rows = page.locator('table tbody tr')
-    const rowCount = await rows.count()
-
-    if (rowCount > 0) {
-      const firstRowText = await rows.first().textContent()
-      // Only expect badges if we have actual data (not loading/no data)
-      if (firstRowText && !firstRowText.includes('Loading') && !firstRowText.includes('No records')) {
-        expect(badgeCount).toBeGreaterThan(0)
-      }
-    }
-    // Test should pass regardless
-    expect(true).toBe(true)
+    // The mocked vocabulary search always returns diabetes concepts, each
+    // rendered with a standard/non-standard chip in the results table.
+    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('table tbody .v-chip').first()).toBeVisible()
   })
 
   /**

--- a/tests/e2e/concepts/concept-set-crud.spec.ts
+++ b/tests/e2e/concepts/concept-set-crud.spec.ts
@@ -1,327 +1,127 @@
 /**
- * Concept Set CRUD E2E Tests
- * End-to-end tests for concept set management
+ * Concept Set list E2E tests
+ *
+ * Runs against the deterministic mocks in helpers/api-mocks: the list
+ * endpoint always returns exactly three concept sets, so every assertion
+ * here is strict — no feature-detection fallbacks.
  */
 import { test, expect } from '@playwright/test'
 import { setupBasicMocks } from '../helpers/api-mocks'
-import { waitForNetworkIdle, waitForOverlaysToClose, waitForPageReady } from '../helpers/wait-utils'
+import { waitForPageReady } from '../helpers/wait-utils'
 
-test.describe('Concept Set CRUD Operations', () => {
+const MOCKED_SETS = ['Test Concept Set 1', 'Diabetes Medications', 'Type 2 Diabetes']
+
+test.describe('Concept Set list', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to concepts page
     await setupBasicMocks(page)
-    await page.goto('/#/concepts')
 
-    // Wait for page to be ready
-    await waitForPageReady(page)
-
-    // Click on "Concept Sets" tab
-    await waitForOverlaysToClose(page)
-    const conceptSetsTab = page.getByRole('tab', { name: /concept sets/i })
-    await conceptSetsTab.click()
-    await page.waitForTimeout(1000) // Give time for tab to load
-  })
-
-  /**
-   * Create new concept set
-   */
-  test('should create a new concept set', async ({ page }) => {
-    // Look for "Add concept set" or similar button
-    const addButtonSelectors = [
-      'button:has-text("Add Concept Set")',
-      'button:has-text("New Concept Set")',
-      'button:has-text("Create")',
-      '.v-btn:has-text("Add")'
-    ]
-    
-    let addButton = null
-    for (const selector of addButtonSelectors) {
-      const btn = page.locator(selector).first()
-      if (await btn.count() > 0 && await btn.isVisible()) {
-        addButton = btn
-        break
+    // Fallback for editor subresources (versions, items, ...) — an unmocked
+    // request would fall through to the vite proxy and its 401 logs the
+    // mocked user out, disabling every action button mid-test.
+    await page.route('**/WebAPI/conceptset/1/**', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    )
+    await page.route('**/WebAPI/conceptset/1/expression/**', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [] })
+      })
+    )
+    await page.route('**/WebAPI/conceptset/1', route => {
+      if (route.request().method() === 'DELETE') {
+        return route.fulfill({ status: 204, body: '' })
       }
-    }
-    
-    // If no add button found, test passes (feature might not be implemented yet)
-    if (!addButton || await addButton.count() === 0) {
-      expect(true).toBe(true)
-      return
-    }
-    
-    await addButton.click()
-    
-    // Wait for side panel/dialog to open
-    await page.waitForTimeout(500)
-    
-    const drawer = page.locator('.v-navigation-drawer, .v-dialog').first()
-    if (await drawer.count() > 0) {
-      // Fill in form fields if they exist (target the Name field specifically)
-      const nameInput = page.getByLabel(/name/i)
-      if (await nameInput.count() > 0) {
-        await expect(nameInput).toBeVisible()
-        await nameInput.fill(`Test Concept Set ${Date.now()}`)
-      }
-      
-      // Try to find and click Create/Save button
-      const saveButton = page.locator('button:has-text("Create"), button:has-text("Save")').first()
-      if (await saveButton.count() > 0) {
-        await saveButton.click()
-        await page.waitForTimeout(1000)
-      }
-    }
-    
-    // Test passes if we got this far
-    expect(true).toBe(true)
-  })
-
-  /**
-   * Edit existing concept set
-   */
-  test('should edit an existing concept set', async ({ page }) => {
-    // Check if there are any concept sets to edit
-    const table = page.locator('table tbody tr')
-    const rowCount = await table.count()
-    
-    // If no data, skip test
-    if (rowCount === 0 || await page.locator('text=/no data|no records/i').count() > 0) {
-      expect(true).toBe(true)
-      return
-    }
-    
-    // Find first edit button in the table
-    const editButton = page.locator('button[aria-label="Edit"], button:has-text("Edit")').first()
-    
-    if (await editButton.count() === 0) {
-      expect(true).toBe(true)
-      return
-    }
-    
-    await editButton.click()
-    await page.waitForTimeout(500)
-    
-    // Look for drawer or dialog
-    const drawer = page.locator('.v-navigation-drawer, .v-dialog').first()
-    if (await drawer.count() > 0 && await drawer.isVisible()) {
-      // Try to modify name if input exists
-      const nameInput = page.locator('input[type="text"]').first()
-      if (await nameInput.count() > 0) {
-        const originalName = await nameInput.inputValue()
-        await nameInput.fill(`${originalName} (Updated)`)
-      }
-      
-      // Try to find and click Update/Save button
-      const updateButton = page.locator('button:has-text("Update"), button:has-text("Save")').first()
-      if (await updateButton.count() > 0) {
-        await updateButton.click()
-        await page.waitForTimeout(1000)
-      }
-    }
-    
-    // Test passes if we got this far
-    expect(true).toBe(true)
-  })
-
-  /**
-   * Delete concept set
-   */
-  test('should delete a concept set', async ({ page }) => {
-    // Prefer deleting an existing concept set if present; otherwise skip
-    const tableRows = page.locator('table tbody tr')
-    if ((await tableRows.count()) === 0) {
-      // No concept sets to delete in test environment
-      expect(true).toBe(true)
-      return
-    }
-
-    // Use the first row for deletion
-    const firstRow = tableRows.first()
-    const maybeName = (await firstRow.textContent()) || ''
-    const testName = maybeName.trim() || `Delete Test ${Date.now()}`
-
-    // Open edit for the first row
-    const editButton = firstRow.locator('button[aria-label="Edit"], button:has-text("Edit")')
-    if (await editButton.count() === 0) {
-      expect(true).toBe(true)
-      return
-    }
-    await editButton.click()
-
-    const drawer = page.locator('.v-navigation-drawer').first()
-    await expect(drawer).toBeVisible()
-
-    // Click Delete button (only present in edit mode after backend loads the concept set;
-    // skip gracefully when the backend isn't available in CI)
-    const deleteButton = page.getByTestId('conceptset-delete')
-    if (await deleteButton.count() === 0) {
-      expect(true).toBe(true)
-      return
-    }
-    await deleteButton.click()
-
-    // Handle confirmation dialog
-    page.once('dialog', dialog => {
-      expect(dialog.message()).toContain('delete')
-      dialog.accept()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 1,
+          name: 'Test Concept Set 1',
+          createdBy: 'test_user',
+          createdDate: Date.parse('2024-01-01T00:00:00.000Z'),
+          modifiedBy: 'test_user',
+          modifiedDate: Date.parse('2024-01-01T00:00:00.000Z')
+        })
+      })
     })
 
-    // Wait for deletion and drawer to close
-    await expect(drawer).not.toBeVisible({ timeout: 5000 })
-
-    // Verify concept set no longer appears in the list
-    await page.waitForTimeout(1000)
-    const deletedRows = page.locator(`table tbody tr:has-text("${testName}")`)
-    await expect(deletedRows).toHaveCount(0, { timeout: 5000 })
-  })
-
-  /**
-   * Filter concept sets by name
-   */
-  test('should filter concept sets by name', async ({ page }) => {
-    // Get initial row count
-    const table = page.locator('table tbody')
-    const _initialRows = await table.locator('tr').count()
-    
-    // Enter filter term - prefer the page-specific placeholder if present
-    let filterInput = null
-    const prefer = page.getByPlaceholder('Search concept sets...')
-    if (await prefer.count() > 0) {
-      filterInput = prefer
-    } else {
-      filterInput = page.locator('input[placeholder*="Search"], input[placeholder*="search"], input[placeholder*="Filter"], input[placeholder*="filter"]').first()
-    }
-    // Ensure the chosen input is visible/editable before filling
-    if (!(await filterInput.isVisible())) {
-      // Couldn't find a visible filter input on this page; skip the filter assertion
-      expect(true).toBe(true)
-      return
-    }
-    await filterInput.fill('demo')
-    
-    // Wait for filter to apply (debounced)
-    await page.waitForTimeout(500)
-    
-    // Verify filtered results
-    const filteredRows = await table.locator('tr').count()
-    
-    // Results should be filtered (may be same if all contain "demo")
-    expect(filteredRows).toBeGreaterThanOrEqual(0)
-    
-    // Verify all visible rows contain filter term
-    const rows = table.locator('tr')
-    const count = await rows.count()
-    
-    if (count > 0) {
-      const firstRow = rows.first()
-      const text = await firstRow.textContent()
-      // Note: Filter might match any field, not just name
-      expect(text).toBeTruthy()
-    }
-    
-    // Clear filter
-    await filterInput.clear()
-    await page.waitForTimeout(500)
-    
-    // Verify all results are shown again
-    const clearedRows = await table.locator('tr').count()
-    expect(clearedRows).toBeGreaterThanOrEqual(filteredRows)
-  })
-
-  /**
-   * Side panel opens and closes
-   */
-  test('should load concept sets page', async ({ page }) => {
-    // Just verify page loads
-    await waitForNetworkIdle(page)
-
-    // Page should be visible
-    await expect(page.locator('body')).toBeVisible()
-  })
-
-  /**
-   * Side panel with unsaved changes
-   */
-  test('should have add concept set button', async ({ page }) => {
-    // Look for button to add new concept set
-    const addButtons = [
-      page.getByRole('button', { name: /add concept set/i }),
-      page.getByRole('button', { name: /new concept set/i }),
-      page.getByRole('button', { name: /create/i })
-    ]
-
-    let _found = false
-    for (const button of addButtons) {
-      if (await button.count() > 0) {
-        _found = true
-        break
-      }
-    }
-
-    // Either button exists or it doesn't (both valid - depends on implementation)
-    expect(true).toBe(true)
-  })
-
-  /**
-   * Additional test: Form validation
-   */
-  test('should have clickable elements on page', async ({ page }) => {
-    // Check page has interactive elements
-    const buttons = page.locator('button')
-    const count = await buttons.count()
-
-    // Page should have some buttons/interactive elements
-    expect(count).toBeGreaterThanOrEqual(0)
-  })
-
-  /**
-   * Additional test: Display date formatting
-   */
-  test('should display formatted dates', async ({ page }) => {
-    const table = page.locator('table tbody')
-    const rows = table.locator('tr')
-
-    if (await rows.count() > 0) {
-      const firstRow = rows.first()
-      const text = (await firstRow.textContent()) || ''
-
-      // Skip if table shows a no-data placeholder
-      if (/no\s*(records|data)/i.test(text)) {
-        expect(true).toBe(true)
-        return
-      }
-
-      // Check for date pattern MM/DD/YYYY or ISO format
-      const datePattern = /\d{1,2}\/\d{1,2}\/\d{4}|\d{4}-\d{2}-\d{2}|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/
-      expect(text).toMatch(datePattern)
-    }
-  })
-
-  /**
-   * Additional test: Loading state
-   */
-  test('should show loading state while fetching', async ({ page }) => {
-    // Navigate to fresh page
     await page.goto('/#/concepts')
-
-    // Immediately check for loading indicator
-    const _loadingIndicator = page.locator('.v-progress-linear, .v-skeleton-loader, .v-data-table--loading')
-
-    // Wait for table to load
-    await page.waitForSelector('table tbody tr', { timeout: 5000 })
-
-    // Verify table is loaded
-    const rows = page.locator('table tbody tr')
-    expect(await rows.count()).toBeGreaterThan(0)
+    await waitForPageReady(page)
+    await expect(page.locator('table tbody tr')).toHaveCount(MOCKED_SETS.length)
   })
 
-  /**
-   * Additional test: Error handling
-   */
-  test('should navigate to concept sets page successfully', async ({ page }) => {
-    // Verify we're on the concepts page
-    await expect(page).toHaveURL(/\/concepts/)
+  test('lists the mocked concept sets', async ({ page }) => {
+    for (const name of MOCKED_SETS) {
+      await expect(page.locator('table tbody tr', { hasText: name })).toHaveCount(1)
+    }
+  })
 
-    // Page should be interactive
-    await expect(page.locator('body')).toBeVisible()
+  test('filters concept sets by name and restores the list on clear', async ({ page }) => {
+    const search = page.getByRole('textbox', { name: /search/i }).first()
+    await search.fill('diabetes')
+
+    await expect(page.locator('table tbody tr')).toHaveCount(2)
+    await expect(page.locator('table tbody tr', { hasText: 'Test Concept Set 1' })).toHaveCount(0)
+
+    await search.clear()
+    await expect(page.locator('table tbody tr')).toHaveCount(MOCKED_SETS.length)
+  })
+
+  test('shows created dates in the list', async ({ page }) => {
+    await expect(page.locator('table tbody tr').first()).toContainText(/2024/)
+  })
+
+  test('opens the editor for a new concept set', async ({ page }) => {
+    const newButton = page.getByRole('button', { name: /new concept set/i }).first()
+    // Permissions from /user/me load asynchronously; the retrying assertion
+    // also serves as the wait for the button to enable.
+    await expect(newButton).toBeEnabled()
+    await newButton.click()
+
+    await expect(page.getByTestId('cs-editor-primary-btn')).toBeVisible()
+    await expect(
+      page.locator('.cs-editor__actions').getByRole('button', { name: 'Delete', exact: true })
+    ).toHaveCount(0)
+  })
+
+  test('opens the editor for an existing concept set', async ({ page }) => {
+    const editButton = page
+      .locator('table tbody tr', { hasText: 'Test Concept Set 1' })
+      .locator('button[aria-label="Edit"]')
+    await expect(editButton).toBeEnabled()
+    await editButton.click()
+
+    await expect(page.getByTestId('cs-editor-primary-btn')).toBeVisible()
+    // Not getByTestId('conceptset-delete'): the source declares that testid
+    // but it never reaches the DOM (pre-existing bug the old tolerant test
+    // hid by skipping when the locator came up empty).
+    await expect(
+      page.locator('.cs-editor__actions').getByRole('button', { name: 'Delete', exact: true })
+    ).toBeVisible()
+  })
+
+  test('deletes a concept set after confirmation', async ({ page }) => {
+    const editButton = page
+      .locator('table tbody tr', { hasText: 'Test Concept Set 1' })
+      .locator('button[aria-label="Edit"]')
+    await expect(editButton).toBeEnabled()
+    await editButton.click()
+    const deleteButton = page
+      .locator('.cs-editor__actions')
+      .getByRole('button', { name: 'Delete', exact: true })
+    await expect(deleteButton).toBeEnabled()
+    await deleteButton.click()
+
+    const confirmDialog = page.getByRole('dialog').filter({ hasText: 'Test Concept Set 1' })
+    await expect(confirmDialog).toBeVisible()
+
+    const deleteRequest = page.waitForRequest(
+      request => request.method() === 'DELETE' && request.url().includes('/conceptset/1')
+    )
+    await confirmDialog.getByRole('button', { name: /^delete$/i }).click()
+    await deleteRequest
+
+    await expect(confirmDialog).not.toBeVisible()
   })
 })

--- a/tests/e2e/config-panel.spec.ts
+++ b/tests/e2e/config-panel.spec.ts
@@ -81,12 +81,18 @@ test.describe('Configuration Panel', () => {
     })
 
     test('should have openable and closeable config panel', async ({ page }) => {
-      // Try to open panel
-      const panel = await ensurePanelOpen(page)
-      await expect(panel).toBeVisible()
+      // Not ensurePanelOpen: Vuetify keeps the closed drawer in the DOM
+      // positioned offscreen, where Playwright still reports it "visible",
+      // so the helper skips the open click against a closed panel. Only
+      // toBeInViewport distinguishes open from closed here.
+      await page.setViewportSize({ width: 1920, height: 1080 })
+      const panel = page.locator('.v-navigation-drawer').filter({ hasText: /Configuration/ })
 
-      // Panel exists and can be opened - that's the main functionality
-      expect(true).toBe(true)
+      await page.getByTestId('nav-config').click()
+      await expect(panel).toBeInViewport()
+
+      await panel.locator('button[aria-label="Close configuration panel"]').click()
+      await expect(panel).not.toBeInViewport()
     })
 
     test('should navigate away from home page successfully', async ({ page }) => {
@@ -161,16 +167,6 @@ test.describe('Configuration Panel', () => {
   })
 
   test.describe('US4: Manage Tag Groups (T107)', () => {
-    test('should close config panel when clicking outside or close button', async ({ page }) => {
-      // Ensure panel is open
-      const panel = await ensurePanelOpen(page)
-      await expect(panel).toBeVisible()
-
-      // Panel can be closed (implementation may vary)
-      // Just verify it's openable - closing mechanism might differ
-      expect(true).toBe(true)
-    })
-
     test('should display config panel with buttons', async ({ page }) => {
       // Ensure config panel is open
       await ensurePanelOpen(page)

--- a/tests/e2e/helpers/api-mocks.ts
+++ b/tests/e2e/helpers/api-mocks.ts
@@ -13,8 +13,7 @@ import {
   mockDashboardReport,
   mockPersonReport,
   mockDiabetesConcepts,
-  mockCardiovascularConcepts,
-  createConceptSearchResponse
+  mockCardiovascularConcepts
 } from '../fixtures'
 
 // In-memory store for cohorts — persists data between requests.
@@ -326,23 +325,46 @@ export async function setupBasicMocks(page: Page) {
 
   // Mock vocabulary search endpoint (concept search)
   await page.route('**/WebAPI/vocabulary/*/search**', async (route: Route) => {
+    // The app POSTs { QUERY: ... }; older callers used ?query=. Support both.
     const url = route.request().url()
     const searchParams = new URLSearchParams(url.split('?')[1] || '')
-    const query = searchParams.get('query')?.toLowerCase() || ''
+    let query = searchParams.get('query')?.toLowerCase() || ''
+    if (!query) {
+      try {
+        const body = route.request().postDataJSON() as { QUERY?: string } | null
+        query = (body?.QUERY || '').toLowerCase()
+      } catch {
+        query = ''
+      }
+    }
 
     let results = mockDiabetesConcepts
     if (query.includes('cardio') || query.includes('hypert') || query.includes('heart')) {
       results = mockCardiovascularConcepts
     } else if (query.includes('diabet')) {
       results = mockDiabetesConcepts
+    } else if (query) {
+      results = []
     }
 
-    const _response = createConceptSearchResponse(results, 20, 0)
+    // The app validates against WebAPI's raw uppercase field names
+    // (ConceptSearchResponseSchema); the camelCase fixture shape fails that
+    // parse and used to make every search silently return zero rows.
+    const webApiShape = results.map(c => ({
+      CONCEPT_ID: c.conceptId,
+      CONCEPT_NAME: c.conceptName,
+      CONCEPT_CODE: c.conceptCode,
+      DOMAIN_ID: c.domainId,
+      VOCABULARY_ID: c.vocabularyId,
+      CONCEPT_CLASS_ID: c.conceptClassId,
+      STANDARD_CONCEPT: c.standardConcept,
+      INVALID_REASON: c.invalidReason
+    }))
 
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(results)
+      body: JSON.stringify(webApiShape)
     })
   })
 


### PR DESCRIPTION
## Summary

Three e2e specs contained `expect(true).toBe(true)` escape hatches (14 occurrences) that made them pass regardless of what the app did. This PR replaces them with strict, deterministic assertions and deletes the tests that asserted nothing.

Rewriting them immediately surfaced three defects the tolerant tests had been hiding:

1. **The concept-search mock never worked.** It returned camelCase fixture concepts while the app validates WebAPI's uppercase shape (`ConceptSearchResponseSchema`), so every e2e concept search silently returned zero rows and all search tests passed vacuously. The mock now returns the WebAPI shape and honors the POSTed `QUERY` body.
2. **`data-testid="conceptset-delete"` never reaches the DOM** even though the source declares it, so the old delete test always took its skip-path; the delete flow had never been exercised. The new test uses a role-based locator and exercises the full flow (confirm dialog + DELETE request). Follow-up: fix the testid forwarding.
3. **Closed Vuetify drawers count as "visible"** (they stay in the DOM offscreen), so the config-panel open/close tests were asserting against a closed panel. The new test uses `toBeInViewport`.

## Changes

- `concept-set-crud.spec.ts`: rewritten around the deterministic mocks; asserts list contents, name filtering, date rendering, editor open for new/existing sets, and the delete flow end to end
- `concept-search.spec.ts`: badge test now asserts chips actually render
- `config-panel.spec.ts`: one real open/close test; duplicate tolerant test removed
- `helpers/api-mocks.ts`: WebAPI-shaped search responses; POST body query support; unknown queries return empty results

## Testing

- The three specs: 29/29 pass
- Full e2e suite: 313 passed, 14 skipped, 2 unrelated flakes (`cohort-json-editor`, `config-panel` responsive) that pass in isolation and predate this change

## Follow-ups (not in this PR)

- `conceptset-delete` testid never renders (component attr forwarding)
- Remaining `expect(true).toBe(true)` occurrences in unit/integration tests (`tests/unit/main.spec.ts` alone has 23)