### PR TITLE
Show which data source a cohort sample belongs to

### DIFF
--- a/src/components/cohort-samples/CohortSampleDetail.vue
+++ b/src/components/cohort-samples/CohortSampleDetail.vue
@@ -5,6 +5,13 @@
         <div class="text-subtitle-1 font-weight-medium">
           {{ sample.name }}
         </div>
+        <div
+          v-if="sourceName"
+          class="text-caption text-grey-darken-1"
+          data-testid="cohort-sample-detail-source"
+        >
+          {{ t('components.cohortSampleDetail.source', 'Source: {name}', { name: sourceName }).value }}
+        </div>
         <div class="text-caption text-grey-darken-1">
           {{
             t('components.cohortSampleDetail.personsCreated', '{count} persons · created {date}', {
@@ -107,6 +114,14 @@ defineEmits<{ 'open-profile': [personId: string] }>()
 const dsStore = useDataSourcesStore()
 
 const effectiveSourceKey = computed(() => props.sourceKey ?? dsStore.selectedSource?.sourceKey)
+
+// Once a sample is generated, the view gives no indication of which source's
+// sample is being looked at, which is ambiguous when a cohort has samples
+// from more than one source (#204).
+const sourceName = computed(
+  () => dsStore.sources.find(s => s.sourceKey === effectiveSourceKey.value)?.sourceName
+    ?? effectiveSourceKey.value
+)
 
 function formatCount(n: number): string {
   return new Intl.NumberFormat().format(n)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1620,6 +1620,7 @@
       "failedToCreateSample": "Failed to create sample"
     },
     "cohortSampleDetail": {
+      "source": "Source: {name}",
       "personsCreated": "{count} persons · created {date}",
       "records": "Records",
       "noRecords": "This sample has no person records."

--- a/tests/component/cohort-samples/CohortSampleDetail.spec.ts
+++ b/tests/component/cohort-samples/CohortSampleDetail.spec.ts
@@ -5,6 +5,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createPinia, setActivePinia } from 'pinia'
 import CohortSampleDetail from '@/components/cohort-samples/CohortSampleDetail.vue'
+import { useDataSourcesStore } from '@/stores/datasources'
 
 const vuetify = createVuetify({ components, directives })
 const globalMountOpts = {
@@ -46,6 +47,25 @@ describe('CohortSampleDetail', () => {
       props: { sample: { id: 1, name: 'demo', size: 0, elements: [] } },
     })
     expect(wrapper.find('[data-testid=cohort-sample-detail-empty]').exists()).toBe(true)
+  })
+
+  it('shows which source the sample belongs to (#204)', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const dsStore = useDataSourcesStore()
+    dsStore.sources = [
+      { sourceId: 1, sourceName: 'SynPUF 5%', sourceKey: 'SYNPUF5PCT', sourceDialect: 'postgresql', daimons: [] },
+    ]
+
+    const wrapper = mount(CohortSampleDetail, {
+      global: { plugins: [vuetify, pinia], stubs: globalMountOpts.stubs },
+      props: {
+        sourceKey: 'SYNPUF5PCT',
+        sample: { id: 1, name: 'demo', size: 0, elements: [] },
+      },
+    })
+
+    expect(wrapper.find('[data-testid=cohort-sample-detail-source]').text()).toContain('SynPUF 5%')
   })
 
   it('shows the loading skeleton when loading is true', () => {


### PR DESCRIPTION
## Problem

A cohort can be sampled from more than one data source, but once you open a sample there is no indication of which source it came from.

## Fix

Show the source name in the sample header. The source key was already threaded through as a prop and simply never resolved to a display name or rendered; it now resolves via the data sources store and falls back to the raw key.

Fixes #204
