### PR TITLE
Fix data source save failing with a 415 on every non-keyfile dialect

### DIFF
--- a/src/components/config/DataSourceDialog.vue
+++ b/src/components/config/DataSourceDialog.vue
@@ -315,8 +315,8 @@ const isFormValid = ref(false)
 const isSaving = ref(false)
 const isDeleting = ref(false)
 const showDeleteConfirm = ref(false)
-// Numeric id of the loaded source — WebAPI's delete endpoint is keyed on
-// sourceId, not the string sourceKey.
+// Numeric id of the loaded source — WebAPI's update and delete endpoints are
+// keyed on sourceId, not the string sourceKey.
 const loadedSourceId = ref<number | null>(null)
 
 const form = reactive({
@@ -497,8 +497,8 @@ async function handleSave() {
           ? keytabFile.value[0]
           : undefined
 
-    if (isEditing.value && props.sourceKey) {
-      await updateSource(props.sourceKey, request, file)
+    if (isEditing.value && loadedSourceId.value != null) {
+      await updateSource(loadedSourceId.value, request, file)
     } else {
       await createSource(request, file)
     }

--- a/src/components/config/DataSourceDialog.vue
+++ b/src/components/config/DataSourceDialog.vue
@@ -331,8 +331,16 @@ const form = reactive({
   checkConnection: false,
 })
 
-const keyfile = ref<File[]>([])
-const keytabFile = ref<File[]>([])
+// v-file-input models a single File unless `multiple` is set, so these hold
+// either shape depending on the Vuetify version.
+type FileModel = File | File[] | null
+const keyfile = ref<FileModel>(null)
+const keytabFile = ref<FileModel>(null)
+
+function selectedFile(model: FileModel): File | undefined {
+  if (!model) return undefined
+  return Array.isArray(model) ? model[0] : model
+}
 
 // Daimon configuration
 const daimonEnabled = reactive<Record<DaimonType, boolean>>({
@@ -404,8 +412,8 @@ function resetForm() {
   form.krbAdminServer = ''
   form.checkConnection = false
   loadedSourceId.value = null
-  keyfile.value = []
-  keytabFile.value = []
+  keyfile.value = null
+  keytabFile.value = null
 
   // Reset daimons
   for (const type of DAIMON_TYPES) {
@@ -491,11 +499,10 @@ async function handleSave() {
   try {
     const request = buildRequest()
     const file =
-      showBigQuery.value && keyfile.value.length > 0
-        ? keyfile.value[0]
-        : showKerberos.value && form.krbAuthMethod === 'KEYTAB' && keytabFile.value.length > 0
-          ? keytabFile.value[0]
-          : undefined
+      (showBigQuery.value ? selectedFile(keyfile.value) : undefined) ??
+      (showKerberos.value && form.krbAuthMethod === 'KEYTAB'
+        ? selectedFile(keytabFile.value)
+        : undefined)
 
     if (isEditing.value && loadedSourceId.value != null) {
       await updateSource(loadedSourceId.value, request, file)

--- a/src/services/source.service.ts
+++ b/src/services/source.service.ts
@@ -3,7 +3,7 @@
  * Handles create, read, update, delete operations for data sources.
  */
 import { logger } from '@/utils/logger'
-import { httpGet, httpPost, httpPut, httpDelete, getBaseUrl } from '@/services/http-client'
+import { httpGet, httpPost, httpDelete, getBaseUrl } from '@/services/http-client'
 import { unwrap, parseOrThrow } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { CDMSourceListSchema, type CDMSource } from '@/models/webapi.types'
@@ -42,20 +42,12 @@ export async function getSourceDetails(sourceKey: string): Promise<SourceDetails
 
 /**
  * Create a new data source
- * Uses multipart/form-data when a keyfile is provided
  */
 export async function createSource(request: SourceRequest, keyfile?: File): Promise<DataSource> {
   try {
     logger.debug('SourceService', 'Creating new source', { name: request.name })
 
-    let response: DataSource
-
-    if (keyfile) {
-      // Use multipart/form-data for keyfile upload
-      response = await uploadSourceWithKeyfile('/source', 'POST', request, keyfile)
-    } else {
-      response = await httpPost<DataSource>('/source', mapRequestToApiPayload(request))
-    }
+    const response = await uploadSource('/source', 'POST', request, keyfile)
 
     logger.debug('SourceService', `Successfully created source: ${response.sourceName}`)
     return response
@@ -67,30 +59,25 @@ export async function createSource(request: SourceRequest, keyfile?: File): Prom
 
 /**
  * Update an existing data source
- * Uses multipart/form-data when a keyfile is provided
+ *
+ * WebAPI's update endpoint is keyed on the numeric `sourceId`
+ * (`PUT /source/{sourceId}`), not the string `sourceKey`.
  */
 export async function updateSource(
-  sourceKey: string,
+  sourceId: number,
   request: SourceRequest,
   keyfile?: File
 ): Promise<DataSource> {
   try {
-    logger.debug('SourceService', `Updating source key ${sourceKey}`, { name: request.name })
+    logger.debug('SourceService', `Updating source id ${sourceId}`, { name: request.name })
 
-    let response: DataSource
-
-    if (keyfile) {
-      // Use multipart/form-data for keyfile upload
-      response = await uploadSourceWithKeyfile(`/source/${sourceKey}`, 'PUT', request, keyfile)
-    } else {
-      response = await httpPut<DataSource>(`/source/${sourceKey}`, mapRequestToApiPayload(request))
-    }
+    const response = await uploadSource(`/source/${sourceId}`, 'PUT', request, keyfile)
 
     logger.debug('SourceService', `Successfully updated source: ${response.sourceName}`)
     return response
   } catch (error) {
     logger.error('SourceService', 'Failed to update source', {
-      sourceKey,
+      sourceId,
       name: request.name,
       error,
     })
@@ -184,13 +171,18 @@ function mapRequestToApiPayload(request: SourceRequest): Record<string, unknown>
 }
 
 /**
- * Upload source with keyfile using multipart/form-data
+ * Save a source using multipart/form-data
+ *
+ * WebAPI's create/update endpoints consume multipart/form-data only, and
+ * resolve the `source` part through its message converters — so the part has
+ * to carry an `application/json` content type. A plain JSON request body, or
+ * an untyped part, is rejected with HttpMediaTypeNotSupportedException.
  */
-async function uploadSourceWithKeyfile(
+async function uploadSource(
   endpoint: string,
   method: 'POST' | 'PUT',
   request: SourceRequest,
-  keyfile: File
+  keyfile?: File
 ): Promise<DataSource> {
   const formData = new FormData()
 
@@ -198,8 +190,9 @@ async function uploadSourceWithKeyfile(
   const sourceData = mapRequestToApiPayload(request)
   formData.append('source', new Blob([JSON.stringify(sourceData)], { type: 'application/json' }))
 
-  // Add keyfile
-  formData.append('keyfile', keyfile)
+  if (keyfile) {
+    formData.append('keyfile', keyfile)
+  }
 
   // Get auth token
   const { useAuthStore } = await import('@/stores/auth')

--- a/tests/component/config/DataSourceDialog.spec.ts
+++ b/tests/component/config/DataSourceDialog.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * DataSourceDialog save-path tests
+ *
+ * Covers handleSave's two branches: create for a new source, and update keyed
+ * on the numeric sourceId loaded with the source — not the string sourceKey
+ * the dialog receives as a prop.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+const createSource = vi.fn()
+const updateSource = vi.fn()
+const deleteSource = vi.fn()
+const getSourceDetails = vi.fn()
+
+vi.mock('@/services/source.service', () => ({
+  createSource: (...args: unknown[]) => createSource(...args),
+  updateSource: (...args: unknown[]) => updateSource(...args),
+  deleteSource: (...args: unknown[]) => deleteSource(...args),
+  getSourceDetails: (...args: unknown[]) => getSourceDetails(...args),
+}))
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import DataSourceDialog from '@/components/config/DataSourceDialog.vue'
+
+const vuetify = createVuetify({ components, directives })
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+// The fields stay real so v-form validation runs for the Save button; only the
+// dialog shell and buttons are stubbed, since AtlasDialog teleports its
+// content out of the wrapper.
+function makeStubs() {
+  return {
+    AtlasButton: {
+      name: 'AtlasButton',
+      props: ['loading', 'disabled'],
+      emits: ['click'],
+      template:
+        '<button class="atlas-btn" :disabled="disabled" @click="$emit(\'click\', $event)"><slot /></button>',
+    },
+    AtlasDialog: {
+      name: 'AtlasDialog',
+      props: ['modelValue', 'title', 'maxWidth', 'eyebrow', 'persistent'],
+      template: '<div class="dialog" v-if="modelValue"><slot /><slot name="actions" /></div>',
+    },
+  }
+}
+
+const details = {
+  sourceId: 42,
+  sourceKey: 'CDM',
+  sourceName: 'CDM Source',
+  sourceDialect: 'POSTGRESQL',
+  connectionString: 'jdbc:postgresql://localhost:5432/cdm',
+  daimons: [{ daimonType: 'CDM', tableQualifier: 'demo_cdm', priority: 0 }],
+}
+
+async function mountDialog(sourceKey: string | null) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const wrapper = mount(DataSourceDialog, {
+    global: { plugins: [vuetify, pinia], stubs: makeStubs() },
+    props: { modelValue: false, sourceKey },
+  })
+  // The dialog loads the source on open, so it has to transition closed → open.
+  await wrapper.setProps({ modelValue: true })
+  await flushPromises()
+  return wrapper
+}
+
+async function fillRequiredFields(wrapper: VueWrapper) {
+  const byLabel = (name: string, label: string) =>
+    wrapper.findAllComponents({ name }).find(c => c.props('label') === label)!
+
+  await byLabel('AtlasTextField', 'columns.name').setValue('New Source')
+  await byLabel('AtlasTextField', 'configuration.viewEdit.source.label').setValue('NEW_SOURCE')
+  await byLabel('AtlasTextField', 'configuration.viewEdit.connectionString.label').setValue(
+    'jdbc:postgresql://localhost:5432/newdb'
+  )
+  await byLabel('AtlasSelect', 'configuration.viewEdit.dialect.label').setValue('POSTGRESQL')
+  await flushPromises()
+}
+
+async function clickSave(wrapper: VueWrapper) {
+  // The Save button is gated on validity, which v-form only pushes into the
+  // dialog once it has run a validation pass.
+  const form = wrapper.findComponent({ name: 'VForm' }).vm as unknown as {
+    validate: () => Promise<{ valid: boolean }>
+  }
+  expect((await form.validate()).valid).toBe(true)
+  await flushPromises()
+
+  const buttons = wrapper.findAll('button.atlas-btn')
+  await buttons[buttons.length - 1].trigger('click')
+  await flushPromises()
+}
+
+describe('DataSourceDialog save', () => {
+  beforeEach(() => {
+    createSource.mockReset().mockResolvedValue({ sourceId: 7, sourceName: 'New Source' })
+    updateSource.mockReset().mockResolvedValue({ sourceId: 42, sourceName: 'CDM Source' })
+    deleteSource.mockReset().mockResolvedValue(undefined)
+    getSourceDetails.mockReset().mockResolvedValue(details)
+  })
+
+  it('creates a source when no sourceKey is supplied', async () => {
+    const wrapper = await mountDialog(null)
+    await fillRequiredFields(wrapper)
+
+    await clickSave(wrapper)
+
+    expect(updateSource).not.toHaveBeenCalled()
+    expect(createSource).toHaveBeenCalledTimes(1)
+    expect(createSource.mock.calls[0][0]).toMatchObject({
+      name: 'New Source',
+      key: 'NEW_SOURCE',
+      dialect: 'POSTGRESQL',
+    })
+    expect(wrapper.emitted('saved')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('updates through the numeric sourceId, not the sourceKey prop', async () => {
+    const wrapper = await mountDialog('CDM')
+
+    await clickSave(wrapper)
+
+    expect(createSource).not.toHaveBeenCalled()
+    expect(updateSource).toHaveBeenCalledTimes(1)
+    const [sourceId, request] = updateSource.mock.calls[0]
+    expect(sourceId).toBe(42)
+    expect(request).toMatchObject({ name: 'CDM Source', key: 'CDM' })
+    expect(wrapper.emitted('saved')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('reports the failure and stays open when the save is rejected', async () => {
+    updateSource.mockRejectedValue(new Error('Unable to update data source. Please try again.'))
+    const wrapper = await mountDialog('CDM')
+
+    await clickSave(wrapper)
+
+    expect(wrapper.emitted('saved')).toBeUndefined()
+    expect(wrapper.emitted('error')?.[0]).toEqual([
+      'Unable to update data source. Please try again.',
+    ])
+    wrapper.unmount()
+  })
+})

--- a/tests/component/config/DataSourceDialog.spec.ts
+++ b/tests/component/config/DataSourceDialog.spec.ts
@@ -79,7 +79,7 @@ async function mountDialog(sourceKey: string | null) {
   return wrapper
 }
 
-async function fillRequiredFields(wrapper: VueWrapper) {
+async function fillRequiredFields(wrapper: VueWrapper, dialect = 'POSTGRESQL') {
   const byLabel = (name: string, label: string) =>
     wrapper.findAllComponents({ name }).find(c => c.props('label') === label)!
 
@@ -88,7 +88,7 @@ async function fillRequiredFields(wrapper: VueWrapper) {
   await byLabel('AtlasTextField', 'configuration.viewEdit.connectionString.label').setValue(
     'jdbc:postgresql://localhost:5432/newdb'
   )
-  await byLabel('AtlasSelect', 'configuration.viewEdit.dialect.label').setValue('POSTGRESQL')
+  await byLabel('AtlasSelect', 'configuration.viewEdit.dialect.label').setValue(dialect)
   await flushPromises()
 }
 
@@ -128,6 +128,24 @@ describe('DataSourceDialog save', () => {
       dialect: 'POSTGRESQL',
     })
     expect(wrapper.emitted('saved')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('sends the BigQuery keyfile through', async () => {
+    const wrapper = await mountDialog(null)
+    await fillRequiredFields(wrapper, 'BIGQUERY')
+
+    const keyfile = new File(['{"type":"service_account"}'], 'key.json', {
+      type: 'application/json',
+    })
+    // v-file-input without `multiple` models one File, not a list of them.
+    await wrapper.findComponent({ name: 'VFileInput' }).setValue(keyfile)
+    await flushPromises()
+
+    await clickSave(wrapper)
+
+    expect(createSource).toHaveBeenCalledTimes(1)
+    expect(createSource.mock.calls[0][1]).toBe(keyfile)
     wrapper.unmount()
   })
 

--- a/tests/unit/services/source.service.spec.ts
+++ b/tests/unit/services/source.service.spec.ts
@@ -48,6 +48,38 @@ describe('SourceService', () => {
     global.fetch = vi.fn()
   })
 
+  // WebAPI resolves @RequestPart("source") SourceRequest through its message
+  // converters, so the part has to carry an application/json content type —
+  // an untyped part is rejected with HttpMediaTypeNotSupportedException just
+  // like a plain JSON request body is.
+  async function sourcePartOf(init: RequestInit) {
+    expect(init.body).toBeInstanceOf(FormData)
+    const part = (init.body as FormData).get('source')
+    expect(part).toBeInstanceOf(Blob)
+    const blob = part as Blob
+    expect(blob.type).toBe('application/json')
+    const text = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(String(reader.result))
+      reader.onerror = () => reject(reader.error)
+      reader.readAsText(blob)
+    })
+    return JSON.parse(text)
+  }
+
+  function mockFetchOnce(response: Record<string, unknown>) {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => response
+    } as Response)
+  }
+
+  function lastFetchCall() {
+    const calls = vi.mocked(global.fetch).mock.calls
+    expect(calls).toHaveLength(1)
+    return calls[0] as [string, RequestInit]
+  }
+
   describe('fetchCDMSources', () => {
     // http-client is module-mocked above (vi.mock('@/services/http-client', ...)),
     // so these stub httpGet directly rather than the raw fetch response the
@@ -144,16 +176,14 @@ describe('SourceService', () => {
   })
 
   describe('createSource', () => {
-    it('creates a source without keyfile', async () => {
+    it('creates a source without keyfile as multipart form data', async () => {
       const { httpPost } = await import('@/services/http-client')
-      const mockResponse = {
+      mockFetchOnce({
         sourceId: 2,
         sourceName: 'New Source',
         sourceDialect: 'postgresql',
         sourceKey: 'NEW_SOURCE'
-      }
-
-      vi.mocked(httpPost).mockResolvedValue(mockResponse)
+      })
 
       const result = await createSource({
         name: 'New Source',
@@ -162,24 +192,29 @@ describe('SourceService', () => {
         connectionString: 'jdbc:postgresql://localhost:5432/newdb'
       })
 
-      expect(httpPost).toHaveBeenCalledWith('/source', expect.objectContaining({
+      expect(httpPost).not.toHaveBeenCalled()
+      const [url, init] = lastFetchCall()
+      expect(url).toBe('/WebAPI/source')
+      expect(init.method).toBe('POST')
+      // The browser has to set multipart/form-data itself so the body carries
+      // a boundary.
+      expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined()
+      expect(await sourcePartOf(init)).toMatchObject({
         sourceName: 'New Source',
         sourceDialect: 'postgresql',
         sourceKey: 'NEW_SOURCE'
-      }))
+      })
+      expect((init.body as FormData).get('keyfile')).toBeNull()
       expect(result.sourceId).toBe(2)
     })
 
     it('creates a source with username and password', async () => {
-      const { httpPost } = await import('@/services/http-client')
-      const mockResponse = {
+      mockFetchOnce({
         sourceId: 3,
         sourceName: 'Auth Source',
         sourceDialect: 'postgresql',
         sourceKey: 'AUTH_SOURCE'
-      }
-
-      vi.mocked(httpPost).mockResolvedValue(mockResponse)
+      })
 
       await createSource({
         name: 'Auth Source',
@@ -190,22 +225,20 @@ describe('SourceService', () => {
         password: 'secret'
       })
 
-      expect(httpPost).toHaveBeenCalledWith('/source', expect.objectContaining({
+      const [, init] = lastFetchCall()
+      expect(await sourcePartOf(init)).toMatchObject({
         username: 'admin',
         password: 'secret'
-      }))
+      })
     })
 
     it('creates a source with daimons', async () => {
-      const { httpPost } = await import('@/services/http-client')
-      const mockResponse = {
+      mockFetchOnce({
         sourceId: 4,
         sourceName: 'Full Source',
         sourceDialect: 'postgresql',
         sourceKey: 'FULL_SOURCE'
-      }
-
-      vi.mocked(httpPost).mockResolvedValue(mockResponse)
+      })
 
       await createSource({
         name: 'Full Source',
@@ -218,23 +251,20 @@ describe('SourceService', () => {
         ]
       })
 
-      expect(httpPost).toHaveBeenCalledWith('/source', expect.objectContaining({
-        daimons: expect.arrayContaining([
-          expect.objectContaining({ daimonType: 'CDM', tableQualifier: 'cdm' })
-        ])
-      }))
+      const [, init] = lastFetchCall()
+      expect((await sourcePartOf(init)).daimons).toEqual([
+        { daimonType: 'CDM', tableQualifier: 'cdm', priority: 0 },
+        { daimonType: 'Vocabulary', tableQualifier: 'vocab', priority: 1 }
+      ])
     })
 
     it('creates a source with Kerberos settings', async () => {
-      const { httpPost } = await import('@/services/http-client')
-      const mockResponse = {
+      mockFetchOnce({
         sourceId: 5,
         sourceName: 'Kerb Source',
         sourceDialect: 'impala',
         sourceKey: 'KERB_SOURCE'
-      }
-
-      vi.mocked(httpPost).mockResolvedValue(mockResponse)
+      })
 
       await createSource({
         name: 'Kerb Source',
@@ -245,10 +275,11 @@ describe('SourceService', () => {
         krbAdminServer: 'kdc.example.com'
       })
 
-      expect(httpPost).toHaveBeenCalledWith('/source', expect.objectContaining({
+      const [, init] = lastFetchCall()
+      expect(await sourcePartOf(init)).toMatchObject({
         krbAuthMethod: 'KEYTAB',
         krbAdminServer: 'kdc.example.com'
-      }))
+      })
     })
 
     it('creates a source with keyfile using multipart form', async () => {
@@ -284,8 +315,7 @@ describe('SourceService', () => {
     })
 
     it('throws on network error', async () => {
-      const { httpPost } = await import('@/services/http-client')
-      vi.mocked(httpPost).mockRejectedValue(new Error('Server error'))
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Server error'))
 
       await expect(createSource({
         name: 'Fail Source',
@@ -297,16 +327,14 @@ describe('SourceService', () => {
   })
 
   describe('updateSource', () => {
-    it('updates a source without keyfile', async () => {
+    it('updates a source without keyfile as multipart form data', async () => {
       const { httpPut } = await import('@/services/http-client')
-      const mockResponse = {
+      mockFetchOnce({
         sourceId: 1,
         sourceName: 'Updated Source',
         sourceDialect: 'postgresql',
         sourceKey: 'UPDATED_SOURCE'
-      }
-
-      vi.mocked(httpPut).mockResolvedValue(mockResponse)
+      })
 
       const result = await updateSource(1, {
         name: 'Updated Source',
@@ -315,9 +343,14 @@ describe('SourceService', () => {
         connectionString: 'jdbc:postgresql://localhost:5432/updated'
       })
 
-      expect(httpPut).toHaveBeenCalledWith('/source/1', expect.objectContaining({
+      expect(httpPut).not.toHaveBeenCalled()
+      const [url, init] = lastFetchCall()
+      // Keyed on the numeric sourceId, not the string sourceKey.
+      expect(url).toBe('/WebAPI/source/1')
+      expect(init.method).toBe('PUT')
+      expect(await sourcePartOf(init)).toMatchObject({
         sourceName: 'Updated Source'
-      }))
+      })
       expect(result.sourceName).toBe('Updated Source')
     })
 
@@ -354,8 +387,7 @@ describe('SourceService', () => {
     })
 
     it('throws on network error', async () => {
-      const { httpPut } = await import('@/services/http-client')
-      vi.mocked(httpPut).mockRejectedValue(new Error('Update failed'))
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Update failed'))
 
       await expect(updateSource(1, {
         name: 'Fail Update',


### PR DESCRIPTION
Saving a data source from Configuration → Data Sources failed with a 415:

```
{"message": "An exception occurred: org.springframework.web.HttpMediaTypeNotSupportedException"}
```

WebAPI's create/update endpoints consume `multipart/form-data` only:

```java
@PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, ...)
public ResponseEntity<SourceInfo> createSource(
        @RequestPart(value = "keyfile", required = false) MultipartFile keyfile,
        @RequestPart("source") SourceRequest source)
```

`createSource`/`updateSource` only built a `FormData` body when a keyfile was
attached — the BigQuery and Kerberos-keytab cases. Every other dialect (the
PostgreSQL source in the report included) took the `httpPost`/`httpPut` branch
and sent a plain JSON body, which Spring rejects at the mapping before the
handler runs.

Route both saves through the multipart helper and make the keyfile part
optional. The `source` part stays a `Blob` typed `application/json`: Spring
resolves `@RequestPart("source") SourceRequest` through its message converters,
so an untyped part fails the same way a JSON request body does.

The update path had a second defect behind the first: it addressed
`PUT /source/{sourceKey}`, but the endpoint is keyed on the numeric
`sourceId`, so editing a source would have failed again once the media type
was fixed. It now uses the `loadedSourceId` the dialog already tracks for
delete.
