### PR TITLE
Harden the API error contract and fix misreported failures

### DIFF
--- a/public/plugin-runtime.js
+++ b/public/plugin-runtime.js
@@ -137,7 +137,7 @@ window.__atlasPluginRuntimeReady = (function () {
     });
 
     // Load and register single-spa-vue
-    return window.System.import('./vendor/single-spa-vue.js').then(function(module) {
+    var chain = window.System.import('./vendor/single-spa-vue.js').then(function(module) {
       // Register it under the 'single-spa-vue' name
       window.System.register('single-spa-vue', [], function(_export) {
         return {
@@ -154,5 +154,10 @@ window.__atlasPluginRuntimeReady = (function () {
       // instead of letting this chain resolve with single-spa-vue unregistered.
       throw err;
     });
+    // Same handled-marking as rejected(): if a sibling vendor script fails
+    // first, Promise.all rejects and ensurePluginRuntime never awaits this
+    // chain, so its rejection would surface as unhandledrejection.
+    chain.catch(function () {});
+    return chain;
   }
 })()

--- a/public/plugin-runtime.js
+++ b/public/plugin-runtime.js
@@ -14,7 +14,7 @@ window.__atlasPluginRuntimeReady = (function () {
     // downstream by ensurePluginRuntime), nothing else checks window.Vue -
     // resolving here would let the runtime report "ready" with the 'vue'
     // SystemJS module exporting nothing, breaking every plugin silently.
-    return Promise.reject(new Error('[SystemJS] window.Vue is not available!'))
+    return rejected(new Error('[SystemJS] window.Vue is not available!'))
   }
 
   // A synchronous throw inside a classic <script> fires the window's error
@@ -24,7 +24,16 @@ window.__atlasPluginRuntimeReady = (function () {
   try {
     return registerRuntime()
   } catch (err) {
-    return Promise.reject(err)
+    return rejected(err)
+  }
+
+  // ensurePluginRuntime attaches its await a task later at best - or never,
+  // if vendor-script loading fails first - so an eagerly-created rejection
+  // must be pre-marked as handled or it fires unhandledrejection.
+  function rejected(err) {
+    var p = Promise.reject(err)
+    p.catch(function () {})
+    return p
   }
 
   function registerRuntime() {

--- a/src/components/characterization/CharacterizationWorkbench.vue
+++ b/src/components/characterization/CharacterizationWorkbench.vue
@@ -378,7 +378,7 @@ async function handleRun(sourceKey: string): Promise<void> {
   if (props.characterizationId == null) return
   try {
     const exec = await store.runExecution(props.characterizationId, sourceKey)
-    onRunStarted(exec)
+    if (exec) onRunStarted(exec)
   } catch (err) {
     logger.error('CharacterizationWorkbench', 'Run failed', err)
     const msg = err instanceof Error ? err.message : tv('cc.fa.runError', 'Failed to start generation')

--- a/src/components/cohort-samples/CohortSamplesPanel.vue
+++ b/src/components/cohort-samples/CohortSamplesPanel.vue
@@ -129,6 +129,7 @@ async function loadList() {
 
 async function loadDetail(sampleId: number) {
   detailLoading.value = true
+  error.value = null
   try {
     const result = await getCohortSample(props.cohortId, props.sourceKey, sampleId, {
       withElements: true,
@@ -137,6 +138,9 @@ async function loadDetail(sampleId: number) {
       selectedSample.value = result.data
     } else {
       selectedSample.value = null
+      error.value =
+        result.error.message ||
+        tv('components.cohortSamples.failedToLoadSampleDetail', 'Failed to load sample detail')
       logger.error('CohortSamplesPanel', 'Failed to load sample detail', result.error)
     }
   } finally {

--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -2227,10 +2227,11 @@ async function handleSave(): Promise<{ id?: number; name?: string }> {
     const saved = await saveCohortDefinition(atlasDefinition)
 
     if (!saved.success) {
+      logger.error('CohortBuilder', 'saveCohortDefinition failed', saved.error)
       errorMessage.value =
         saved.error.status === 403
           ? tv('components.cohortBuilder.saveForbidden', 'You do not have permission to save this cohort')
-          : saved.error.message
+          : tv('components.cohortBuilder.saveToServerError', 'Failed to save cohort to server')
       showError.value = true
       return {}
     }

--- a/src/components/versions/VersionsTabContent.vue
+++ b/src/components/versions/VersionsTabContent.vue
@@ -198,8 +198,10 @@ async function handleCopy(versionNumber: number): Promise<void> {
     // route to navigate to (see ASSET_DETAIL_ROUTE_SEGMENT) - the copy
     // still succeeded (toast above), so just skip the navigation for it
     // rather than pushing a dead link.
+    // The copy responses are loosely validated (z.any() for cohorts), so id
+    // can be absent - skip navigation rather than pushing '/.../undefined'.
     const detailSegment = ASSET_DETAIL_ROUTE_SEGMENT[props.config.assetType]
-    if (detailSegment) {
+    if (detailSegment && newAsset.id != null) {
       setTimeout(() => {
         router.push({
           path: `/${detailSegment}/${newAsset.id}`,

--- a/src/composables/useIncidenceRateBuilder.ts
+++ b/src/composables/useIncidenceRateBuilder.ts
@@ -40,13 +40,11 @@ export function useIncidenceRateBuilder() {
       return false
     }
 
-    // Name uniqueness check
+    // Name uniqueness check. Advisory only: if the check itself fails (it is
+    // already logged by the service), still attempt the save — the server is
+    // the authority and the save surfaces its own errors.
     const existsResult = await existsIncidenceRate(ir.name, ir.id ?? 0)
-    if (!existsResult.success) {
-      notify(`Could not verify name uniqueness: ${existsResult.error.message}`, 'error')
-      return false
-    }
-    if (existsResult.data > 0) {
+    if (existsResult.success && existsResult.data > 0) {
       notify('An incidence rate with this name already exists', 'error')
       return false
     }

--- a/src/composables/usePathwayGeneration.ts
+++ b/src/composables/usePathwayGeneration.ts
@@ -41,7 +41,9 @@ export function usePathwayGeneration(pathwayId: number) {
       return false
     }
     execution.value = result.data
-    if (!TERMINAL.has(result.data.status)) {
+    // result.data is null when the generate response carried no execution id:
+    // the run started, but there is nothing to poll.
+    if (result.data && !TERMINAL.has(result.data.status)) {
       polling.value = true
       timer = setInterval(pollOnce, PATHWAY_GENERATION_POLL_MS)
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2296,7 +2296,8 @@
         "export": {
           "title": "Export design",
           "description": "Download the design as JSON.",
-          "download": "Download design JSON"
+          "download": "Download design JSON",
+          "exportError": "Export failed."
         },
         "import": {
           "title": "Import design",
@@ -3313,6 +3314,7 @@
       "preset": "Preset",
       "retrievingList": "Retrieving feature analyses list...",
       "saveError": "An error occurred while attempting to save a feature analysis.",
+      "loadDefaultsError": "Failed to load default covariate settings.",
       "selectConceptSet": "Select Concept Set...",
       "unsavedConfirmation": "Your changes are not saved. Would you like to continue?",
       "warning": "Warning:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1616,6 +1616,7 @@
       "description": "Random selections of persons drawn from the generated cohort, optionally filtered by age and gender.",
       "newSample": "New sample",
       "failedToLoadSamples": "Failed to load samples",
+      "failedToLoadSampleDetail": "Failed to load sample detail",
       "failedToCreateSample": "Failed to create sample"
     },
     "cohortSampleDetail": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1672,7 +1672,8 @@
       "searching": "コンセプトを検索中...",
       "foundResults": "{count} 件の結果が見つかりました",
       "conceptMeta": "ID: {id} | コード: {code} | ドメイン: {domain}",
-      "enterSearchTerm": "コンセプトを検索するには検索語を入力してください"
+      "enterSearchTerm": "コンセプトを検索するには検索語を入力してください",
+      "searchFailed": "コンセプトの検索に失敗しました"
     },
     "cohortBuilder": {
       "stateRequired": "必須",
@@ -1689,8 +1690,11 @@
       "stateDrugExposure": "薬剤曝露",
       "stateConfigured": "設定済み",
       "saveToServerError": "コホートをサーバーに保存できませんでした",
+      "saveForbidden": "このコホートを保存する権限がありません",
       "saveSuccess": "コホートを保存しました",
       "saveError": "コホートを保存できませんでした",
+      "loadForbidden": "このコホートを開く権限がありません",
+      "loadError": "コホートの読み込みに失敗しました",
       "exportFailed": "エクスポートに失敗しました: {error}",
       "exportDownloaded": "コホート JSON をダウンロードしました",
       "copiedToClipboard": "コホート JSON をクリップボードにコピーしました",
@@ -2144,7 +2148,8 @@
         "export": {
           "title": "デザインをエクスポート",
           "description": "デザインを JSON としてダウンロードします。",
-          "download": "デザイン JSON をダウンロード"
+          "download": "デザイン JSON をダウンロード",
+          "exportError": "エクスポートに失敗しました。"
         },
         "import": {
           "title": "デザインをインポート",
@@ -3860,6 +3865,8 @@
   },
   "cohortDefinitions": {
     "closeYourCurrentCohort": "新しいコホート定義を作成する前に、現在のコホート定義を閉じてください",
+    "copyLoadForbidden": "このコホートを読み取る権限がありません。",
+    "deleteError": "コホートの削除に失敗しました。",
     "cohort": {
       "modals": {
         "analysisTypes": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1510,6 +1510,7 @@
       "description": "生成されたコホートから抽出された対象者のランダムな選択で、年齢と性別で任意に絞り込めます。",
       "newSample": "新規サンプル",
       "failedToLoadSamples": "サンプルの読み込みに失敗しました",
+      "failedToLoadSampleDetail": "サンプル詳細の読み込みに失敗しました",
       "failedToCreateSample": "サンプルの作成に失敗しました"
     },
     "cohortSampleDetail": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1496,7 +1496,8 @@
       "searching": "개념 검색 중...",
       "foundResults": "{count}개의 결과를 찾았습니다",
       "conceptMeta": "ID: {id} | 코드: {code} | 도메인: {domain}",
-      "enterSearchTerm": "개념을 찾으려면 검색어를 입력하세요"
+      "enterSearchTerm": "개념을 찾으려면 검색어를 입력하세요",
+      "searchFailed": "개념 검색에 실패했습니다"
     },
     "cohortBuilder": {
       "stateRequired": "필수",
@@ -1513,8 +1514,11 @@
       "stateDrugExposure": "약물 노출",
       "stateConfigured": "구성됨",
       "saveToServerError": "코호트를 서버에 저장하지 못했습니다",
+      "saveForbidden": "이 코호트를 저장할 권한이 없습니다",
       "saveSuccess": "코호트를 저장했습니다",
       "saveError": "코호트를 저장하지 못했습니다",
+      "loadForbidden": "이 코호트를 열 권한이 없습니다",
+      "loadError": "코호트를 불러오지 못했습니다",
       "exportFailed": "내보내기 실패: {error}",
       "exportDownloaded": "코호트 JSON을 다운로드했습니다",
       "copiedToClipboard": "코호트 JSON을 클립보드에 복사했습니다",
@@ -3218,6 +3222,8 @@
   },
   "cohortDefinitions": {
     "closeYourCurrentCohort": "새로운 코호트 정의을 만들기 전에 현재 코호트 정의를 닫으십시오.",
+    "copyLoadForbidden": "이 코호트를 읽을 권한이 없습니다.",
+    "deleteError": "코호트를 삭제하지 못했습니다.",
     "cohort": {
       "modals": {
         "analysisTypes": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1331,6 +1331,7 @@
       "description": "생성된 코호트에서 무작위로 추출한 대상자로, 연령과 성별로 선택적으로 필터링할 수 있습니다.",
       "newSample": "새 샘플",
       "failedToLoadSamples": "샘플을 불러오지 못했습니다",
+      "failedToLoadSampleDetail": "샘플 상세 정보를 불러오지 못했습니다",
       "failedToCreateSample": "샘플을 만들지 못했습니다"
     },
     "cohortSampleDetail": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1509,7 +1509,8 @@
       "searching": "Поиск концептов...",
       "foundResults": "Найдено результатов: {count}",
       "conceptMeta": "ID: {id} | Код: {code} | Домен: {domain}",
-      "enterSearchTerm": "Введите поисковый запрос для поиска концептов"
+      "enterSearchTerm": "Введите поисковый запрос для поиска концептов",
+      "searchFailed": "Не удалось выполнить поиск концептов"
     },
     "cohortBuilder": {
       "stateRequired": "Обязательно",
@@ -1526,8 +1527,11 @@
       "stateDrugExposure": "Воздействие препарата",
       "stateConfigured": "Настроено",
       "saveToServerError": "Не удалось сохранить когорту на сервере",
+      "saveForbidden": "У вас нет прав для сохранения этой когорты",
       "saveSuccess": "Когорта успешно сохранена",
       "saveError": "Не удалось сохранить когорту",
+      "loadForbidden": "У вас нет прав для открытия этой когорты",
+      "loadError": "Не удалось загрузить когорту",
       "exportFailed": "Ошибка экспорта: {error}",
       "exportDownloaded": "JSON когорты загружен",
       "copiedToClipboard": "JSON когорты скопирован в буфер обмена",
@@ -3231,6 +3235,8 @@
   },
   "cohortDefinitions": {
     "closeYourCurrentCohort": "Пожалуйста, закройте текущее определение когорты перед созданием нового",
+    "copyLoadForbidden": "У вас нет прав для чтения этой когорты.",
+    "deleteError": "Не удалось удалить когорту.",
     "cohort": {
       "modals": {
         "analysisTypes": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1344,6 +1344,7 @@
       "description": "Случайная выборка лиц из сгенерированной когорты с возможностью фильтрации по возрасту и полу.",
       "newSample": "Новая выборка",
       "failedToLoadSamples": "Не удалось загрузить выборки",
+      "failedToLoadSampleDetail": "Не удалось загрузить сведения о выборке",
       "failedToCreateSample": "Не удалось создать выборку"
     },
     "cohortSampleDetail": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1496,7 +1496,8 @@
       "searching": "正在搜索概念...",
       "foundResults": "找到 {count} 条结果",
       "conceptMeta": "ID: {id} | 代码: {code} | 域: {domain}",
-      "enterSearchTerm": "输入搜索词以查找概念"
+      "enterSearchTerm": "输入搜索词以查找概念",
+      "searchFailed": "搜索概念失败"
     },
     "cohortBuilder": {
       "stateRequired": "必填",
@@ -1513,8 +1514,11 @@
       "stateDrugExposure": "药物暴露",
       "stateConfigured": "已配置",
       "saveToServerError": "无法将队列保存到服务器",
+      "saveForbidden": "您没有权限保存此队列",
       "saveSuccess": "队列保存成功",
       "saveError": "无法保存队列",
+      "loadForbidden": "您没有权限打开此队列",
+      "loadError": "加载队列失败",
       "exportFailed": "导出失败：{error}",
       "exportDownloaded": "已下载队列 JSON",
       "copiedToClipboard": "已将队列 JSON 复制到剪贴板",
@@ -3218,6 +3222,8 @@
   },
   "cohortDefinitions": {
     "closeYourCurrentCohort": "在创建新的队列定义之前，请先关闭您的当前队列定义",
+    "copyLoadForbidden": "您没有权限读取此队列。",
+    "deleteError": "删除队列失败。",
     "cohort": {
       "modals": {
         "analysisTypes": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1331,6 +1331,7 @@
       "description": "从生成的队列中随机抽取的人员，可按年龄和性别进行筛选。",
       "newSample": "新建样本",
       "failedToLoadSamples": "加载样本失败",
+      "failedToLoadSampleDetail": "加载样本详情失败",
       "failedToCreateSample": "创建样本失败"
     },
     "cohortSampleDetail": {

--- a/src/plugins/host/pythiaBridge.ts
+++ b/src/plugins/host/pythiaBridge.ts
@@ -242,13 +242,22 @@ async function handleCreateStandaloneConceptSet(
     includeMapped: false,
   }))
 
-  const created = await createConceptSet({
-    name: payload.name,
-    description: payload.description ?? '',
-    items: conceptSetItems,
-  })
+  let created
+  try {
+    created = await createConceptSet({
+      name: payload.name,
+      description: payload.description ?? '',
+      items: conceptSetItems,
+    })
+  } catch (err) {
+    showSnackbar(
+      err instanceof Error ? err.message : 'Failed to create concept set',
+      'error'
+    )
+    return
+  }
 
-  if (!created || created.id === undefined || created.id === null) {
+  if (created.id === undefined || created.id === null) {
     showSnackbar('Failed to create concept set', 'error')
     return
   }

--- a/src/plugins/host/pythiaBridge.ts
+++ b/src/plugins/host/pythiaBridge.ts
@@ -7,7 +7,7 @@ import { useFeatureAnalysesStore } from '@/stores/feature-analyses'
 import { useCharacterizationStore } from '@/stores/characterization'
 import { usePathwayStore } from '@/stores/pathway'
 import { useIncidenceRateStore } from '@/stores/incidence-rate'
-import { useUIStore } from '@/stores/ui'
+import { useNotifications } from '@/stores/notifications'
 import type {
   AgentProposal,
   CharacterizationCreatePayload,
@@ -848,13 +848,13 @@ function handleSnackbar(payload: { message: string; type?: string }) {
   showSnackbar(payload.message, payload.type ?? 'info')
 }
 
+// The UI store never defined showSnackbar, so every message the bridge raised
+// fell through to a log line the user never saw. Route them to the
+// notification store that AtlasNotificationHost actually renders.
 function showSnackbar(message: string, type: string = 'info') {
-  const ui = useUIStore()
-  const fn = (ui as unknown as { showSnackbar?: (msg: string, t?: string) => void })
-    .showSnackbar
-  if (typeof fn === 'function') {
-    fn(message, type)
-  } else {
-    logger.info('pythiaBridge', 'snackbar', { message, type })
-  }
+  const notify = useNotifications()
+  if (type === 'error') notify.danger(message)
+  else if (type === 'success') notify.success(message)
+  else if (type === 'warning') notify.warning(message)
+  else notify.info(message)
 }

--- a/src/services/api-error.ts
+++ b/src/services/api-error.ts
@@ -43,6 +43,8 @@ export async function unwrap<T>(fn: () => Promise<T>, context: string): Promise<
 /**
  * The WebAPI list endpoint may return either a bare array or a Spring
  * Data-style page wrapper `{ content: [...] }`. Normalise to a plain array.
+ * Anything else (SSO-redirect JSON, an error body served with HTTP 200) is
+ * not "an empty list" — throw so the caller's unwrap() surfaces it.
  */
 export function unwrapList<T = unknown>(payload: unknown): T[] {
   if (Array.isArray(payload)) return payload as T[]
@@ -53,5 +55,9 @@ export function unwrapList<T = unknown>(payload: unknown): T[] {
   ) {
     return (payload as { content: T[] }).content
   }
-  return []
+  throw new ApiError(
+    'Expected a list response but got a different shape',
+    0,
+    JSON.stringify(payload) ?? String(payload)
+  )
 }

--- a/src/services/api-error.ts
+++ b/src/services/api-error.ts
@@ -1,4 +1,4 @@
-import type { ZodError } from 'zod'
+import type { ZodError, ZodType, ZodTypeDef } from 'zod'
 import { logger } from '@/utils/logger'
 import { type ApiResult, success, failure } from '@/types/api'
 
@@ -28,6 +28,23 @@ export function toApiError(err: unknown): ApiError {
   if (err instanceof ApiError) return err
   if (err instanceof Error) return new ApiError(err.message, 0, null)
   return new ApiError(String(err), 0, null)
+}
+
+/**
+ * Validate a response payload, throwing the standard ApiError shape on
+ * mismatch: `message` for the toast, zod issues in `body` for the log.
+ * unwrap() already logs the thrown error - don't log again at the call site.
+ */
+export function parseOrThrow<T>(
+  schema: ZodType<T, ZodTypeDef, unknown>,
+  data: unknown,
+  message: string
+): T {
+  const parsed = schema.safeParse(data)
+  if (!parsed.success) {
+    throw new ApiError(message, 0, zodIssues(parsed.error))
+  }
+  return parsed.data
 }
 
 export async function unwrap<T>(fn: () => Promise<T>, context: string): Promise<ApiResult<T>> {

--- a/src/services/characterization.service.ts
+++ b/src/services/characterization.service.ts
@@ -5,6 +5,7 @@
  */
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead } from '@/services/http-client'
 import { unwrap, unwrapList, ApiError, zodIssues } from '@/services/api-error'
+import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
 import {
   CharacterizationDefinitionSchema,
@@ -256,7 +257,7 @@ export async function getCharacterizationExecution(
 export async function generateCharacterization(
   id: number,
   sourceKey: string
-): Promise<ApiResult<CharacterizationExecution>> {
+): Promise<ApiResult<CharacterizationExecution | null>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(
       `/cohort-characterization/${id}/generation/${encodeURIComponent(sourceKey)}`
@@ -281,7 +282,18 @@ export async function generateCharacterization(
       )
     }
 
-    const executionId = job.data.executionId ?? job.data.id ?? 0
+    // Don't fabricate an execution id: polling id 0 would track a phantom
+    // execution. The generation did start, so this isn't a failure either -
+    // return null so the caller refreshes the canonical list instead.
+    const executionId = job.data.executionId ?? job.data.id
+    if (executionId === undefined) {
+      logger.warn(
+        CONTEXT,
+        `Generation response from POST /cohort-characterization/${id}/generation/${sourceKey} carried no execution id`,
+        job.data
+      )
+      return null
+    }
     return {
       id: executionId,
       status: job.data.status ?? 'STARTING',

--- a/src/services/characterization.service.ts
+++ b/src/services/characterization.service.ts
@@ -4,7 +4,7 @@
  * (WebAPI /cohort-characterization/...)
  */
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead } from '@/services/http-client'
-import { unwrap, unwrapList, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, unwrapList, ApiError, parseOrThrow } from '@/services/api-error'
 import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
 import {
@@ -28,11 +28,7 @@ export async function listCharacterizations(): Promise<ApiResult<Characterizatio
   return unwrap(async () => {
     const data = await httpGet<unknown>('/cohort-characterization?size=10000')
     const list = unwrapList(data)
-    const parsed = z.array(CharacterizationListItemSchema).safeParse(list)
-    if (!parsed.success) {
-      throw new ApiError('Invalid response from /cohort-characterization', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(z.array(CharacterizationListItemSchema), list, 'Invalid response from /cohort-characterization')
   }, CONTEXT)
 }
 
@@ -45,15 +41,11 @@ export async function getCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohort-characterization/${id}/design`)
-    const parsed = CharacterizationDefinitionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from /cohort-characterization/${id}/design`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as CharacterizationDefinition
+    return parseOrThrow(
+      CharacterizationDefinitionSchema,
+      data,
+      `Invalid response from /cohort-characterization/${id}/design`
+    ) as CharacterizationDefinition
   }, CONTEXT)
 }
 
@@ -82,15 +74,11 @@ export async function createCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/cohort-characterization', serializeCharacterization(def))
-    const parsed = CharacterizationDefinitionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        'Invalid response from POST /cohort-characterization',
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as CharacterizationDefinition
+    return parseOrThrow(
+      CharacterizationDefinitionSchema,
+      data,
+      'Invalid response from POST /cohort-characterization'
+    ) as CharacterizationDefinition
   }, CONTEXT)
 }
 
@@ -109,15 +97,11 @@ export async function updateCharacterization(
       `/cohort-characterization/${def.id}`,
       serializeCharacterization(def)
     )
-    const parsed = CharacterizationDefinitionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from PUT /cohort-characterization/${def.id}`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as CharacterizationDefinition
+    return parseOrThrow(
+      CharacterizationDefinitionSchema,
+      data,
+      `Invalid response from PUT /cohort-characterization/${def.id}`
+    ) as CharacterizationDefinition
   }, CONTEXT)
 }
 
@@ -141,15 +125,11 @@ export async function copyCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(`/cohort-characterization/${id}`)
-    const parsed = CharacterizationDefinitionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from POST /cohort-characterization/${id}`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as CharacterizationDefinition
+    return parseOrThrow(
+      CharacterizationDefinitionSchema,
+      data,
+      `Invalid response from POST /cohort-characterization/${id}`
+    ) as CharacterizationDefinition
   }, CONTEXT)
 }
 
@@ -190,15 +170,11 @@ export async function importCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/cohort-characterization/import', design)
-    const parsed = CharacterizationDefinitionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        'Invalid response from POST /cohort-characterization/import',
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as CharacterizationDefinition
+    return parseOrThrow(
+      CharacterizationDefinitionSchema,
+      data,
+      'Invalid response from POST /cohort-characterization/import'
+    ) as CharacterizationDefinition
   }, CONTEXT)
 }
 
@@ -212,15 +188,11 @@ export async function listCharacterizationExecutions(
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohort-characterization/${id}/generation`)
     const list = unwrapList(data)
-    const parsed = z.array(CharacterizationExecutionSchema).safeParse(list)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from /cohort-characterization/${id}/generation`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data
+    return parseOrThrow(
+      z.array(CharacterizationExecutionSchema),
+      list,
+      `Invalid response from /cohort-characterization/${id}/generation`
+    )
   }, CONTEXT)
 }
 
@@ -233,15 +205,11 @@ export async function getCharacterizationExecution(
 ): Promise<ApiResult<CharacterizationExecution>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohort-characterization/generation/${generationId}`)
-    const parsed = CharacterizationExecutionSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from /cohort-characterization/generation/${generationId}`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data
+    return parseOrThrow(
+      CharacterizationExecutionSchema,
+      data,
+      `Invalid response from /cohort-characterization/generation/${generationId}`
+    )
   }, CONTEXT)
 }
 
@@ -273,30 +241,27 @@ export async function generateCharacterization(
         status: GenerationStatusSchema.optional(),
       })
       .passthrough()
-    const job = jobExecutionSchema.safeParse(data)
-    if (!job.success) {
-      throw new ApiError(
-        `Invalid response from POST /cohort-characterization/${id}/generation/${sourceKey}`,
-        0,
-        zodIssues(job.error)
-      )
-    }
+    const job = parseOrThrow(
+      jobExecutionSchema,
+      data,
+      `Invalid response from POST /cohort-characterization/${id}/generation/${sourceKey}`
+    )
 
     // Don't fabricate an execution id: polling id 0 would track a phantom
     // execution. The generation did start, so this isn't a failure either -
     // return null so the caller refreshes the canonical list instead.
-    const executionId = job.data.executionId ?? job.data.id
+    const executionId = job.executionId ?? job.id
     if (executionId === undefined) {
       logger.warn(
         CONTEXT,
         `Generation response from POST /cohort-characterization/${id}/generation/${sourceKey} carried no execution id`,
-        job.data
+        job
       )
       return null
     }
     return {
       id: executionId,
-      status: job.data.status ?? 'STARTING',
+      status: job.status ?? 'STARTING',
       sourceKey,
     }
   }, CONTEXT)
@@ -338,15 +303,11 @@ export async function getCharacterizationResultCount(
     const data = await httpGet<unknown>(
       `/cohort-characterization/generation/${generationId}/result/count`
     )
-    const parsed = z.number().safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from /cohort-characterization/generation/${generationId}/result/count`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data
+    return parseOrThrow(
+      z.number(),
+      data,
+      `Invalid response from /cohort-characterization/generation/${generationId}/result/count`
+    )
   }, CONTEXT)
 }
 

--- a/src/services/cohort-definition.service.ts
+++ b/src/services/cohort-definition.service.ts
@@ -5,7 +5,7 @@
  */
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead, getBaseUrl } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import {
   type AtlasCohortDefinition,
@@ -134,11 +134,7 @@ export async function getCohortGenerationInfo(
 ): Promise<ApiResult<CohortGenerationInfoList>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohortdefinition/${cohortId}/info`)
-    const parsed = CohortGenerationInfoListSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort generation info response format', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortGenerationInfoListSchema, data, 'Invalid cohort generation info response format')
   }, CONTEXT)
 }
 
@@ -150,11 +146,7 @@ export async function getCohortGenerationInfo(
 export async function getCohorts(): Promise<ApiResult<CohortDefinitionSummary[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>('/cohortdefinition')
-    const parsed = CohortDefinitionListSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort list response format', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortDefinitionListSchema, data, 'Invalid cohort list response format')
   }, CONTEXT)
 }
 

--- a/src/services/cohort-sample.service.ts
+++ b/src/services/cohort-sample.service.ts
@@ -5,7 +5,7 @@
  * generated cohort, optionally filtered by age and gender criteria.
  */
 import { httpGet, httpPost, httpDelete } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import {
   CohortSampleSchema,
@@ -27,11 +27,7 @@ export async function listCohortSamples(
 ): Promise<ApiResult<CohortSampleList>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohortsample/${cohortDefinitionId}/${sourceKey}`)
-    const parsed = CohortSampleListSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort sample list response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortSampleListSchema, data, 'Invalid cohort sample list response')
   }, CONTEXT)
 }
 
@@ -61,11 +57,7 @@ export async function getCohortSample(
       ? `/cohortsample/${cohortDefinitionId}/${sourceKey}/${sampleId}?fields=elements`
       : `/cohortsample/${cohortDefinitionId}/${sourceKey}/${sampleId}`
     const data = await httpGet<unknown>(url)
-    const parsed = CohortSampleSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort sample response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortSampleSchema, data, 'Invalid cohort sample response')
   }, CONTEXT)
 }
 
@@ -80,11 +72,7 @@ export async function createCohortSample(
 ): Promise<ApiResult<CohortSample>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(`/cohortsample/${cohortDefinitionId}/${sourceKey}`, parameters)
-    const parsed = CohortSampleSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort sample response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortSampleSchema, data, 'Invalid cohort sample response')
   }, CONTEXT)
 }
 
@@ -101,11 +89,7 @@ export async function refreshCohortSample(
     const data = await httpPost<unknown>(
       `/cohortsample/${cohortDefinitionId}/${sourceKey}/${sampleId}/refresh`
     )
-    const parsed = CohortSampleSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort sample response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CohortSampleSchema, data, 'Invalid cohort sample response')
   }, CONTEXT)
 }
 

--- a/src/services/concept-search.service.ts
+++ b/src/services/concept-search.service.ts
@@ -12,7 +12,7 @@ import {
 import { mapConceptFromAPI, mapComparisonItemFromAPI } from '@/utils/api-mappers'
 import { logger } from '@/utils/logger'
 import { httpClient, httpPostRead } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, ApiError, zodIssues, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 
 type ConceptRecordCountResponse = Array<Record<string, number[]>>
@@ -20,15 +20,6 @@ type ConceptRecordCountResponse = Array<Record<string, number[]>>
 export type RecommendedConceptsResult =
   | { available: true; concepts: Concept[] }
   | { available: false; concepts: [] }
-
-// httpClient throws `Error('HTTP {status}: {statusText}')` — parse the code
-// out so we can distinguish 501 (feature unavailable) from real failures.
-function extractHttpStatus(error: unknown): number | null {
-  if (!(error instanceof Error)) return null
-  const match = /^HTTP (\d{3})\b/.exec(error.message)
-  if (!match || !match[1]) return null
-  return parseInt(match[1], 10)
-}
 
 // Single implementation for the one endpoint, POST /vocabulary/{sourceKey}/search:
 // the ApiResult contract (this used to be the separate searchConceptsResult),
@@ -64,14 +55,9 @@ export async function searchConcepts(
       body.DOMAIN_ID = [options.domain]
     }
     const data = await httpPostRead<unknown>(endpoint, body)
-    const parsed = ConceptSearchResponseSchema.safeParse(data)
+    const parsed = parseOrThrow(ConceptSearchResponseSchema, data, 'Invalid concept search response format')
 
-    if (!parsed.success) {
-      logger.error('ConceptSearch', 'Concept search validation error', parsed.error)
-      throw new ApiError('Invalid concept search response format', 0, zodIssues(parsed.error))
-    }
-
-    return parsed.data.map(mapConceptFromAPI)
+    return parsed.map(mapConceptFromAPI)
   }, 'ConceptSearchService')
 }
 
@@ -86,13 +72,16 @@ export async function getConceptById(
 
     if (!parsed.success) {
       logger.error('ConceptSearch', 'Concept detail validation error', parsed.error)
-      return null
+      throw new ApiError('Invalid concept detail response', 0, zodIssues(parsed.error))
     }
 
     return mapConceptFromAPI(parsed.data)
   } catch (error) {
+    // null strictly means "no such concept" - anything else (transport,
+    // validation) propagates so callers don't render a failure as not-found.
+    if (error instanceof ApiError && error.status === 404) return null
     logger.error('ConceptSearch', `Failed to fetch concept ${conceptId}`, error)
-    return null
+    throw error
   }
 }
 
@@ -259,7 +248,8 @@ export async function getRecommendedConcepts(
   try {
     data = await httpPostRead<unknown>(endpoint, conceptIds)
   } catch (error) {
-    if (extractHttpStatus(error) === 501) {
+    // 501 = feature unavailable on this WebAPI build, not a real failure.
+    if (error instanceof ApiError && error.status === 501) {
       return { available: false, concepts: [] }
     }
     throw error

--- a/src/services/concept-set-versions.service.ts
+++ b/src/services/concept-set-versions.service.ts
@@ -50,7 +50,9 @@ const conceptSetExpressionResponseSchema = z.object({
         includeMapped: z.boolean(),
       })
     )
-    .optional(),
+    // WebAPI sends items: null instead of [] for empty item lists (see the
+    // sibling schema above) - tolerate both here too.
+    .nullish(),
 })
 
 /**

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -96,13 +96,15 @@ export async function getAllConceptSets(): Promise<ConceptSetListItem[]> {
 
     if (!parsed.success) {
       logger.error('ConceptSet', 'Concept set list validation error', parsed.error)
-      return []
+      throw new Error('Invalid concept set list response')
     }
 
     return parsed.data
   } catch (error) {
+    // A failed fetch is not "no concept sets" - propagate so the store's
+    // error state renders instead of an empty list.
     logger.error('ConceptSet', 'Failed to fetch concept sets', error)
-    return []
+    throw error
   }
 }
 
@@ -146,7 +148,7 @@ export async function getConceptSetById(
  */
 export async function createConceptSet(
   conceptSet: Omit<ConceptSet, 'id' | 'createdDate' | 'createdBy' | 'modifiedDate' | 'modifiedBy'>
-): Promise<ConceptSet | null> {
+): Promise<ConceptSet> {
   try {
     const metadataPayload = {
       name: conceptSet.name,
@@ -184,8 +186,10 @@ export async function createConceptSet(
 
     return mapConceptSetFromAPI(data)
   } catch (error) {
+    // Propagate: the server's error detail (fetchJSON surfaces the body) is
+    // what the user needs; a bare null reduced every failure to a generic toast.
     logger.error('ConceptSet', 'Failed to create concept set', error)
-    return null
+    throw error
   }
 }
 
@@ -194,7 +198,7 @@ export async function createConceptSet(
  * @param conceptSet Concept set with id
  * @returns Updated concept set
  */
-export async function updateConceptSet(conceptSet: ConceptSet): Promise<ConceptSet | null> {
+export async function updateConceptSet(conceptSet: ConceptSet): Promise<ConceptSet> {
   if (!conceptSet.id) {
     throw new Error('Concept set ID is required for update')
   }
@@ -236,7 +240,7 @@ export async function updateConceptSet(conceptSet: ConceptSet): Promise<ConceptS
     })
   } catch (error) {
     logger.error('ConceptSet', `Failed to update concept set ${conceptSet.id}`, error)
-    return null
+    throw error
   }
 }
 

--- a/src/services/feature-analysis.service.ts
+++ b/src/services/feature-analysis.service.ts
@@ -3,7 +3,7 @@
  * CRUD and metadata lookups for feature analyses (WebAPI /feature-analysis/...)
  */
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
-import { unwrap, unwrapList, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, unwrapList, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import {
   FeatureAnalysisSchema,
@@ -27,11 +27,7 @@ export async function listFeatureAnalyses(): Promise<ApiResult<FeatureAnalysisLi
   return unwrap(async () => {
     const data = await httpGet<unknown>('/feature-analysis?size=100000')
     const list = unwrapList(data)
-    const parsed = z.array(FeatureAnalysisListItemSchema).safeParse(list)
-    if (!parsed.success) {
-      throw new ApiError('Invalid response from /feature-analysis', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(z.array(FeatureAnalysisListItemSchema), list, 'Invalid response from /feature-analysis')
   }, CONTEXT)
 }
 
@@ -42,11 +38,7 @@ export async function listFeatureAnalyses(): Promise<ApiResult<FeatureAnalysisLi
 export async function getFeatureAnalysis(id: number): Promise<ApiResult<FeatureAnalysis>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/feature-analysis/${id}`)
-    const parsed = FeatureAnalysisSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(`Invalid response from /feature-analysis/${id}`, 0, zodIssues(parsed.error))
-    }
-    return parsed.data as FeatureAnalysis
+    return parseOrThrow(FeatureAnalysisSchema, data, `Invalid response from /feature-analysis/${id}`) as FeatureAnalysis
   }, CONTEXT)
 }
 
@@ -59,11 +51,7 @@ export async function createFeatureAnalysis(
 ): Promise<ApiResult<FeatureAnalysis>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/feature-analysis', fa)
-    const parsed = FeatureAnalysisSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid response from POST /feature-analysis', 0, zodIssues(parsed.error))
-    }
-    return parsed.data as FeatureAnalysis
+    return parseOrThrow(FeatureAnalysisSchema, data, 'Invalid response from POST /feature-analysis') as FeatureAnalysis
   }, CONTEXT)
 }
 
@@ -79,15 +67,11 @@ export async function updateFeatureAnalysis(
       throw new Error('updateFeatureAnalysis requires fa.id')
     }
     const data = await httpPut<unknown>(`/feature-analysis/${fa.id}`, fa)
-    const parsed = FeatureAnalysisSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from PUT /feature-analysis/${fa.id}`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as FeatureAnalysis
+    return parseOrThrow(
+      FeatureAnalysisSchema,
+      data,
+      `Invalid response from PUT /feature-analysis/${fa.id}`
+    ) as FeatureAnalysis
   }, CONTEXT)
 }
 
@@ -108,15 +92,11 @@ export async function deleteFeatureAnalysis(id: number): Promise<ApiResult<void>
 export async function copyFeatureAnalysis(id: number): Promise<ApiResult<FeatureAnalysis>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/feature-analysis/${id}/copy`)
-    const parsed = FeatureAnalysisSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        `Invalid response from /feature-analysis/${id}/copy`,
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data as FeatureAnalysis
+    return parseOrThrow(
+      FeatureAnalysisSchema,
+      data,
+      `Invalid response from /feature-analysis/${id}/copy`
+    ) as FeatureAnalysis
   }, CONTEXT)
 }
 
