### PR TITLE
Fix inclusion rules report showing empty despite valid data

### DIFF
--- a/src/models/report.types.ts
+++ b/src/models/report.types.ts
@@ -1257,6 +1257,10 @@ export const InclusionRuleReportSchema = z.object({
       percentExcluded: z.string(),
     })
   ),
-  treemapData: z.string(),
+  // Optional/nullable: the server omits this when there is nothing to plot
+  // (e.g. a small cohort, or `mode=0`/by-event). Requiring it made the whole
+  // envelope fail validation and get silently discarded, hiding a perfectly
+  // valid summary/inclusionRuleStats behind a "no report data" message (#202).
+  treemapData: z.string().nullable().optional(),
   prevalenceThreshold: z.number().optional(),
 })

--- a/tests/unit/services/getInclusionRuleReport.spec.ts
+++ b/tests/unit/services/getInclusionRuleReport.spec.ts
@@ -111,4 +111,62 @@ describe('getInclusionRuleReport', () => {
       expect(result.error.status).toBe(403)
     }
   })
+
+  it('still returns the summary and inclusion rule stats when treemapData is omitted (#202)', async () => {
+    // The server omits treemapData when there is nothing to plot. Requiring
+    // it in the schema used to fail validation for the whole envelope and
+    // discard an otherwise valid, non-empty report.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          summary: { baseCount: 65660, finalCount: 65660, lostCount: 0, percentMatched: '100.00' },
+          inclusionRuleStats: [
+            {
+              id: 0,
+              name: 'Rule A',
+              countSatisfying: 65660,
+              percentSatisfying: '100.00',
+              percentExcluded: '0.00',
+            },
+          ],
+        }),
+    })
+
+    const result = await getInclusionRuleReport(1, 'EUNOMIA', 1)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.summary.finalCount).toBe(65660)
+    expect(result.data.inclusionRuleStats).toHaveLength(1)
+    expect(result.data.treemap).toBeNull()
+  })
+
+  it('still returns the summary and inclusion rule stats when treemapData is null (#202)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          summary: { baseCount: 100, finalCount: 80, lostCount: 20, percentMatched: '80.00' },
+          inclusionRuleStats: [
+            {
+              id: 0,
+              name: 'Rule A',
+              countSatisfying: 80,
+              percentSatisfying: '80.00',
+              percentExcluded: '20.00',
+            },
+          ],
+          treemapData: null,
+        }),
+    })
+
+    const result = await getInclusionRuleReport(1, 'EUNOMIA', 1)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.summary.finalCount).toBe(80)
+    expect(result.data.inclusionRuleStats).toHaveLength(1)
+    expect(result.data.treemap).toBeNull()
+  })
 })


### PR DESCRIPTION
## Problem

After generating a cohort that matched 65,660 people, the inclusion rules report renders completely empty.

## Cause

`InclusionRuleReportSchema` required `treemapData` as a plain string, but WebAPI omits it whenever there is nothing to plot (a small cohort, or `mode=0`/by-event). `safeParse` then rejected the entire envelope, so `getInclusionRuleReport` discarded a perfectly valid `summary` and `inclusionRuleStats` and the UI fell back to an indistinguishable "no report data" state. The decoding path already used optional chaining on `treemapData`, so it assumed this could happen; only the schema disagreed.

## Fix

Make `treemapData` nullable and optional.

Fixes #202
