### PR TITLE
Fix Observation Length chart x-axis truncating fractional year labels

### DIFF
--- a/src/ui/chart-config.ts
+++ b/src/ui/chart-config.ts
@@ -892,6 +892,12 @@ export function dashboardAgeBarOptions(data: DatasourceHistogramChartData): ECha
   const binStarts = validBins.map(bin => offset + bin.intervalIndex * intervalSize)
   const yValues = validBins.map(bin => bin.countValue)
   const axisLabel = data.xAxisLabel || 'Age'
+  // Bin bounds can be fractional (e.g. days expressed as years, interval
+  // ~0.082), so round for display instead of dumping raw floats. Shared by
+  // the tooltip and the x-axis tick labels so both charts and this one
+  // format consistently instead of the axis truncating fractional ticks to
+  // whole numbers (#208).
+  const fmtBin = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(1))
 
   return {
     ...chartRootTextStyle(),
@@ -906,9 +912,6 @@ export function dashboardAgeBarOptions(data: DatasourceHistogramChartData): ECha
 
         const [xStart, xEnd, yValue] = point
         const value = formatSINumber(yValue)
-        // Bin bounds can be fractional (e.g. days expressed as years, interval
-        // ~0.082), so round for display instead of dumping raw floats.
-        const fmtBin = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(1))
         const label = intervalSize === 1 ? fmtBin(xStart) : `${fmtBin(xStart)} - ${fmtBin(xEnd)}`
         return `<strong>${axisLabel}: ${label}</strong><br/>${data.seriesName || data.unit || 'Count'}: ${value}`
       },
@@ -928,7 +931,7 @@ export function dashboardAgeBarOptions(data: DatasourceHistogramChartData): ECha
       nameLocation: 'middle',
       nameGap: 30,
       axisLabel: {
-        formatter: (value: number) => `${Math.floor(value)}`,
+        formatter: (value: number) => fmtBin(value),
         fontSize: 11,
       },
     },

--- a/tests/unit/utils/chart-config.spec.ts
+++ b/tests/unit/utils/chart-config.spec.ts
@@ -711,6 +711,44 @@ describe('chart-config', () => {
       expect(result).not.toContain('31.123')
     })
 
+    it('formats fractional x-axis tick labels to one decimal place instead of truncating (#208)', () => {
+      // Observation Length: 30-day bins expressed as years -> fractional ticks
+      // like 1.25 used to be floored to 1, producing duplicate whole-number
+      // labels (0, 1, 1, 2, 2...) instead of 0.0, 1.2, 2.5...
+      const data: DatasourceHistogramChartData = {
+        intervalSize: 30 / 365.25,
+        offset: 0,
+        bins: [{ intervalIndex: 0, countValue: 1 }],
+        unit: 'Person Count',
+        xAxisLabel: 'Years',
+      }
+
+      const options = dashboardAgeBarOptions(data)
+      const formatter = (options.xAxis as ChartAxisOption & {
+        axisLabel: { formatter: (v: number) => string }
+      }).axisLabel.formatter
+
+      expect(formatter(2.5)).toBe('2.5')
+      expect(formatter(0)).toBe('0')
+      expect(formatter(30 / 365.25)).toBe('0.1')
+    })
+
+    it('keeps whole-number x-axis tick labels whole for integer bin sizes', () => {
+      const data: DatasourceHistogramChartData = {
+        intervalSize: 1,
+        offset: 0,
+        bins: [{ intervalIndex: 0, countValue: 1 }],
+        unit: 'Persons',
+      }
+
+      const options = dashboardAgeBarOptions(data)
+      const formatter = (options.xAxis as ChartAxisOption & {
+        axisLabel: { formatter: (v: number) => string }
+      }).axisLabel.formatter
+
+      expect(formatter(5)).toBe('5')
+    })
+
     it('formats tooltip with large numbers using SI notation', () => {
       const data: DatasourceHistogramChartData = {
         intervalSize: 1,


### PR DESCRIPTION
## Problem

On the Observation Length chart, the x-axis shows duplicated whole-number labels (`0, 1, 1, 2, 2, ...`) instead of the decimal years that the Cumulative Observation chart directly below it displays correctly.

## Cause

The histogram's axis label formatter floored every tick to a whole number. That is right for integer bin sizes such as age in years, but Observation Length uses 30-day bins expressed as fractional years, so ticks like `1.25` and `2.5` both collapsed onto neighbouring integers.

## Fix

Reuse the fractional-safe formatter the tooltip already uses for the axis labels too, so both read consistently.

Fixes #208