@@ -150,11 +130,8 @@ export async function listFeatureAnalysisDomains(): Promise<ApiResult<string[]>>
   return unwrap(async () => {
     const data = await httpGet<unknown>('/feature-analysis/domains')
     const schema = z.array(z.union([z.string(), z.object({ id: z.string() }).passthrough()]))
-    const parsed = schema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid response from /feature-analysis/domains', 0, zodIssues(parsed.error))
-    }
-    return parsed.data.map(entry => (typeof entry === 'string' ? entry : entry.id))
+    const parsed = parseOrThrow(schema, data, 'Invalid response from /feature-analysis/domains')
+    return parsed.map(entry => (typeof entry === 'string' ? entry : entry.id))
   }, CONTEXT)
 }
 
@@ -167,15 +144,11 @@ export async function listFeatureAnalysisAggregates(): Promise<
 > {
   return unwrap(async () => {
     const data = await httpGet<unknown>('/feature-analysis/aggregates')
-    const parsed = z.array(FeatureAnalysisAggregateSchema).safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        'Invalid response from /feature-analysis/aggregates',
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data
+    return parseOrThrow(
+      z.array(FeatureAnalysisAggregateSchema),
+      data,
+      'Invalid response from /feature-analysis/aggregates'
+    )
   }, CONTEXT)
 }
 
