### PR TITLE
Fix table pagination getting stuck when a caller does not manage page state

### DIFF
--- a/src/components/ui/AtlasDataTable.vue
+++ b/src/components/ui/AtlasDataTable.vue
@@ -5,8 +5,6 @@
     :headers="headers"
     :items="items"
     :loading="loading"
-    :items-per-page="itemsPerPage"
-    :page="page"
     :height="height"
     :fixed-header="fixedHeader"
     :hide-default-footer="hideDefaultFooter"
@@ -14,7 +12,7 @@
     :loading-text="loadingText"
     :aria-label="caption"
     density="compact"
-    v-bind="forwardAttrs"
+    v-bind="tableBind"
     @update:page="(v: number) => $emit('update:page', v)"
     @update:items-per-page="(v: number) => $emit('update:itemsPerPage', v)"
   >
@@ -65,8 +63,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   loading: false,
-  itemsPerPage: 10,
-  page: 1,
+  itemsPerPage: undefined,
+  page: undefined,
   sortBy: undefined,
   height: undefined,
   fixedHeader: false,
@@ -97,10 +95,23 @@ const sortByModel = computed<SortItem[]>({
   },
 })
 
+// Vuetify treats `page`/`items-per-page` as externally controlled when the
+// vnode carries the prop key AND an `onUpdate:` listener. This wrapper always
+// attaches the listeners, so binding the props unconditionally made every
+// table controlled — including callers that never round-trip page state,
+// whose pager was then pinned to a value nothing ever updated (#203, #222).
+// Forward the keys only when the caller actually provided them.
 const attrs = useAttrs()
-const forwardAttrs = computed(() => {
-  const { density: _d, ...rest } = attrs as Record<string, unknown>
+
+// Single merged v-bind: Vue's SFC compiler rejects multiple bare `v-bind`
+// directives on one element, so the conditional pagination keys and the
+// forwarded $attrs have to combine here.
+const tableBind = computed(() => {
+  const { density: _d, ...restAttrs } = attrs as Record<string, unknown>
   void _d
-  return rest
+  const bind: Record<string, unknown> = { ...restAttrs }
+  if (props.page !== undefined) bind.page = props.page
+  if (props.itemsPerPage !== undefined) bind['items-per-page'] = props.itemsPerPage
+  return bind
 })
 </script>

--- a/tests/component/ui/AtlasDataTable.spec.ts
+++ b/tests/component/ui/AtlasDataTable.spec.ts
@@ -58,6 +58,43 @@ describe('AtlasDataTable', () => {
     expect(dt.props('page')).toBe(2)
   })
 
+  it('does not bind page/items-per-page onto v-data-table when the caller never passed them (#203, #222)', () => {
+    // Vuetify's `useProxiedModel` treats a model as externally controlled when
+    // the vnode carries BOTH the prop key and an `onUpdate:` listener. This
+    // wrapper always attaches the listeners, so binding the props
+    // unconditionally (with numeric defaults) made every table controlled —
+    // including callers that never round-trip page state, whose pager was then
+    // pinned to a value that never changed.
+    const wrapper = mountWith()
+    const dt = wrapper.findComponent({ name: 'VDataTable' })
+    // $props always has every declared prop key (Vue's props system), so it
+    // can't tell us what the caller actually bound. Vuetify's own
+    // "controlled" check reads the raw vnode props instead — that's what
+    // must NOT contain `page`/`itemsPerPage` here.
+    const vnodeProps = (dt.vm.$.vnode.props ?? {}) as Record<string, unknown>
+    expect(Object.prototype.hasOwnProperty.call(vnodeProps, 'page')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(vnodeProps, 'itemsPerPage')).toBe(false)
+  })
+
+  it('paginates on its own when the caller does not manage page state (#203, #222)', async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({ name: `row-${i}`, value: i }))
+    const wrapper = mount(AtlasDataTable, {
+      global: { plugins: [vuetify] },
+      props: { headers: HEADERS, items: many },
+    })
+
+    expect(wrapper.findAll('tbody tr')).toHaveLength(10)
+    expect(wrapper.text()).toContain('row-0')
+
+    const next = wrapper.findAll('.v-pagination__next button, button[aria-label*="Next"]')
+    expect(next.length).toBeGreaterThan(0)
+    await next[0]!.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('row-10')
+    expect(wrapper.text()).not.toContain('row-0')
+  })
+
   it('forwards sortBy', () => {
     const sortBy = [{ key: 'name', order: 'asc' as const }]
     const wrapper = mountWith({ sortBy })


### PR DESCRIPTION
## Problem

Pagination controls do nothing in several places: page 2 of related concepts never appears (#203), and the characterization cohort selector will not change its page size (#222).

## Cause

Vuetify's `useProxiedModel` treats `page`/`items-per-page` as externally controlled when the vnode carries both the prop key and a matching `onUpdate:` listener. `AtlasDataTable` always attached the listeners *and* always bound the props, with numeric defaults, even for callers that never pass them and never round-trip the value. Every table was therefore "controlled" by a value that nothing ever updated, so `v-data-table`'s internal pager could not advance and each click re-rendered the same frozen page.

## Fix

Forward `page`/`items-per-page` to `v-data-table` only when the caller actually provided them. Callers that do not manage pagination now get normal uncontrolled pagination; callers that do are unaffected.

## Verification

Adds a behavioural test that mounts an unmanaged table with 25 rows, clicks the footer's next button, and asserts the rendered rows actually advance from `row-0` to `row-10`, alongside a test pinning the vnode-prop mechanism.

Fixes #203
Fixes #222
