### PR TITLE
Fix concept set list showing used sets as unused, and the duplicate-looking validation warning

### DIFF
--- a/src/composables/useCohortValidation.ts
+++ b/src/composables/useCohortValidation.ts
@@ -78,44 +78,47 @@ export function extractConceptSets(
   // first and leaving criteria pointing at a CodesetId that no longer exists.
   const conceptSetsMap = new Map<number | string, ConceptSetReference>()
 
-  // Extract from entry events
-  entryEvents.forEach(event => {
+  // Mirrors the recursive walk in `utils/concept-set-usages.ts`: a concept
+  // set can be referenced not just on `event.conceptSet`, but on a
+  // `conceptSet`-type attribute (e.g. VisitTypeCS) or inside a correlated
+  // "with" sub-criteria group (`event.nestedCriteria`). Missing either of
+  // those made a genuinely-used concept set look unused (#205) and dropped
+  // it from the `ConceptSets` array sent for server-side validation (#200).
+  function collectFromEvent(event: CohortEvent) {
     if (event.conceptSet) {
       conceptSetsMap.set(event.conceptSet.id, event.conceptSet)
     }
-  })
-
-  // Extract from additional criteria
-  if (additionalCriteria?.events) {
-    additionalCriteria.events.forEach(event => {
-      if (event.conceptSet) {
-        conceptSetsMap.set(event.conceptSet.id, event.conceptSet)
+    for (const attribute of event.attributes ?? []) {
+      if (attribute.type === 'conceptSet' && attribute.conceptSet) {
+        conceptSetsMap.set(attribute.conceptSet.id, attribute.conceptSet)
       }
-    })
+    }
+    if (event.nestedCriteria) {
+      collectFromGroup(event.nestedCriteria)
+    }
   }
 
-  // Extract from inclusion rules
+  function collectFromGroup(group: CriteriaGroup) {
+    group.events.forEach(collectFromEvent)
+    group.nestedGroups?.forEach(collectFromGroup)
+  }
+
+  entryEvents.forEach(collectFromEvent)
+
+  if (additionalCriteria) {
+    collectFromGroup(additionalCriteria)
+  }
+
   inclusionRules.forEach(rule => {
-    rule.criteriaGroups.forEach(group => {
-      group.events.forEach(event => {
-        if (event.conceptSet) {
-          conceptSetsMap.set(event.conceptSet.id, event.conceptSet)
-        }
-      })
-    })
+    rule.criteriaGroups.forEach(collectFromGroup)
   })
 
-  // Extract from exit criteria (drug exposure)
   if (exitCriteria?.conceptSet) {
     conceptSetsMap.set(exitCriteria.conceptSet.id, exitCriteria.conceptSet)
   }
+  exitCriteria?.censoringEvents?.forEach(collectFromEvent)
 
-  // Extract from censoring criteria
-  censoringCriteria.forEach(event => {
-    if (event.conceptSet) {
-      conceptSetsMap.set(event.conceptSet.id, event.conceptSet)
-    }
-  })
+  censoringCriteria.forEach(collectFromEvent)
 
   return Array.from(conceptSetsMap.values())
 }

--- a/src/composables/useCohortValidation.ts
+++ b/src/composables/useCohortValidation.ts
@@ -85,11 +85,18 @@ export function extractConceptSets(
   // those made a genuinely-used concept set look unused (#205) and dropped
   // it from the `ConceptSets` array sent for server-side validation (#200).
   function collectFromEvent(event: CohortEvent) {
-    if (event.conceptSet) {
+    // A newly-added criterion is seeded with a placeholder concept set
+    // reference (id null, name "Select concept set...") rather than leaving
+    // `conceptSet` unset (see GroupCriteriaUI.vue). A bare truthiness check
+    // folded that placeholder into the used-concept-sets list, which then
+    // got serialized with a fabricated array-index id that could collide
+    // with a real, already-selected concept set's id and produce a
+    // duplicate-looking "Select Concept Set..." validation warning (#214).
+    if (event.conceptSet && event.conceptSet.id != null) {
       conceptSetsMap.set(event.conceptSet.id, event.conceptSet)
     }
     for (const attribute of event.attributes ?? []) {
-      if (attribute.type === 'conceptSet' && attribute.conceptSet) {
+      if (attribute.type === 'conceptSet' && attribute.conceptSet && attribute.conceptSet.id != null) {
         conceptSetsMap.set(attribute.conceptSet.id, attribute.conceptSet)
       }
     }
@@ -113,7 +120,7 @@ export function extractConceptSets(
     rule.criteriaGroups.forEach(collectFromGroup)
   })
 
-  if (exitCriteria?.conceptSet) {
+  if (exitCriteria?.conceptSet && exitCriteria.conceptSet.id != null) {
     conceptSetsMap.set(exitCriteria.conceptSet.id, exitCriteria.conceptSet)
   }
   exitCriteria?.censoringEvents?.forEach(collectFromEvent)

--- a/tests/unit/composables/extractConceptSets.spec.ts
+++ b/tests/unit/composables/extractConceptSets.spec.ts
@@ -61,4 +61,60 @@ describe('extractConceptSets', () => {
     expect(result).toHaveLength(1)
     expect(result[0]?.id).toBe(5)
   })
+
+  it('finds a concept set that is only referenced inside a nested/correlated criteria group (#205)', () => {
+    const cs: ConceptSetReference = { id: 7, name: 'Nested Only', items: [] }
+    const nestedEvent = event('nested-e1', cs)
+    const outerEvent: CohortEvent = {
+      ...event('e1'),
+      nestedCriteria: { id: 'g-nested', logicType: 'ALL', events: [nestedEvent] } as CriteriaGroup,
+    }
+
+    const result = extractConceptSets([outerEvent], undefined, [], emptyExit, [])
+
+    expect(result.map(r => r.id)).toEqual([7])
+  })
+
+  it('finds a concept set that is only referenced through a conceptSet-type attribute (#205)', () => {
+    const cs: ConceptSetReference = { id: 8, name: 'Visit Type CS', items: [] }
+    const eventWithAttribute: CohortEvent = {
+      ...event('e1'),
+      attributes: [{ type: 'conceptSet', conceptSet: cs } as CohortEvent['attributes'][number]],
+    }
+
+    const result = extractConceptSets([eventWithAttribute], undefined, [], emptyExit, [])
+
+    expect(result.map(r => r.id)).toEqual([8])
+  })
+
+  it('finds a concept set nested inside additional criteria and inclusion rule sub-groups (#205)', () => {
+    const csAdditional: ConceptSetReference = { id: 9, name: 'Additional Nested', items: [] }
+    const csInclusion: ConceptSetReference = { id: 10, name: 'Inclusion Nested', items: [] }
+
+    const additionalCriteria: CriteriaGroup = {
+      id: 'ac',
+      logicType: 'ALL',
+      events: [],
+      nestedGroups: [{ id: 'ac-nested', logicType: 'ALL', events: [event('ae1', csAdditional)] } as CriteriaGroup],
+    } as CriteriaGroup
+
+    const inclusionRules: InclusionRule[] = [
+      {
+        id: 'r1',
+        name: 'Rule 1',
+        criteriaGroups: [
+          {
+            id: 'g1',
+            logicType: 'ALL',
+            events: [],
+            nestedGroups: [{ id: 'g1-nested', logicType: 'ALL', events: [event('ie1', csInclusion)] } as CriteriaGroup],
+          } as CriteriaGroup,
+        ],
+      } as InclusionRule,
+    ]
+
+    const result = extractConceptSets([], additionalCriteria, inclusionRules, emptyExit, [])
+
+    expect((result.map(r => r.id) as number[]).sort((a, b) => a - b)).toEqual([9, 10])
+  })
 })

--- a/tests/unit/composables/extractConceptSets.spec.ts
+++ b/tests/unit/composables/extractConceptSets.spec.ts
@@ -117,4 +117,25 @@ describe('extractConceptSets', () => {
 
     expect((result.map(r => r.id) as number[]).sort((a, b) => a - b)).toEqual([9, 10])
   })
+
+  it('ignores the "Select concept set..." placeholder seeded on a freshly-added criterion (#214)', () => {
+    // GroupCriteriaUI seeds new criteria with a placeholder concept set
+    // reference (id null) instead of leaving conceptSet unset. Treating that
+    // placeholder as a real, used concept set got it serialized with a
+    // fabricated id that could collide with a genuinely-selected concept
+    // set's real id downstream.
+    const real: ConceptSetReference = { id: 3, name: 'Diabetes', items: [] }
+    const placeholder = { id: null as unknown as number, name: 'Select concept set...', items: [] }
+
+    const result = extractConceptSets(
+      [event('e1', real), event('e2', placeholder)],
+      undefined,
+      [],
+      emptyExit,
+      []
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe(3)
+  })
 })


### PR DESCRIPTION
Both commits rewrite `extractConceptSets()` in `src/composables/useCohortValidation.ts`. They are not separable into two pull requests, so they are submitted together.

## Concept sets reported as unused while in use (#205)

`extractConceptSets()` powers the used/unused flag in the concept set list and builds the `ConceptSets` array sent for server-side validation. It only inspected `event.conceptSet` directly on entry events, additional criteria, inclusion rules, exit and censoring criteria. It never recursed into nested or correlated criteria groups (`event.nestedCriteria`), and never looked at `conceptSet`-type attributes, unlike the sibling usage-update walk in `src/utils/concept-set-usages.ts`, which already handles both. A concept set referenced only through one of those paths was invisible to the scan and got flagged as unused.

The function now mirrors that same recursive walk.

## Duplicate-looking "Select Concept Set..." validation warning (#214)

A freshly added criterion is seeded with a placeholder concept set reference (`id: null`, name `Select concept set...`) rather than leaving `conceptSet` unset. `extractConceptSets()` treated any object on `event.conceptSet` as a real, used concept set, so the placeholder was folded into the list sent for validation. Downstream, the Atlas JSON converter falls back to the array index as a fabricated id for any non-numeric id, which can collide with a real, already selected concept set's id in the same payload and produce a second, confusing warning beside the legitimate one.

A reference now needs a real, non-null id before it counts as used.

## Note

The same walk feeds the `ConceptSets` array sent for server-side validation, which is the likely cause of #200. That issue is left open pending confirmation against a live WebAPI.

Fixes #205
Fixes #214