@@ -190,14 +163,10 @@ export async function getDefaultCovariateSettings(
     const data = await httpGet<unknown>(
       `/featureextraction/defaultcovariatesettings?temporal=${temporal ? 'true' : 'false'}`
     )
-    const parsed = CovariateSettingSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError(
-        'Invalid response from /featureextraction/defaultcovariatesettings',
-        0,
-        zodIssues(parsed.error)
-      )
-    }
-    return parsed.data
+    return parseOrThrow(
+      CovariateSettingSchema,
+      data,
+      'Invalid response from /featureextraction/defaultcovariatesettings'
+    )
   }, CONTEXT)
 }

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -155,7 +155,11 @@ export async function httpClient<T>(endpoint: string, options: HttpClientOptions
         } catch {
           // keep statusText
         }
-        const error = new ApiError(`HTTP ${response.status}: ${detail}`, response.status, detail)
+        // error.message ends up in user-facing toasts; a WebAPI error body can
+        // be a full HTML stack trace, so cap it there. `body` keeps the whole
+        // thing for logs.
+        const summary = detail.length > 300 ? `${detail.slice(0, 300)}…` : detail
+        const error = new ApiError(`HTTP ${response.status}: ${summary}`, response.status, detail)
         if (retryAllowed && isRetryableError(error, response.status) && attempt < maxRetries - 1) {
           const delay = initialDelay * Math.pow(2, attempt)
           logger.warn(

--- a/src/services/incidence-rate.service.ts
+++ b/src/services/incidence-rate.service.ts
@@ -29,7 +29,9 @@ const CONTEXT = 'IncidenceRateService'
 // always works with a parsed object.
 function decodeIRExpression(wire: unknown): IncidenceRate {
   const parsed = IncidenceRateWireSchema.safeParse(wire)
-  if (!parsed.success) throw parsed.error
+  if (!parsed.success) {
+    throw new ApiError('Invalid incidence rate response', 0, zodIssues(parsed.error))
+  }
   const { expression: raw, ...rest } = parsed.data
   if (!raw) {
     return {
@@ -48,8 +50,11 @@ function decodeIRExpression(wire: unknown): IncidenceRate {
   } catch {
     throw new Error('expression is not valid JSON')
   }
-  const expr = IncidenceRateExpressionSchema.parse(parsedExpr)
-  return { ...rest, expression: expr } as IncidenceRate
+  const expr = IncidenceRateExpressionSchema.safeParse(parsedExpr)
+  if (!expr.success) {
+    throw new ApiError('Invalid incidence rate expression', 0, zodIssues(expr.error))
+  }
+  return { ...rest, expression: expr.data } as IncidenceRate
 }
 
 function encodeIRForSave(ir: IncidenceRate): Record<string, unknown> {

--- a/src/services/incidence-rate.service.ts
+++ b/src/services/incidence-rate.service.ts
@@ -4,7 +4,7 @@
  * (WebAPI /ir/...)
  */
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { logger } from '@/utils/logger'
 import {
@@ -28,11 +28,11 @@ const CONTEXT = 'IncidenceRateService'
 // for both reads and writes. Decode/encode at the boundary so the editor
 // always works with a parsed object.
 function decodeIRExpression(wire: unknown): IncidenceRate {
-  const parsed = IncidenceRateWireSchema.safeParse(wire)
-  if (!parsed.success) {
-    throw new ApiError('Invalid incidence rate response', 0, zodIssues(parsed.error))
-  }
-  const { expression: raw, ...rest } = parsed.data
+  const { expression: raw, ...rest } = parseOrThrow(
+    IncidenceRateWireSchema,
+    wire,
+    'Invalid incidence rate response'
+  )
   if (!raw) {
     return {
       ...rest,
@@ -50,11 +50,8 @@ function decodeIRExpression(wire: unknown): IncidenceRate {
   } catch {
     throw new Error('expression is not valid JSON')
   }
-  const expr = IncidenceRateExpressionSchema.safeParse(parsedExpr)
-  if (!expr.success) {
-    throw new ApiError('Invalid incidence rate expression', 0, zodIssues(expr.error))
-  }
-  return { ...rest, expression: expr.data } as IncidenceRate
+  const expr = parseOrThrow(IncidenceRateExpressionSchema, parsedExpr, 'Invalid incidence rate expression')
+  return { ...rest, expression: expr } as IncidenceRate
 }
 
 function encodeIRForSave(ir: IncidenceRate): Record<string, unknown> {
@@ -66,11 +63,11 @@ function encodeIRForSave(ir: IncidenceRate): Record<string, unknown> {
 export async function listIncidenceRates(): Promise<ApiResult<IncidenceRate[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>('/ir/')
-    const parsed = z.array(IncidenceRateSummarySchema.passthrough()).safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid incidence rate list response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data as IncidenceRate[]
+    return parseOrThrow(
+      z.array(IncidenceRateSummarySchema.passthrough()),
+      data,
+      'Invalid incidence rate list response'
+    ) as IncidenceRate[]
   }, CONTEXT)
 }
 
@@ -169,11 +166,7 @@ export async function listIncidenceRateInfo(
 ): Promise<ApiResult<IncidenceRateInfoBySource[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/ir/${id}/info`)
-    const parsed = IncidenceRateInfoListSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid info list response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(IncidenceRateInfoListSchema, data, 'Invalid info list response')
   }, CONTEXT)
 }
 
@@ -184,11 +177,7 @@ export async function getIncidenceRateInfoBySource(
 ): Promise<ApiResult<IncidenceRateInfoBySource>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/ir/${id}/info/${sourceKey}`)
-    const parsed = IncidenceRateInfoBySourceSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid info-by-source response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(IncidenceRateInfoBySourceSchema, data, 'Invalid info-by-source response')
   }, CONTEXT)
 }
 
@@ -235,10 +224,10 @@ export async function getIncidenceRateReport(
   return unwrap(async () => {
     const url = `/ir/${id}/report/${sourceKey}?targetId=${targetId}&outcomeId=${outcomeId}`
     const data = await httpGet<unknown>(url)
-    const parsed = IncidenceRateReportSchema.passthrough().safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid report response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data as IncidenceRateReport
+    return parseOrThrow(
+      IncidenceRateReportSchema.passthrough(),
+      data,
+      'Invalid report response'
+    ) as IncidenceRateReport
   }, CONTEXT)
 }

--- a/src/services/jobs.service.ts
+++ b/src/services/jobs.service.ts
@@ -6,9 +6,8 @@
  */
 
 import { httpGet } from '@/services/http-client'
-import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
-import { unwrap, ApiError } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import {
   JobExecutionListSchema,
   type Job,
@@ -48,15 +47,10 @@ export async function getJobs(): Promise<ApiResult<Job[]>> {
     const batchData = await httpGet<unknown>('/job/execution?comprehensivePage=true')
 
     // Validate Spring Batch response with Zod
-    const parsed = JobExecutionListSchema.safeParse(batchData)
-
-    if (!parsed.success) {
-      logger.error('JobsService', 'Job executions validation error', parsed.error)
-      throw new ApiError('Invalid job executions response format', 0, null)
-    }
+    const parsed = parseOrThrow(JobExecutionListSchema, batchData, 'Invalid job executions response format')
 
     // Extract executions from response (handles both array and paginated formats)
-    const executions = extractExecutions(parsed.data)
+    const executions = extractExecutions(parsed)
 
     const jobs = executions.map(transformJobExecution)
 

--- a/src/services/pathway.service.ts
+++ b/src/services/pathway.service.ts
@@ -4,7 +4,7 @@
  * (WebAPI /pathway-analysis/...)
  */
 import { httpGet, httpPost, httpPostRead, httpPut, httpDelete } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { logger } from '@/utils/logger'
 import {
@@ -51,9 +51,7 @@ export async function listPathways(): Promise<ApiResult<Pathway[]>> {
 export async function getPathway(id: number): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/pathway-analysis/${id}`)
-    const parsed = PathwaySchema.passthrough().safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid pathway response', 0, zodIssues(parsed.error))
-    return parsed.data as Pathway
+    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid pathway response') as Pathway
   }, CONTEXT)
 }
 
@@ -64,9 +62,7 @@ export async function getPathway(id: number): Promise<ApiResult<Pathway>> {
 export async function createPathway(pathway: Pathway): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/pathway-analysis', pathway)
-    const parsed = PathwaySchema.passthrough().safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid create response', 0, zodIssues(parsed.error))
-    return parsed.data as Pathway
+    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid create response') as Pathway
   }, CONTEXT)
 }
 
@@ -77,9 +73,7 @@ export async function createPathway(pathway: Pathway): Promise<ApiResult<Pathway
 export async function savePathway(id: number, pathway: Pathway): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpPut<unknown>(`/pathway-analysis/${id}`, pathway)
-    const parsed = PathwaySchema.passthrough().safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid save response', 0, zodIssues(parsed.error))
-    return parsed.data as Pathway
+    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid save response') as Pathway
   }, CONTEXT)
 }
 
@@ -90,9 +84,7 @@ export async function savePathway(id: number, pathway: Pathway): Promise<ApiResu
 export async function copyPathway(id: number): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(`/pathway-analysis/${id}`, undefined)
-    const parsed = PathwaySchema.passthrough().safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid copy response', 0, zodIssues(parsed.error))
-    return parsed.data as Pathway
+    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid copy response') as Pathway
   }, CONTEXT)
 }
 
@@ -194,9 +186,7 @@ export async function runPathwayDiagnostics(pathway: Pathway): Promise<PathwayDi
 export async function listPathwayExecutions(id: number): Promise<ApiResult<PathwayExecution[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/pathway-analysis/${id}/generation`)
-    const parsed = PathwayExecutionListSchema.safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid execution list', 0, zodIssues(parsed.error))
-    return parsed.data
+    return parseOrThrow(PathwayExecutionListSchema, data, 'Invalid execution list')
   }, CONTEXT)
 }
 
@@ -209,9 +199,7 @@ export async function getPathwayExecution(
 ): Promise<ApiResult<PathwayExecution>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/pathway-analysis/generation/${generationId}`)
-    const parsed = PathwayExecutionSchema.safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid execution response', 0, zodIssues(parsed.error))
-    return parsed.data
+    return parseOrThrow(PathwayExecutionSchema, data, 'Invalid execution response')
   }, CONTEXT)
 }
 
@@ -222,9 +210,7 @@ export async function getPathwayExecution(
 export async function getPathwayResults(generationId: number): Promise<ApiResult<PathwayResults>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/pathway-analysis/generation/${generationId}/result`)
-    const parsed = PathwayResultsSchema.safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid results response', 0, zodIssues(parsed.error))
-    return parsed.data
+    return parseOrThrow(PathwayResultsSchema, data, 'Invalid results response')
   }, CONTEXT)
 }
 
@@ -256,20 +242,19 @@ export async function generatePathway(
         status: PathwayExecutionStatusSchema.optional(),
       })
       .passthrough()
