### PR TITLE
Fix concept search silently showing zero results on page 2

### DIFF
--- a/src/stores/concept-search.ts
+++ b/src/stores/concept-search.ts
@@ -49,7 +49,14 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
 
   const totalCount = computed(() => facets.filteredConcepts.value.length)
 
-  // Client-side pagination and sorting
+  // Sorted (but NOT paginated) results. `ConceptTable` forwards this list to
+  // `AtlasDataTable`/`v-data-table` together with `page`/`itemsPerPage`, and
+  // `v-data-table` does its own slicing for the current page. Slicing here as
+  // well used to double-paginate: page 1 happened to look correct because the
+  // first `itemsPerPage` items of an already-`itemsPerPage`-sized array is
+  // that same array, but page 2 sliced an out-of-range window from an array
+  // that only ever contained one page's worth of items, silently returning
+  // nothing (see #201/#203).
   const concepts = computed(() => {
     const sorted = [...facets.filteredConcepts.value]
 
@@ -75,11 +82,7 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
       })
     }
 
-    // Apply pagination
-    const start = (page.value - 1) * itemsPerPage.value
-    const end = start + itemsPerPage.value
-
-    return sorted.slice(start, end)
+    return sorted
   })
 
   // `isEmpty` reflects whether the search returned ANY results (`allConcepts`),

--- a/tests/unit/stores/concept-search.spec.ts
+++ b/tests/unit/stores/concept-search.spec.ts
@@ -364,23 +364,29 @@ describe('Concept Search Store', () => {
       await store.search('test')
     })
 
-    it('should paginate results with default page size', () => {
+    it('should expose the full sorted result set for the table to paginate, not a pre-sliced page', () => {
+      // `AtlasDataTable`/`v-data-table` receives `store.concepts` together
+      // with `page`/`itemsPerPage` and slices it itself. If the store also
+      // sliced, the table would slice an already-page-sized array a second
+      // time (see #201/#203).
       const store = useConceptSearchStore()
 
-      expect(store.concepts.length).toBe(25)
+      expect(store.concepts.length).toBe(100)
       expect(store.concepts[0].conceptId).toBe(1)
-      expect(store.concepts[24].conceptId).toBe(25)
+      expect(store.concepts[99].conceptId).toBe(100)
       expect(store.totalCount).toBe(100)
     })
 
-    it('should navigate to different pages', () => {
+    it('should not truncate or reorder the sorted list when navigating to a later page (#201/#203 regression)', () => {
       const store = useConceptSearchStore()
 
       store.updatePagination(2, 25)
-      expect(store.concepts[0].conceptId).toBe(26)
+      expect(store.concepts.length).toBe(100)
+      expect(store.concepts[25].conceptId).toBe(26)
 
-      store.updatePagination(3, 25)
-      expect(store.concepts[0].conceptId).toBe(51)
+      store.updatePagination(4, 25)
+      expect(store.concepts.length).toBe(100)
+      expect(store.concepts[99].conceptId).toBe(100)
     })
 
     it('should compute page range text', () => {


### PR DESCRIPTION
## Problem

Concept search returns thousands of results, but page 2 renders no rows at all, with nothing in the console.

## Cause

The concept-search store's `concepts` getter already sliced results down to the current page, then handed that page-sized array to `AtlasDataTable` together with the same `page`/`itemsPerPage` props, so `v-data-table` sliced it a second time. Page 1 looked correct by coincidence: the first `itemsPerPage` items of an already-`itemsPerPage`-sized array is that same array. Page 2 sliced an out-of-range window and silently returned nothing.

## Fix

Stop pre-slicing in the store and let the table paginate once, the same pattern `RecommendTab` already uses. The concept-search e2e assertion that should have caught this is tightened as well, since it accepted zero rows on page 2 as passing.

## Note

#203 reports the same symptom on a different component that never pre-sliced its data, so it has a separate root cause and is fixed in #231 instead.

Fixes #201
