### PR TITLE
Show the resulting concept set after adding a concept, not the search view

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -1127,16 +1127,31 @@ function confirmDelete() {
 // Concept Building Methods
 // ============================================================================
 
+// A brand-new set opens on Search so users can add concepts right away, but a
+// single add left the search view up with no visible confirmation that
+// anything happened, since the added concept only shows on the Selected tab.
+// Switch there after the FIRST concept lands in an empty set, not on every
+// add, so search-then-add-several still works (#210).
+function showResultAfterFirstAdd(wasEmpty: boolean) {
+  if (wasEmpty && (store.currentSet?.items.length ?? 0) > 0) {
+    activeTab.value = 'selected'
+  }
+}
+
 function onAddConcept(concept: Concept, flags?: ConceptAddFlags) {
+  const wasEmpty = (store.currentSet?.items.length ?? 0) === 0
   store.addConceptToSet(concept, flags)
   hasUnsavedChanges.value = true
+  showResultAfterFirstAdd(wasEmpty)
 }
 
 function onAddConcepts(concepts: Concept[], flags?: ConceptAddFlags) {
+  const wasEmpty = (store.currentSet?.items.length ?? 0) === 0
   for (const concept of concepts) {
     store.addConceptToSet(concept, flags)
   }
   hasUnsavedChanges.value = true
+  showResultAfterFirstAdd(wasEmpty)
 }
 
 function onRemoveConcept(concept: Concept) {
@@ -1164,8 +1179,13 @@ function onToggleExclude(conceptId: number) {
   hasUnsavedChanges.value = true
 }
 
-function onRecommendedConceptsAdded(_count: number) {
+function onRecommendedConceptsAdded(count: number) {
   hasUnsavedChanges.value = true
+  // Same rule as onAddConcept: only jump to Selected when this batch is
+  // what populated a previously-empty set, not on every recommend-add (#210).
+  if (count > 0 && store.currentSet?.items.length === count) {
+    activeTab.value = 'selected'
+  }
 }
 
 // ============================================================================

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -473,6 +473,23 @@ describe('ConceptSetEditor', () => {
     expect(addConceptSpy).toHaveBeenNthCalledWith(2, second, flags)
   })
 
+  it('switches to the Selected tab after the first concept lands in an empty set, not on later adds (#210)', async () => {
+    const wrapper = mountComponent({ conceptSet: null })
+    const store = useConceptSetsStore()
+    store.currentSet = { id: 'new', name: '', items: [] }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.activeTab).toBe('search')
+
+    await wrapper.vm.onAddConcept(mockConcept)
+    expect(wrapper.vm.activeTab).toBe('selected')
+
+    // A second add to an already-populated set should not force a tab
+    // switch back if the user has since navigated away from Selected.
+    wrapper.vm.activeTab = 'search'
+    await wrapper.vm.onAddConcept({ ...mockConcept, conceptId: 999 })
+    expect(wrapper.vm.activeTab).toBe('search')
+  })
+
   it('should remove concept from set when remove-concept is emitted', async () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -490,6 +490,54 @@ describe('ConceptSetEditor', () => {
     expect(wrapper.vm.activeTab).toBe('search')
   })
 
+  it('switches to the Selected tab when a recommend batch fills an empty set (#210)', async () => {
+    const wrapper = mountComponent({ conceptSet: null })
+    const store = useConceptSetsStore()
+    store.currentSet = { id: 'new', name: '', items: [] }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.activeTab).toBe('search')
+
+    // RecommendTab adds the concepts itself and reports how many landed.
+    store.currentSet.items = [
+      { ...mockConcept, isExcluded: false, includeDescendants: false, includeMapped: false },
+      { ...mockConcept, conceptId: 999, isExcluded: false, includeDescendants: false, includeMapped: false },
+    ]
+    await wrapper.vm.onRecommendedConceptsAdded(2)
+
+    expect(wrapper.vm.activeTab).toBe('selected')
+  })
+
+  it('leaves the tab alone when a recommend batch adds to an already populated set (#210)', async () => {
+    const wrapper = mountComponent({ conceptSet: null })
+    const store = useConceptSetsStore()
+    store.currentSet = {
+      id: 'new',
+      name: '',
+      items: [
+        { ...mockConcept, isExcluded: false, includeDescendants: false, includeMapped: false },
+        { ...mockConcept, conceptId: 999, isExcluded: false, includeDescendants: false, includeMapped: false },
+      ],
+    }
+    await wrapper.vm.$nextTick()
+    wrapper.vm.activeTab = 'search'
+
+    // Only one of the two is new, so the set was not empty beforehand.
+    await wrapper.vm.onRecommendedConceptsAdded(1)
+
+    expect(wrapper.vm.activeTab).toBe('search')
+  })
+
+  it('leaves the tab alone when a recommend batch adds nothing (#210)', async () => {
+    const wrapper = mountComponent({ conceptSet: null })
+    const store = useConceptSetsStore()
+    store.currentSet = { id: 'new', name: '', items: [] }
+    await wrapper.vm.$nextTick()
+
+    await wrapper.vm.onRecommendedConceptsAdded(0)
+
+    expect(wrapper.vm.activeTab).toBe('search')
+  })
+
   it('should remove concept from set when remove-concept is emitted', async () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()


### PR DESCRIPTION
## Problem

After checking a concept and choosing "Add to Concept Set", the editor still shows the concept search, with no visible sign that anything was added, because the added concept only appears on the Selected tab.

## Fix

A new set opens on Search so concepts can be added straight away. Switch to Selected once the first concept lands in a previously empty set, on both the single-add and recommend-add paths, but not on later adds, so the search-then-add-several workflow the Search default exists for still works.

## Scope

This addresses the second half of the issue. The first half, that naming the new concept set is not an obvious next step, is a layout question and is deliberately not changed here.

Fixes #210