-    const job = jobSchema.safeParse(data)
-    if (!job.success) throw new ApiError('Invalid generate response', 0, zodIssues(job.error))
+    const job = parseOrThrow(jobSchema, data, 'Invalid generate response')
     // Don't fabricate an execution id: polling id 0 would track a phantom
     // execution. The generation did start, so this isn't a failure either -
     // return null so the caller skips polling and relies on the list/get
     // endpoints for the canonical row.
-    const executionId = job.data.executionId ?? job.data.id
+    const executionId = job.executionId ?? job.id
     if (executionId === undefined) {
-      logger.warn(CONTEXT, 'Generate response carried no execution id', job.data)
+      logger.warn(CONTEXT, 'Generate response carried no execution id', job)
       return null
     }
     return {
       id: executionId,
-      status: job.data.status ?? 'STARTING',
+      status: job.status ?? 'STARTING',
       sourceKey,
     }
   }, CONTEXT)
@@ -297,8 +282,6 @@ export async function getPathwayDesignByGeneration(
 ): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/pathway-analysis/generation/${generationId}/design`)
-    const parsed = PathwaySchema.passthrough().safeParse(data)
-    if (!parsed.success) throw new ApiError('Invalid design response', 0, zodIssues(parsed.error))
-    return parsed.data as Pathway
+    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid design response') as Pathway
   }, CONTEXT)
 }

--- a/src/services/pathway.service.ts
+++ b/src/services/pathway.service.ts
@@ -239,7 +239,7 @@ export async function getPathwayResults(generationId: number): Promise<ApiResult
 export async function generatePathway(
   id: number,
   sourceKey: string
-): Promise<ApiResult<PathwayExecution>> {
+): Promise<ApiResult<PathwayExecution | null>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(
       `/pathway-analysis/${id}/generation/${sourceKey}`,
@@ -258,8 +258,17 @@ export async function generatePathway(
       .passthrough()
     const job = jobSchema.safeParse(data)
     if (!job.success) throw new ApiError('Invalid generate response', 0, zodIssues(job.error))
+    // Don't fabricate an execution id: polling id 0 would track a phantom
+    // execution. The generation did start, so this isn't a failure either -
+    // return null so the caller skips polling and relies on the list/get
+    // endpoints for the canonical row.
+    const executionId = job.data.executionId ?? job.data.id
+    if (executionId === undefined) {
+      logger.warn(CONTEXT, 'Generate response carried no execution id', job.data)
+      return null
+    }
     return {
-      id: job.data.executionId ?? job.data.id ?? 0,
+      id: executionId,
       status: job.data.status ?? 'STARTING',
       sourceKey,
     }

--- a/src/services/permission.service.ts
+++ b/src/services/permission.service.ts
@@ -8,10 +8,9 @@
  */
 
 import { httpGet } from '@/services/http-client'
-import { unwrap, ApiError } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { PermissionSchema, PermissionListSchema, type Permission } from '@/models/role.types'
-import { logger } from '@/utils/logger'
 
 const CONTEXT = 'PermissionService'
 
@@ -40,14 +39,7 @@ export async function fetchPermissions(
 
     const url = `/permission/?${params.toString()}`
     const data = await httpGet<unknown>(url)
-    const parsed = PermissionListSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Permissions validation error', parsed.error)
-      throw new ApiError('Invalid permissions response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(PermissionListSchema, data, 'Invalid permissions response format')
   }, CONTEXT)
 }
 
@@ -58,14 +50,7 @@ export async function fetchPermissions(
 export async function fetchPermissionById(permissionId: number): Promise<ApiResult<Permission>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/permission/${permissionId}`)
-    const parsed = PermissionSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Permission validation error', parsed.error)
-      throw new ApiError('Invalid permission response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(PermissionSchema, data, 'Invalid permission response format')
   }, CONTEXT)
 }
 

--- a/src/services/profile.service.ts
+++ b/src/services/profile.service.ts
@@ -1,7 +1,6 @@
 import { httpGet } from '@/services/http-client'
-import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
-import { unwrap, ApiError } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import {
   PersonProfileSchema,
   type PersonProfile,
@@ -18,12 +17,7 @@ export async function getPerson(
     const cohort = cohortId ?? 0
     const endpoint = `/${sourceKey}/person/${personId}?cohort=${cohort}`
     const data = await httpGet<unknown>(endpoint)
-    const parsed = PersonProfileSchema.safeParse(data)
-    if (!parsed.success) {
-      logger.error('ProfileService', 'Person profile schema validation failed', parsed.error)
-      throw new ApiError('Invalid person profile response format', 0, null)
-    }
-    return parsed.data
+    return parseOrThrow(PersonProfileSchema, data, 'Invalid person profile response format')
   }, 'ProfileService')
 }
 

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -5,7 +5,7 @@
  */
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import {
   WebAPIReportResponseSchema,
@@ -51,15 +51,12 @@ export async function getCohortReport(
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/cohortdefinition/${cohortId}/report/${sourceKey}`)
 
-    const parsed = WebAPIReportResponseSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid cohort report response', 0, zodIssues(parsed.error))
-    }
-    if (!parsed.data.summary) {
+    const parsed = parseOrThrow(WebAPIReportResponseSchema, data, 'Invalid cohort report response')
+    if (!parsed.summary) {
       throw new ApiError('Invalid cohort report response: missing summary', 0, null)
     }
 
-    return parsed.data as WebAPIReportResponse
+    return parsed as WebAPIReportResponse
   }, CONTEXT)
 }
 
@@ -85,13 +82,10 @@ export async function getInclusionRuleReport(
       `/cohortdefinition/${cohortId}/report/${sourceKey}/inclusion?mode=${mode}`
     )
 
-    const parsed = InclusionRuleReportSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid inclusion-rule report response', 0, zodIssues(parsed.error))
-    }
+    const parsed = parseOrThrow(InclusionRuleReportSchema, data, 'Invalid inclusion-rule report response')
 
     let treemap: InclusionTreemapNode | null = null
-    const raw = parsed.data.treemapData?.trim()
+    const raw = parsed.treemapData?.trim()
     if (raw) {
       try {
         treemap = JSON.parse(raw) as InclusionTreemapNode
@@ -101,10 +95,10 @@ export async function getInclusionRuleReport(
     }
 
     return {
-      summary: parsed.data.summary,
-      inclusionRuleStats: parsed.data.inclusionRuleStats,
+      summary: parsed.summary,
+      inclusionRuleStats: parsed.inclusionRuleStats,
       treemap,
-      prevalenceThreshold: parsed.data.prevalenceThreshold,
+      prevalenceThreshold: parsed.prevalenceThreshold,
     }
   }, CONTEXT)
 }

--- a/src/services/role.service.ts
+++ b/src/services/role.service.ts
@@ -8,7 +8,7 @@
  */
 
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
-import { unwrap, ApiError } from '@/services/api-error'
+import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import {
   RawRoleSchema,
@@ -35,14 +35,7 @@ const CONTEXT = 'RoleService'
 export async function fetchRoles(): Promise<ApiResult<Role[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>('/role/')
-    const parsed = RoleListSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Roles validation error', parsed.error)
-      throw new ApiError('Invalid roles response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(RoleListSchema, data, 'Invalid roles response format')
   }, CONTEXT)
 }
 
@@ -53,14 +46,7 @@ export async function fetchRoles(): Promise<ApiResult<Role[]>> {
 export async function fetchRoleById(roleId: number): Promise<ApiResult<Role>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/role/${roleId}`)
-    const parsed = RawRoleSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Role validation error', parsed.error)
-      throw new ApiError('Invalid role response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(RawRoleSchema, data, 'Invalid role response format')
   }, CONTEXT)
 }
 
@@ -71,21 +57,16 @@ export async function fetchRoleById(roleId: number): Promise<ApiResult<Role>> {
 export async function createRole(payload: RoleCreate): Promise<ApiResult<Role>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/role/', payload)
-    const parsed = RawRoleSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Create role validation error', parsed.error)
-      throw new ApiError('Invalid role response format', 0, null)
-    }
+    const parsed = parseOrThrow(RawRoleSchema, data, 'Invalid role response format')
 
     // Audit log: Role created (FR-029)
-    logger.info(CONTEXT, `Role created: "${parsed.data.name}" (ID: ${parsed.data.id})`, {
-      roleId: parsed.data.id,
-      roleName: parsed.data.name,
+    logger.info(CONTEXT, `Role created: "${parsed.name}" (ID: ${parsed.id})`, {
+      roleId: parsed.id,
+      roleName: parsed.name,
       operation: 'CREATE',
     })
 
-    return parsed.data
+    return parsed
   }, CONTEXT)
 }
 
@@ -96,22 +77,17 @@ export async function createRole(payload: RoleCreate): Promise<ApiResult<Role>> 
 export async function updateRole(roleId: number, payload: RoleUpdate): Promise<ApiResult<Role>> {
   return unwrap(async () => {
     const data = await httpPut<unknown>(`/role/${roleId}`, payload)
-    const parsed = RawRoleSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Update role validation error', parsed.error)
-      throw new ApiError('Invalid role response format', 0, null)
-    }
+    const parsed = parseOrThrow(RawRoleSchema, data, 'Invalid role response format')
 
     // Audit log: Role updated (FR-029)
-    logger.info(CONTEXT, `Role updated: "${parsed.data.name}" (ID: ${roleId})`, {
+    logger.info(CONTEXT, `Role updated: "${parsed.name}" (ID: ${roleId})`, {
       roleId,
-      roleName: parsed.data.name,
+      roleName: parsed.name,
       operation: 'UPDATE',
       changes: payload,
     })
 
-    return parsed.data
+    return parsed
   }, CONTEXT)
 }
 
@@ -142,14 +118,7 @@ export async function deleteRole(roleId: number): Promise<ApiResult<void>> {
 export async function getRolePermissions(roleId: number): Promise<ApiResult<Permission[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/role/${roleId}/permissions`)
-    const parsed = PermissionListSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Role permissions validation error', parsed.error)
-      throw new ApiError('Invalid permissions response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(PermissionListSchema, data, 'Invalid permissions response format')
   }, CONTEXT)
 }
 
@@ -204,14 +173,7 @@ export async function removePermissionFromRole(
 export async function getRoleUsers(roleId: number): Promise<ApiResult<User[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/role/${roleId}/users`)
-    const parsed = UserListSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Role users validation error', parsed.error)
-      throw new ApiError('Invalid users response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(UserListSchema, data, 'Invalid users response format')
   }, CONTEXT)
 }
 

--- a/src/services/source.service.ts
+++ b/src/services/source.service.ts
@@ -4,7 +4,7 @@
  */
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete, getBaseUrl } from '@/services/http-client'
-import { unwrap, ApiError, zodIssues } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { CDMSourceListSchema, type CDMSource } from '@/models/webapi.types'
 import type {
@@ -21,11 +21,7 @@ import type {
 export async function fetchCDMSources(): Promise<ApiResult<CDMSource[]>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>('/source/sources')
-    const parsed = CDMSourceListSchema.safeParse(data)
-    if (!parsed.success) {
-      throw new ApiError('Invalid source list response', 0, zodIssues(parsed.error))
-    }
-    return parsed.data
+    return parseOrThrow(CDMSourceListSchema, data, 'Invalid source list response')
   }, 'SourceService')
 }
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -8,10 +8,9 @@
  */
 
 import { httpGet } from '@/services/http-client'
-import { unwrap, ApiError } from '@/services/api-error'
+import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { UserSchema, UserListSchema, type User } from '@/models/role.types'
-import { logger } from '@/utils/logger'
 
 const CONTEXT = 'UserService'
 
@@ -31,14 +30,7 @@ export async function fetchUsers(limit = 50, offset = 0): Promise<ApiResult<User
 
     const url = `/user/?${params.toString()}`
     const data = await httpGet<unknown>(url)
-    const parsed = UserListSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'Users validation error', parsed.error)
-      throw new ApiError('Invalid users response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(UserListSchema, data, 'Invalid users response format')
   }, CONTEXT)
 }
 
@@ -49,14 +41,7 @@ export async function fetchUsers(limit = 50, offset = 0): Promise<ApiResult<User
 export async function fetchUserById(userId: number): Promise<ApiResult<User>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/user/${userId}`)
-    const parsed = UserSchema.safeParse(data)
-
-    if (!parsed.success) {
-      logger.error(CONTEXT, 'User validation error', parsed.error)
-      throw new ApiError('Invalid user response format', 0, null)
-    }
-
-    return parsed.data
+    return parseOrThrow(UserSchema, data, 'Invalid user response format')
   }, CONTEXT)
 }
 

--- a/src/stores/characterization.ts
+++ b/src/stores/characterization.ts
@@ -275,7 +275,7 @@ export const useCharacterizationStore = defineStore('characterization', () => {
   async function runExecution(
     characterizationId: number,
     sourceKey: string
-  ): Promise<CharacterizationExecution> {
+  ): Promise<CharacterizationExecution | null> {
     executionsError.value = null
 
     const result = await generateCharacterization(characterizationId, sourceKey)
@@ -286,6 +286,12 @@ export const useCharacterizationStore = defineStore('characterization', () => {
     }
 
     const created = result.data
+    // Started, but the response carried nothing trackable - fall back to the
+    // canonical list instead of inserting/polling a synthetic row.
+    if (created === null) {
+      await loadExecutions(characterizationId)
+      return null
+    }
     // Replace any existing execution with the same generation id; otherwise prepend.
     const existingIdx =
       created.id != null ? executions.value.findIndex(e => e.id === created.id) : -1

--- a/src/stores/cohort.ts
+++ b/src/stores/cohort.ts
@@ -224,45 +224,35 @@ export const useCohortStore = defineStore('cohort', () => {
   // The mounted editor reads this when it answers a save request — a cohort
   // built programmatically otherwise has no name and the editor refuses to save.
   const saveOptions = ref<{ name?: string; description?: string }>({})
-  let saveResolver: ((r: { id?: number; name?: string }) => void) | null = null
-  let saveTimeoutId: ReturnType<typeof setTimeout> | null = null
+  // A queue, not a single slot: overlapping requests are answered in the order
+  // they were raised, so each caller gets its own save's result. A single slot
+  // cross-wired them — request B's arrival settled A with {}, then A's
+  // completion resolved B with A's result, and B's real result was dropped.
+  interface PendingSave {
+    resolve: (r: { id?: number; name?: string }) => void
+    timeoutId: ReturnType<typeof setTimeout>
+  }
+  const pendingSaves: PendingSave[] = []
+
+  function settleOldestSave(result: { id?: number; name?: string }) {
+    const entry = pendingSaves.shift()
+    if (!entry) return
+    clearTimeout(entry.timeoutId)
+    entry.resolve(result)
+  }
 
   function requestSave(opts: { name?: string; description?: string } = {}): Promise<{ id?: number; name?: string }> {
-    // Clear any timer from a still-in-flight prior request so its timeout
-    // can't fire later and resolve *this* request's promise instead.
-    if (saveTimeoutId) {
-      clearTimeout(saveTimeoutId)
-      saveTimeoutId = null
-    }
-    // Only one resolver slot exists, so replacing it below would otherwise
-    // strand a still-pending prior request's promise forever (its own timer
-    // was just cleared, and nothing else will ever settle it). Settle it now.
-    if (saveResolver) {
-      const prev = saveResolver
-      saveResolver = null
-      prev({})
-    }
     return new Promise(resolve => {
       saveOptions.value = opts
-      saveResolver = resolve
-      saveRequest.value++
       // Never hang the caller if no editor is mounted to answer the signal.
-      saveTimeoutId = setTimeout(() => notifySaved(), 8000)
+      const timeoutId = setTimeout(() => settleOldestSave({}), 8000)
+      pendingSaves.push({ resolve, timeoutId })
+      saveRequest.value++
     })
   }
 
   function notifySaved(result: { id?: number; name?: string } = {}) {
-    // Clear the fallback timer so a save that resolves early can't leave an
-    // orphaned timeout that later fires and steals the *next* request's
-    // resolver (which would report that later save as failed/empty and drop
-    // its real result, since saveResolver would already be null by then).
-    if (saveTimeoutId) {
-      clearTimeout(saveTimeoutId)
-      saveTimeoutId = null
-    }
-    const resolve = saveResolver
-    saveResolver = null
-    resolve?.(result)
+    settleOldestSave(result)
   }
 
   function requestNewCohort() {

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -261,15 +261,10 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
 
     try {
       const created = await createConceptSet(set)
-      if (created) {
-        // Refresh the list
-        await fetchAll()
-        currentSet.value = created
-        return created
-      } else {
-        error.value = 'Failed to create concept set'
-        return null
-      }
+      // Refresh the list
+      await fetchAll()
+      currentSet.value = created
+      return created
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to create concept set'
       logger.error('ConceptSetsStore', 'Create concept set error', err)
@@ -288,15 +283,10 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
 
     try {
       const updated = await updateConceptSet(set)
-      if (updated) {
-        // Refresh the list
-        await fetchAll()
-        currentSet.value = updated
-        return updated
-      } else {
-        error.value = 'Failed to update concept set'
-        return null
-      }
+      // Refresh the list
+      await fetchAll()
+      currentSet.value = updated
+      return updated
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to update concept set'
       logger.error('ConceptSetsStore', 'Update concept set error', err)

--- a/src/views/CharacterizationBuilderView.vue
+++ b/src/views/CharacterizationBuilderView.vue
@@ -575,7 +575,7 @@ async function handleExport(): Promise<void> {
   } else {
     logger.error('CharacterizationBuilder', 'Export failed', result.error)
     showSnackbar(
-      t('characterizations.editor.utilities.import.importError', 'Export failed.').value,
+      t('characterizations.editor.utilities.export.exportError', 'Export failed.').value,
       'error'
     )
   }

--- a/src/views/FeatureAnalysisEditorView.vue
+++ b/src/views/FeatureAnalysisEditorView.vue
@@ -602,7 +602,10 @@ async function loadDefaultCovariateSettings(temporal: boolean) {
     dirty.value = true
   } else {
     logger.error('FeatureAnalysisEditor', 'Failed to load default covariate settings', result.error)
-    showSnackbar(t('cc.fa.saveError', 'Failed to save feature analysis').value, 'error')
+    showSnackbar(
+      t('cc.fa.loadDefaultsError', 'Failed to load default covariate settings.').value,
+      'error'
+    )
   }
   loadingDefaults.value = false
 }

--- a/src/views/IncidenceRateManagerView.vue
+++ b/src/views/IncidenceRateManagerView.vue
@@ -41,11 +41,24 @@ async function load() {
 
   const id = Number(idStr)
   const version = route.params.version as string | undefined
-  const ok =
-    version && version !== 'current'
-      ? await store.loadVersionPreview(id, Number(version))
-      : await store.loadIR(id)
-  if (!ok)
+  if (version && version !== 'current') {
+    // The route's beforeEnter already loaded this preview - don't fetch twice.
+    if (
+      store.isPreviewMode &&
+      store.currentIR?.id === id &&
+      store.previewVersion?.version === Number(version)
+    ) {
+      return
+    }
+    if (!(await store.loadVersionPreview(id, Number(version)))) {
+      loadingError.value = t(
+        'incidenceRate.editor.loadError',
+        'Failed to load incidence rate'
+      ).value
+    }
+    return
+  }
+  if (!(await store.loadIR(id)))
     loadingError.value = t('incidenceRate.editor.loadError', 'Failed to load incidence rate').value
 }
 
@@ -56,7 +69,10 @@ onMounted(async () => {
 
 onBeforeUnmount(() => store.stopAutoSave())
 
-watch(() => [route.params.id, route.params.version], load)
+// Two separate sources, not one getter returning a fresh array: the array
+// form re-fires on every route.params object replacement even when both
+// values are unchanged.
+watch([() => route.params.id, () => route.params.version], load)
 </script>
 
 <style scoped>

--- a/src/views/PathwayManagerView.vue
+++ b/src/views/PathwayManagerView.vue
@@ -16,6 +16,14 @@ async function loadFromRoute() {
   const version = route.params.version as string | undefined
   if (Number.isFinite(id) && id > 0) {
     if (version && version !== 'current') {
+      // The route's beforeEnter already loaded this preview - don't fetch twice.
+      if (
+        store.isPreviewMode &&
+        store.currentPathway?.id === id &&
+        store.previewVersion?.version === Number(version)
+      ) {
+        return
+      }
       await store.loadVersionPreview(id, Number(version))
     } else {
       await store.loadPathway(id)
@@ -26,5 +34,8 @@ async function loadFromRoute() {
 }
 
 onMounted(loadFromRoute)
-watch(() => [route.params.id, route.params.version], loadFromRoute)
+// Two separate sources, not one getter returning a fresh array: the array
+// form re-fires on every route.params object replacement even when both
+// values are unchanged.
+watch([() => route.params.id, () => route.params.version], loadFromRoute)
 </script>

--- a/tests/component/characterization/CharacterizationBuilderView.spec.ts
+++ b/tests/component/characterization/CharacterizationBuilderView.spec.ts
@@ -69,11 +69,13 @@ import {
   updateCharacterization,
   listCharacterizations,
   listCharacterizationExecutions,
+  exportCharacterization,
 } from '@/services/characterization.service'
 import { listFeatureAnalyses } from '@/services/feature-analysis.service'
 import { getCohorts } from '@/services/cohort-definition.service'
 import CharacterizationBuilderView from '@/views/CharacterizationBuilderView.vue'
-import { success } from '@/types/api'
+import { success, failure } from '@/types/api'
+import { ApiError } from '@/services/api-error'
 
 const vuetify = createVuetify({ components, directives })
 
@@ -284,5 +286,31 @@ describe('CharacterizationBuilderView', () => {
     const payload = vi.mocked(updateCharacterization).mock.calls[0]![0]!
     expect(payload.id).toBe(42)
     expect(payload.name).toBe('Renamed')
+  })
+
+  it('a failed export shows the export-specific error, not the import error', async () => {
+    vi.mocked(getCharacterization).mockResolvedValue(success(sampleCharacterization))
+    vi.mocked(exportCharacterization).mockResolvedValue(
+      failure(new ApiError('HTTP 500: boom', 500, null))
+    )
+
+    mounted = await mountBuilder('/characterizations/42', { id: '42' })
+    await flushPromises()
+
+    const exportBtn = mounted.wrapper.get('[data-testid="char-builder-export-icon"]')
+      .element as HTMLButtonElement
+    expect(exportBtn.disabled).toBe(false)
+    exportBtn.click()
+    await flushPromises()
+
+    expect(exportCharacterization).toHaveBeenCalledWith(42)
+
+    const snackbar = mounted.wrapper.findComponent({ name: 'AtlasSnackbar' })
+    // 'characterizations.editor.utilities.export.exportError'
+    expect(snackbar.props('text')).toBe('Export failed.')
+    // ...and specifically not the import-side key it used to reuse.
+    expect(snackbar.props('text')).not.toBe('Import failed.')
+    expect(snackbar.props('severity')).toBe('danger')
+    expect(snackbar.props('modelValue')).toBe(true)
   })
 })

--- a/tests/component/characterization/CharacterizationWorkbench.spec.ts
+++ b/tests/component/characterization/CharacterizationWorkbench.spec.ts
@@ -6,6 +6,7 @@ import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import CharacterizationWorkbench from '@/components/characterization/CharacterizationWorkbench.vue'
+import { useCharacterizationStore } from '@/stores/characterization'
 
 // vi.mock factories are hoisted above imports, so the ApiResult shape is
 // inlined here rather than built via the `success()` helper.
@@ -95,5 +96,52 @@ describe('CharacterizationWorkbench', () => {
     expect(w.findComponent({ name: 'ConfigureInspector' }).props('open')).toBe(true)
     await w.findComponent({ name: 'ConfigureInspector' }).vm.$emit('close')
     expect(w.findComponent({ name: 'ConfigureInspector' }).props('open')).toBe(false)
+  })
+
+  it('run with a returned execution pins the run query and starts polling', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    const runSpy = vi.spyOn(store, 'runExecution').mockResolvedValue({
+      id: 42, sourceKey: 'CCAE', status: 'PENDING', startTime: 0, executionDuration: 0,
+    })
+    const pollSpy = vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5,
+               availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+
+    // Spy only after the mount-time watchers have finished replacing the query.
+    const replaceSpy = vi.spyOn(router, 'replace')
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('run', 'CCAE')
+    await flushPromises()
+
+    expect(runSpy).toHaveBeenCalledWith(5, 'CCAE')
+    expect(replaceSpy).toHaveBeenCalledWith({ query: expect.objectContaining({ run: '42' }) })
+    expect(pollSpy).toHaveBeenCalledWith(42, expect.any(Function))
+  })
+
+  it('run that resolves null neither pins the run query nor starts polling', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    const runSpy = vi.spyOn(store, 'runExecution').mockResolvedValue(null)
+    const pollSpy = vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5,
+               availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+
+    const replaceSpy = vi.spyOn(router, 'replace')
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('run', 'CCAE')
+    await flushPromises()
+
+    expect(runSpy).toHaveBeenCalledWith(5, 'CCAE')
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(pollSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/component/cohort-samples/CohortSamplesPanel.spec.ts
+++ b/tests/component/cohort-samples/CohortSamplesPanel.spec.ts
@@ -219,6 +219,51 @@ describe('CohortSamplesPanel', () => {
     expect(wrapper.find('[data-testid=cohort-samples-error]').text()).toContain('Failed to create sample')
   })
 
+  it('shows the error banner and clears the selection when the detail fetch fails', async () => {
+    vi.mocked(listCohortSamples).mockResolvedValue(
+      success({ cohortDefinitionId: 1, sourceId: 1, samples: [sample] })
+    )
+    vi.mocked(getCohortSample).mockResolvedValueOnce(
+      failure(new ApiError('sample detail is gone', 404, null))
+    )
+
+    const wrapper = mount(CohortSamplesPanel, {
+      global: globalMountOpts,
+      props: { cohortId: 1, sourceKey: 'EUNOMIA' },
+    })
+    await flushPromises()
+
+    await wrapper.find('[data-testid=cohort-samples-list-row]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid=cohort-samples-error]').text()).toContain(
+      'sample detail is gone'
+    )
+    expect(wrapper.vm.selectedSample).toBeNull()
+    expect(wrapper.find('[data-testid=cohort-sample-detail-table]').exists()).toBe(false)
+  })
+
+  it('falls back to the generic error message when the detail fetch fails without a message', async () => {
+    vi.mocked(listCohortSamples).mockResolvedValue(
+      success({ cohortDefinitionId: 1, sourceId: 1, samples: [sample] })
+    )
+    vi.mocked(getCohortSample).mockResolvedValueOnce(failure(new ApiError('', 0, null)))
+
+    const wrapper = mount(CohortSamplesPanel, {
+      global: globalMountOpts,
+      props: { cohortId: 1, sourceKey: 'EUNOMIA' },
+    })
+    await flushPromises()
+
+    await wrapper.find('[data-testid=cohort-samples-list-row]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid=cohort-samples-error]').text()).toContain(
+      'Failed to load sample detail'
+    )
+    expect(wrapper.vm.selectedSample).toBeNull()
+  })
+
   it('refresh on a non-selected sample does not reload the detail view', async () => {
     const other = { ...sample, id: 99, name: 'other' }
     vi.mocked(listCohortSamples).mockResolvedValue(

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -164,6 +164,7 @@ vi.mock('@/services/atlas-converter', () => ({
 import CohortBuilder from '@/components/cohort/CohortBuilder.vue'
 import { convertInternalToAtlas } from '@/services/atlas-converter'
 import { ApiError } from '@/services/api-error'
+import { logger } from '@/utils/logger'
 
 const vuetify = createVuetify({
   components,
@@ -1782,6 +1783,58 @@ describe('CohortBuilder', () => {
     expect(result).toEqual({})
     expect(setup.errorMessage).toBe('Failed to save cohort to server')
     expect(setup.showError).toBe(true)
+  })
+
+  it('handleSave logs and shows the localized server error when the save API fails', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = 'Savable'
+    setup.entryEvents = [{ id: 'e1', criteriaType: 'X', attributes: [] }]
+
+    const apiError = new ApiError('HTTP 500: <html>Internal Server Error</html>', 500, null)
+    const cohortDefService = await import('@/services/cohort-definition.service')
+    vi.mocked(cohortDefService.saveCohortDefinition).mockResolvedValueOnce({
+      success: false,
+      error: apiError,
+    })
+    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+
+    const result = await setup.handleSave()
+
+    expect(result).toEqual({})
+    expect(loggerSpy).toHaveBeenCalledWith('CohortBuilder', 'saveCohortDefinition failed', apiError)
+    // Raw transport text must not leak into the banner.
+    expect(setup.errorMessage).toBe('Failed to save cohort to server')
+    expect(setup.errorMessage).not.toContain('HTTP 500')
+    expect(setup.showError).toBe(true)
+
+    loggerSpy.mockRestore()
+  })
+
+  it('handleSave shows the forbidden message when the save API returns 403', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = 'Savable'
+    setup.entryEvents = [{ id: 'e1', criteriaType: 'X', attributes: [] }]
+
+    const apiError = new ApiError('HTTP 403: Forbidden', 403, null)
+    const cohortDefService = await import('@/services/cohort-definition.service')
+    vi.mocked(cohortDefService.saveCohortDefinition).mockResolvedValueOnce({
+      success: false,
+      error: apiError,
+    })
+    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
+
+    const result = await setup.handleSave()
+
+    expect(result).toEqual({})
+    expect(loggerSpy).toHaveBeenCalledWith('CohortBuilder', 'saveCohortDefinition failed', apiError)
+    expect(setup.errorMessage).toBe('You do not have permission to save this cohort')
+    expect(setup.showError).toBe(true)
+
+    loggerSpy.mockRestore()
   })
 
   it('handleSave surfaces the thrown Error message when saving rejects', async () => {

--- a/tests/component/feature-analyses/FeatureAnalysisEditorView.spec.ts
+++ b/tests/component/feature-analyses/FeatureAnalysisEditorView.spec.ts
@@ -56,7 +56,8 @@ import {
   listFeatureAnalysisAggregates,
 } from '@/services/feature-analysis.service'
 import FeatureAnalysisEditorView from '@/views/FeatureAnalysisEditorView.vue'
-import { success } from '@/types/api'
+import { success, failure } from '@/types/api'
+import { ApiError } from '@/services/api-error'
 
 const vuetify = createVuetify({ components, directives })
 
@@ -219,6 +220,36 @@ describe('FeatureAnalysisEditorView', () => {
       '[data-testid="feature-analysis-editor-preset-json"] textarea'
     ).element as HTMLTextAreaElement
     expect(presetTextarea.value).toContain('useDemographicsGender')
+  })
+
+  it('a failed "Load default covariate settings" shows the load-defaults error, not the save error', async () => {
+    vi.mocked(getDefaultCovariateSettings).mockResolvedValue(
+      failure(new ApiError('HTTP 500: boom', 500, null))
+    )
+
+    mounted = await mountEditor('/feature-analyses/new')
+
+    const btn = mounted.wrapper.get(
+      '[data-testid="feature-analysis-editor-preset-default"]'
+    ).element as HTMLButtonElement
+    btn.click()
+    await flushPromises()
+
+    const snackbar = mounted.wrapper.findComponent({ name: 'AtlasSnackbar' })
+    // 'cc.fa.loadDefaultsError'
+    expect(snackbar.props('text')).toBe('Failed to load default covariate settings.')
+    // ...and not 'cc.fa.saveError', which this branch used to reuse.
+    expect(snackbar.props('text')).not.toBe(
+      'An error occurred while attempting to save a feature analysis.'
+    )
+    expect(snackbar.props('severity')).toBe('danger')
+    expect(snackbar.props('modelValue')).toBe(true)
+
+    // The textarea must stay untouched on failure.
+    const presetTextarea = mounted.wrapper.find(
+      '[data-testid="feature-analysis-editor-preset-json"] textarea'
+    ).element as HTMLTextAreaElement
+    expect(presetTextarea.value).not.toContain('useDemographicsGender')
   })
 
   it('Save in new mode calls createFeatureAnalysis', async () => {

--- a/tests/unit/composables/useIncidenceRateBuilder.spec.ts
+++ b/tests/unit/composables/useIncidenceRateBuilder.spec.ts
@@ -119,7 +119,7 @@ describe('useIncidenceRateBuilder', () => {
       expect(webapi.existsIncidenceRate).toHaveBeenCalledWith('Test IR', 0)
     })
 
-    it('returns false and notifies when the uniqueness check itself fails', async () => {
+    it('still saves when the uniqueness check itself fails', async () => {
       const store = useIncidenceRateStore()
       store.setIR(makeValidIR())
 
@@ -127,14 +127,17 @@ describe('useIncidenceRateBuilder', () => {
         success: false,
         error: new ApiError('Server error', 500, null),
       })
+      vi.mocked(webapi.createIncidenceRate).mockResolvedValue({
+        success: true,
+        data: { ...makeValidIR(), id: 99 },
+      })
 
       const { save, feedback } = useIncidenceRateBuilder()
       const ok = await save()
 
-      expect(ok).toBe(false)
-      expect(feedback.value?.color).toBe('error')
-      expect(feedback.value?.message).toContain('Server error')
-      expect(webapi.createIncidenceRate).not.toHaveBeenCalled()
+      expect(ok).toBe(true)
+      expect(feedback.value?.color).toBe('success')
+      expect(webapi.createIncidenceRate).toHaveBeenCalled()
     })
 
     it('creates a new IR when no id is set', async () => {

--- a/tests/unit/plugins/pythiaBridge.spec.ts
+++ b/tests/unit/plugins/pythiaBridge.spec.ts
@@ -29,12 +29,14 @@ vi.mock('@/services/incidence-rate.service', () => ({
 }))
 
 import router from '@/router'
+import { createConceptSet } from '@/services/concept-set.service'
 import { createFeatureAnalysis } from '@/services/feature-analysis.service'
 import { createCharacterization } from '@/services/characterization.service'
 import { createPathway } from '@/services/pathway.service'
 import { createIncidenceRate } from '@/services/incidence-rate.service'
 import { setupPythiaBridge, applyProposalDirect } from '@/plugins/host/pythiaBridge'
 import { useCohortStore } from '@/stores/cohort'
+import { useNotifications } from '@/stores/notifications'
 import { createHostMessageBus, getHostMessageBus } from '@/plugins/messaging/HostMessageBus'
 import { ApiError } from '@/services/api-error'
 
@@ -51,6 +53,7 @@ describe('pythiaBridge', () => {
     setupPythiaBridge()
     createHostMessageBus('pythia-plugin')
     vi.mocked(router.push).mockClear()
+    vi.mocked(createConceptSet).mockReset()
     vi.mocked(createFeatureAnalysis).mockReset()
     vi.mocked(createCharacterization).mockReset()
     vi.mocked(createPathway).mockReset()
@@ -277,6 +280,50 @@ describe('pythiaBridge', () => {
 
     await flush()
     expect(createPathway).toHaveBeenCalledOnce()
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  function snackbarSpy() {
+    return vi.spyOn(useNotifications(), 'danger')
+  }
+
+  function conceptSetProposal() {
+    return {
+      type: 'cohort.applyProposal',
+      sourcePluginId: 'pythia-plugin',
+      payload: {
+        proposal: {
+          kind: 'createStandaloneConceptSet',
+          conceptSet: {
+            name: 'Statins',
+            items: [{ conceptId: 1539403, conceptName: 'Simvastatin' }],
+          },
+        },
+      },
+      timestamp: new Date(),
+    }
+  }
+
+  it('createStandaloneConceptSet → surfaces a rejected createConceptSet as a snackbar without navigating', async () => {
+    const snackbar = snackbarSpy()
+    vi.mocked(createConceptSet).mockRejectedValue(new Error('WebAPI returned 500'))
+
+    dispatchPluginMessage(conceptSetProposal())
+
+    await flush()
+    expect(createConceptSet).toHaveBeenCalledOnce()
+    expect(snackbar).toHaveBeenCalledWith('WebAPI returned 500')
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  it('createStandaloneConceptSet → falls back to a generic message for a non-Error throw', async () => {
+    const snackbar = snackbarSpy()
+    vi.mocked(createConceptSet).mockRejectedValue('boom')
+
+    dispatchPluginMessage(conceptSetProposal())
+
+    await flush()
+    expect(snackbar).toHaveBeenCalledWith('Failed to create concept set')
     expect(router.push).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/services/api-error.spec.ts
+++ b/tests/unit/services/api-error.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { ApiError, toApiError, unwrap } from '@/services/api-error'
+import { z } from 'zod'
+import { ApiError, toApiError, unwrap, unwrapList, parseOrThrow } from '@/services/api-error'
 
 vi.mock('@/utils/logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -58,5 +59,81 @@ describe('unwrap', () => {
 
     expect(result.success).toBe(false)
     if (!result.success) expect(result.error.message).toBe('boom')
+  })
+})
+
+describe('parseOrThrow', () => {
+  const schema = z.object({ id: z.number(), name: z.string() })
+
+  it('returns the parsed data when the schema passes', () => {
+    expect(parseOrThrow(schema, { id: 1, name: 'A' }, 'Invalid')).toEqual({ id: 1, name: 'A' })
+  })
+
+  it('throws an ApiError carrying the Zod issues in body', () => {
+    let thrown: unknown
+    try {
+      parseOrThrow(schema, { id: 'nope' }, 'Invalid response from /thing')
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(ApiError)
+    const apiError = thrown as ApiError
+    expect(apiError.message).toBe('Invalid response from /thing')
+    expect(apiError.status).toBe(0)
+    const issues = JSON.parse(apiError.body as string)
+    expect(issues.some((i: { path: string[] }) => i.path.includes('id'))).toBe(true)
+    expect(issues.some((i: { path: string[] }) => i.path.includes('name'))).toBe(true)
+  })
+})
+
+describe('unwrapList', () => {
+  it('passes a bare array through', () => {
+    expect(unwrapList([{ id: 1 }, { id: 2 }])).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('passes an empty array through rather than treating it as a bad shape', () => {
+    expect(unwrapList([])).toEqual([])
+  })
+
+  it('unwraps a Spring Data `{ content: [...] }` page wrapper', () => {
+    expect(unwrapList({ content: [{ id: 5 }], totalElements: 1 })).toEqual([{ id: 5 }])
+  })
+
+  it('throws an ApiError carrying the payload when given a plain object', () => {
+    let thrown: unknown
+    try {
+      unwrapList({ redirect: '/sso/login' })
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(ApiError)
+    const apiError = thrown as ApiError
+    expect(apiError.message).toBe('Expected a list response but got a different shape')
+    expect(apiError.status).toBe(0)
+    expect(JSON.parse(apiError.body as string)).toEqual({ redirect: '/sso/login' })
+  })
+
+  it('throws when `content` is present but not an array', () => {
+    expect(() => unwrapList({ content: null })).toThrow(ApiError)
+    expect(() => unwrapList({ content: null })).toThrow(
+      'Expected a list response but got a different shape'
+    )
+  })
+
+  it('throws for a null payload', () => {
+    expect(() => unwrapList(null)).toThrow(ApiError)
+  })
+
+  it('stringifies an unserialisable payload for the error body', () => {
+    let thrown: unknown
+    try {
+      unwrapList(undefined)
+    } catch (err) {
+      thrown = err
+    }
+
+    expect((thrown as ApiError).body).toBe('undefined')
   })
 })

--- a/tests/unit/services/characterization.service.spec.ts
+++ b/tests/unit/services/characterization.service.spec.ts
@@ -32,6 +32,7 @@ import {
   explorePrevalence,
 } from '@/services/characterization.service'
 import type { CharacterizationDefinition } from '@/models/characterization.types'
+import { logger } from '@/utils/logger'
 
 const validDesign: CharacterizationDefinition = {
   id: 1,
@@ -409,6 +410,32 @@ describe('services/characterization.service', () => {
       if (result.success) {
         expect(result.data.id).toBe(456)
         expect(result.data.sourceKey).toBe('CDM_A')
+      }
+    })
+
+    it('resolves with null instead of fabricating an id when the job response carries no execution id', async () => {
+      ok({ jobParameters: { jobName: 'cohortCharacterization' }, exitStatus: 'UNKNOWN' })
+
+      const result = await generateCharacterization(1, 'CDM_A')
+
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBeNull()
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        'CharacterizationService',
+        'Generation response from POST /cohort-characterization/1/generation/CDM_A carried no execution id',
+        expect.anything()
+      )
+    })
+
+    it('falls back to the job `id` when `executionId` is absent', async () => {
+      ok({ id: 789 })
+
+      const result = await generateCharacterization(1, 'CDM_A')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data?.id).toBe(789)
+        expect(result.data?.status).toBe('STARTING')
       }
     })
 

--- a/tests/unit/services/concept-search.service.spec.ts
+++ b/tests/unit/services/concept-search.service.spec.ts
@@ -240,24 +240,22 @@ describe('ConceptSearchService', () => {
       expect(result).toBeNull()
     })
 
-    it('should return null for invalid response format', async () => {
+    it('throws for invalid response format', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
         text: () => Promise.resolve(JSON.stringify({ invalid: 'response' })),
       })
 
-      const result = await getConceptById('TEST', 123)
-
-      expect(result).toBeNull()
+      await expect(getConceptById('TEST', 123)).rejects.toThrow(
+        'Invalid concept detail response'
+      )
     })
 
-    it('should return null on network error', async () => {
+    it('throws on network error', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
-      const result = await getConceptById('TEST', 123)
-
-      expect(result).toBeNull()
+      await expect(getConceptById('TEST', 123)).rejects.toThrow('Network error')
     })
   })
 

--- a/tests/unit/services/concept-set.service.spec.ts
+++ b/tests/unit/services/concept-set.service.spec.ts
@@ -74,35 +74,29 @@ describe('ConceptSetService', () => {
       expect(result).toHaveLength(2)
     })
 
-    it('should return empty array on fetch failure', async () => {
+    it('throws on fetch failure', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
         statusText: 'Server Error',
       })
 
-      const result = await getAllConceptSets()
-
-      expect(result).toEqual([])
+      await expect(getAllConceptSets()).rejects.toThrow('HTTP 500')
     })
 
-    it('should return empty array for invalid response format', async () => {
+    it('throws for invalid response format', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ invalid: 'response' }),
       })
 
-      const result = await getAllConceptSets()
-
-      expect(result).toEqual([])
+      await expect(getAllConceptSets()).rejects.toThrow('Invalid concept set list response')
     })
 
-    it('should return empty array on network error', async () => {
+    it('throws on network error', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
-      const result = await getAllConceptSets()
-
-      expect(result).toEqual([])
+      await expect(getAllConceptSets()).rejects.toThrow('Network error')
     })
   })
 
@@ -245,24 +239,20 @@ describe('ConceptSetService', () => {
       expect(result).not.toBeNull()
     })
 
-    it('should return null on create failure', async () => {
+    it('throws on create failure', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 400,
         statusText: 'Bad Request',
       })
 
-      const result = await createConceptSet({ name: 'Test', items: [] })
-
-      expect(result).toBeNull()
+      await expect(createConceptSet({ name: 'Test', items: [] })).rejects.toThrow('HTTP 400')
     })
 
-    it('should return null on network error', async () => {
+    it('throws on network error', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
-      const result = await createConceptSet({ name: 'Test', items: [] })
-
-      expect(result).toBeNull()
+      await expect(createConceptSet({ name: 'Test', items: [] })).rejects.toThrow('Network error')
     })
   })
 
@@ -327,24 +317,24 @@ describe('ConceptSetService', () => {
       )
     })
 
-    it('should return null on update failure', async () => {
+    it('throws on update failure', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 400,
         statusText: 'Bad Request',
       })
 
-      const result = await updateConceptSet({ id: 1, name: 'Test', items: [] })
-
-      expect(result).toBeNull()
+      await expect(updateConceptSet({ id: 1, name: 'Test', items: [] })).rejects.toThrow(
+        'HTTP 400'
+      )
     })
 
-    it('should return null on network error', async () => {
+    it('throws on network error', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
-      const result = await updateConceptSet({ id: 1, name: 'Test', items: [] })
-
-      expect(result).toBeNull()
+      await expect(updateConceptSet({ id: 1, name: 'Test', items: [] })).rejects.toThrow(
+        'Network error'
+      )
     })
   })
 

--- a/tests/unit/services/pathway.service.spec.ts
+++ b/tests/unit/services/pathway.service.spec.ts
@@ -359,6 +359,33 @@ describe('services/pathway.service', () => {
       expect(init.method).toBe('POST')
     })
 
+    it('generatePathway normalizes a Spring Batch JobExecution response', async () => {
+      ok({ executionId: 456 })
+
+      const result = await generatePathway(1, 'cdm')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data?.id).toBe(456)
+        expect(result.data?.status).toBe('STARTING')
+        expect(result.data?.sourceKey).toBe('cdm')
+      }
+    })
+
+    it('generatePathway resolves with null instead of fabricating id 0 when the job response carries no execution id', async () => {
+      ok({ jobParameters: { jobName: 'pathwayAnalysis' }, exitStatus: 'UNKNOWN' })
+
+      const result = await generatePathway(1, 'cdm')
+
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBeNull()
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        'PathwayService',
+        'Generate response carried no execution id',
+        expect.anything()
+      )
+    })
+
     it('reports a status carrying failure when neither the execution nor job-execution shape parses', async () => {
       ok({ status: 'NOT_A_REAL_STATUS' })
 

--- a/tests/unit/stores/characterization.spec.ts
+++ b/tests/unit/stores/characterization.spec.ts
@@ -428,6 +428,23 @@ describe('Characterization Store', () => {
         expect(store.executions[0]?.status).toBe('RUNNING')
       })
 
+      it('refreshes the canonical list and returns null when the response carried no trackable execution', async () => {
+        const store = useCharacterizationStore()
+        const existing: CharacterizationExecution = { ...baseExec, id: 500 }
+        store.executions = [existing]
+        const canonical: CharacterizationExecution = { ...baseExec, id: 501, status: 'PENDING' }
+        vi.mocked(generateCharacterization).mockResolvedValue(success(null))
+        vi.mocked(listCharacterizationExecutions).mockResolvedValue(success([canonical]))
+
+        const result = await store.runExecution(42, 'CDM_V5')
+
+        expect(result).toBeNull()
+        expect(listCharacterizationExecutions).toHaveBeenCalledWith(42)
+        expect(store.executions).toEqual([canonical])
+        expect(store.executions.some((e) => e.id === 0)).toBe(false)
+        expect(store.executionsError).toBeNull()
+      })
+
       it('rethrows and sets error on failure', async () => {
         const store = useCharacterizationStore()
         vi.mocked(generateCharacterization).mockResolvedValue(apiErr('Down'))

--- a/tests/unit/stores/cohort.spec.ts
+++ b/tests/unit/stores/cohort.spec.ts
@@ -798,7 +798,7 @@ describe('Cohort Store', () => {
       }
     })
 
-    it('does not let an overlapping request A orphan timer resolve request B', async () => {
+    it('routes each overlapping request its own result, in order', async () => {
       vi.useFakeTimers()
       try {
         const store = useCohortStore()
@@ -806,18 +806,31 @@ describe('Cohort Store', () => {
         vi.advanceTimersByTime(4000)
         const pB = store.requestSave()
 
-        // A's own promise must settle immediately when B supersedes it - it
-        // no longer has a timer or a resolver slot of its own, so nothing
-        // else would ever settle it (a WebMCP tool call awaiting it must not
-        // hang forever - see pythiaBridge.ts).
+        store.notifySaved({ id: 1, name: 'Cohort A' })
+        await expect(pA).resolves.toEqual({ id: 1, name: 'Cohort A' })
+
+        store.notifySaved({ id: 2, name: 'Cohort B' })
+        await expect(pB).resolves.toEqual({ id: 2, name: 'Cohort B' })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('times out each overlapping request on its own clock', async () => {
+      vi.useFakeTimers()
+      try {
+        const store = useCohortStore()
+        const pA = store.requestSave()
+        vi.advanceTimersByTime(4000)
+        const pB = store.requestSave()
+
+        // A waits 8s from its own start, not B's - a WebMCP tool call awaiting
+        // it must never hang forever (see pythiaBridge.ts).
+        vi.advanceTimersByTime(4000)
         await expect(pA).resolves.toEqual({})
 
-        // A's original 8s timer would fire here if it survived request B.
         vi.advanceTimersByTime(4000)
-        await Promise.resolve()
-
-        store.notifySaved({ id: 99, name: 'Cohort B' })
-        await expect(pB).resolves.toEqual({ id: 99, name: 'Cohort B' })
+        await expect(pB).resolves.toEqual({})
       } finally {
         vi.useRealTimers()
       }

--- a/tests/unit/stores/concept-sets.spec.ts
+++ b/tests/unit/stores/concept-sets.spec.ts
@@ -281,16 +281,6 @@ describe('Concept Sets Store', () => {
       expect(store.currentSet).toEqual({ ...newSet, id: 4 })
     })
 
-    it('should handle create failure', async () => {
-      const store = useConceptSetsStore()
-      vi.mocked(createConceptSet).mockResolvedValue(null)
-
-      const result = await store.create({ name: 'New Set', items: [] })
-
-      expect(result).toBeNull()
-      expect(store.error).toBe('Failed to create concept set')
-    })
-
     it('should handle create error', async () => {
       const store = useConceptSetsStore()
       vi.mocked(createConceptSet).mockRejectedValue(new Error('Server error'))
@@ -313,16 +303,6 @@ describe('Concept Sets Store', () => {
 
       expect(result).toEqual(updatedSet)
       expect(store.currentSet).toEqual(updatedSet)
-    })
-
-    it('should handle update failure', async () => {
-      const store = useConceptSetsStore()
-      vi.mocked(updateConceptSet).mockResolvedValue(null)
-
-      const result = await store.update(mockConceptSet)
-
-      expect(result).toBeNull()
-      expect(store.error).toBe('Failed to update concept set')
     })
 
     it('should handle update error', async () => {

--- a/tests/unit/views/PathwayManagerView.spec.ts
+++ b/tests/unit/views/PathwayManagerView.spec.ts
@@ -1,16 +1,14 @@
 /**
- * Component tests: IncidenceRateManagerView
+ * Component tests: PathwayManagerView
  *
- * Guards against the version-preview-unreachable regression: mounting on
- * the /incidence-rates/:id/version/:version route must call
- * store.loadVersionPreview and must never call store.loadIR (which nulls
- * previewVersion and wipes the preview - see PathwayManagerView for the
- * pattern this mirrors).
+ * Mirrors IncidenceRateManagerView.spec.ts: the route's beforeEnter already
+ * loads a version preview, so mounting must not fetch it a second time, and
+ * replacing route.params with identical values must not retrigger the load.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { reactive, ref } from 'vue'
+import { reactive } from 'vue'
 import { mount, VueWrapper } from '@vue/test-utils'
-import IncidenceRateManagerView from '@/views/IncidenceRateManagerView.vue'
+import PathwayManagerView from '@/views/PathwayManagerView.vue'
 
 const mockRoute = reactive<{ params: Record<string, string> }>({ params: {} })
 
@@ -18,51 +16,43 @@ vi.mock('vue-router', () => ({
   useRoute: () => mockRoute,
 }))
 
-vi.mock('@/composables/useI18n', () => ({
-  useI18n: () => ({
-    t: (_key: string, fallback: string) => ref(fallback),
-    tv: (_key: string, fallback: string) => fallback,
-  }),
-}))
-
-vi.mock('@/components/incidence-rate/IncidenceRateBuilder.vue', () => ({
+vi.mock('@/components/pathway/PathwayBuilder.vue', () => ({
   default: {
-    name: 'IncidenceRateBuilder',
-    template: '<div class="ir-builder-mock" />',
+    name: 'PathwayBuilder',
+    template: '<div class="pathway-builder-mock" />',
   },
 }))
 
 const store = {
-  currentIR: null as { id: number } | null,
+  currentPathway: null as { id: number } | null,
   isPreviewMode: false,
   previewVersion: null as { version: number } | null,
-  loadIR: vi.fn(),
+  loadPathway: vi.fn(),
   loadVersionPreview: vi.fn(),
   restoreFromDraft: vi.fn(() => false),
-  createNewIR: vi.fn(),
-  startAutoSave: vi.fn(),
-  stopAutoSave: vi.fn(),
+  createNewPathway: vi.fn(),
 }
 
-vi.mock('@/stores/incidence-rate', () => ({
-  useIncidenceRateStore: () => store,
+vi.mock('@/stores/pathway', () => ({
+  usePathwayStore: () => store,
 }))
 
-describe('IncidenceRateManagerView.vue', () => {
+describe('PathwayManagerView.vue', () => {
   let wrapper: VueWrapper
 
   // mockRoute is reactive, so a wrapper left mounted would keep watching it
-  // and re-run load() during the next test.
+  // and re-run loadFromRoute() during the next test.
   afterEach(() => wrapper.unmount())
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockRoute.params = {}
-    store.currentIR = null
+    store.currentPathway = null
     store.isPreviewMode = false
     store.previewVersion = null
-    store.loadIR.mockResolvedValue(true)
+    store.loadPathway.mockResolvedValue(true)
     store.loadVersionPreview.mockResolvedValue(true)
+    store.restoreFromDraft.mockReturnValue(false)
   })
 
   async function flushMounted() {
@@ -71,68 +61,68 @@ describe('IncidenceRateManagerView.vue', () => {
     await Promise.resolve()
   }
 
-  it('loads the plain IR when no version param is present', async () => {
+  it('loads the plain pathway when no version param is present', async () => {
     mockRoute.params = { id: '5' }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
-    expect(store.loadIR).toHaveBeenCalledWith(5)
+    expect(store.loadPathway).toHaveBeenCalledWith(5)
     expect(store.loadVersionPreview).not.toHaveBeenCalled()
   })
 
-  it('loads the version preview instead of the plain IR when a version param is present', async () => {
+  it('loads the version preview instead of the plain pathway when a version param is present', async () => {
     mockRoute.params = { id: '5', version: '3' }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
     expect(store.loadVersionPreview).toHaveBeenCalledWith(5, 3)
-    expect(store.loadIR).not.toHaveBeenCalled()
+    expect(store.loadPathway).not.toHaveBeenCalled()
   })
 
-  it('loads the plain IR when version param is the literal "current"', async () => {
+  it('loads the plain pathway when version param is the literal "current"', async () => {
     mockRoute.params = { id: '5', version: 'current' }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
-    expect(store.loadIR).toHaveBeenCalledWith(5)
+    expect(store.loadPathway).toHaveBeenCalledWith(5)
     expect(store.loadVersionPreview).not.toHaveBeenCalled()
   })
 
   it('skips the refetch when the store already holds exactly this version preview', async () => {
     mockRoute.params = { id: '5', version: '3' }
     store.isPreviewMode = true
-    store.currentIR = { id: 5 }
+    store.currentPathway = { id: 5 }
     store.previewVersion = { version: 3 }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
     expect(store.loadVersionPreview).not.toHaveBeenCalled()
-    expect(store.loadIR).not.toHaveBeenCalled()
+    expect(store.loadPathway).not.toHaveBeenCalled()
   })
 
   it('refetches when the store holds a preview of a different version', async () => {
     mockRoute.params = { id: '5', version: '3' }
     store.isPreviewMode = true
-    store.currentIR = { id: 5 }
+    store.currentPathway = { id: 5 }
     store.previewVersion = { version: 2 }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
     expect(store.loadVersionPreview).toHaveBeenCalledWith(5, 3)
   })
 
-  it('refetches when the store holds a preview of a different incidence rate', async () => {
+  it('refetches when the store holds a preview of a different pathway', async () => {
     mockRoute.params = { id: '5', version: '3' }
     store.isPreviewMode = true
-    store.currentIR = { id: 9 }
+    store.currentPathway = { id: 9 }
     store.previewVersion = { version: 3 }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
     expect(store.loadVersionPreview).toHaveBeenCalledWith(5, 3)
@@ -141,31 +131,40 @@ describe('IncidenceRateManagerView.vue', () => {
   it('refetches when the store is not in preview mode despite matching id and version', async () => {
     mockRoute.params = { id: '5', version: '3' }
     store.isPreviewMode = false
-    store.currentIR = { id: 5 }
+    store.currentPathway = { id: 5 }
     store.previewVersion = { version: 3 }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
 
     expect(store.loadVersionPreview).toHaveBeenCalledWith(5, 3)
   })
 
-  it('renders the error state when the version preview fails to load', async () => {
-    mockRoute.params = { id: '5', version: '3' }
-    store.loadVersionPreview.mockResolvedValue(false)
+  it('restores the draft when the route carries no usable id', async () => {
+    mockRoute.params = {}
+    store.restoreFromDraft.mockReturnValue(true)
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
-    await wrapper.vm.$nextTick()
 
-    expect(store.loadVersionPreview).toHaveBeenCalledWith(5, 3)
-    expect(wrapper.find('.state.error').text()).toBe('Failed to load incidence rate')
+    expect(store.restoreFromDraft).toHaveBeenCalled()
+    expect(store.createNewPathway).not.toHaveBeenCalled()
+  })
+
+  it('creates a new pathway when there is no id and no draft to restore', async () => {
+    mockRoute.params = {}
+    store.restoreFromDraft.mockReturnValue(false)
+
+    wrapper = mount(PathwayManagerView)
+    await flushMounted()
+
+    expect(store.createNewPathway).toHaveBeenCalled()
   })
 
   it('does not reload when route.params is replaced with identical id and version', async () => {
     mockRoute.params = { id: '5', version: '3' }
 
-    wrapper = mount(IncidenceRateManagerView, { props: { id: '5' } })
+    wrapper = mount(PathwayManagerView)
     await flushMounted()
     expect(store.loadVersionPreview).toHaveBeenCalledTimes(1)
 


### PR DESCRIPTION
Hardens the API error contract so failures surface instead of masquerading as empty or successful results, and fixes the user-facing messages that pointed at the wrong operation.

## Error contract

- **unwrapList**: an HTTP-200 payload that is neither an array nor a Spring `{content: [...]}` wrapper (SSO-redirect JSON, an error body) now throws an `ApiError` instead of silently resolving to an empty list.
- **http-client**: error bodies are capped at 300 chars in `ApiError.message` so toasts stay readable; the full body remains in `.body` for logs.
- **api-error**: new shared `parseOrThrow` helper; 55 copy-pasted `safeParse → throw ApiError` triads across 14 services now use it. The sites that had forked (permission/role/user/profile/jobs) carry zod issues in the error body instead of `null` and no longer double-log.
- **incidence-rate.service**: `decodeIRExpression` throws `ApiError` + zod issues like every sibling call site instead of a bare `ZodError`.
- **concept-set.service**: `getAllConceptSets` / `createConceptSet` / `updateConceptSet` propagate errors instead of returning `[]` / `null`, so a failed fetch renders the store's error state rather than an empty list, and create/update failures show the server's actual message. `pythiaBridge` updated to match.
- **concept-search.service**: `getConceptById` returns `null` only for a real 404 — transport and validation failures propagate, so "Concept not found" is no longer shown for a failed request. The 501 recommended-concepts fallback reads `ApiError.status` instead of regex-parsing the message.
- **concept-set-versions**: the expression response schema tolerates `items: null`, which WebAPI sends instead of `[]` for empty item lists.

## User-facing messages

- **CharacterizationBuilderView**: a failed export said "Import failed." — it reused the import-error key. Added `export.exportError`.
- **FeatureAnalysisEditorView**: failing to *load* default covariate settings showed the *save*-error message. Added `cc.fa.loadDefaultsError`.
- **CohortBuilder**: non-403 save failures show the localized `saveToServerError` message again instead of the raw HTTP body; the detail goes to the log.
- **CohortSamplesPanel**: a failed sample-detail fetch now surfaces in the error banner instead of only logging.
- **useIncidenceRateBuilder**: the name-uniqueness pre-check is advisory — if the `/ir/{id}/exists` call itself fails, the save proceeds and the server stays the authority.
- **locales**: the six keys that existed only in `en.json` are now in ja/ko/ru/zh, along with the three new keys above.

## Correctness

- **cohort store**: overlapping `requestSave()` calls shared one resolver slot, so request B's arrival settled A with `{}`, A's completion then resolved B with A's result, and B's real result was dropped. Replaced with a FIFO queue — each request keeps its own timeout and receives its own save's result.
- **IncidenceRateManagerView / PathwayManagerView**: skip refetching a version preview the route guard already loaded, and watch `id`/`version` as separate sources so a params-object replacement with unchanged values no longer refires the load.
- **VersionsTabContent**: post-copy navigation only runs when the copy response actually carried an id, so `/cohorts/undefined` can't be pushed.
- **characterization/pathway generate**: when the generation response has no recognizable execution id, return `null` instead of fabricating id 0 — callers refresh the canonical list or skip polling rather than tracking a phantom execution.
- **plugin-runtime.js**: eagerly created rejections are pre-marked as handled so they can't fire `unhandledrejection` when `ensurePluginRuntime` never attaches its handler (a sibling vendor script failing first).

