### PR TITLE
Fix renamed concept set not updating in the concept set list

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -2056,7 +2056,7 @@ function handleConceptSetApplied(set: { id?: number | string; name: string; item
     : set.id
 
   const updated: ConceptSetReference = { id: finalId, name: set.name, items }
-  
+
   // Update all criteria that reference this concept set
   updateConceptSetUsages(
     {
@@ -2074,9 +2074,31 @@ function handleConceptSetApplied(set: { id?: number | string; name: string; item
   exitCriteria.value = { ...exitCriteria.value }
   censoringCriteria.value = [...censoringCriteria.value]
 
+  // Keep the cohort's canonical `conceptSets[]` (what `ConceptSetsListDialog`
+  // and the concept-set list read) in sync unconditionally. A pure rename
+  // via the pencil icon has no `selectedCriteriaContext`/
+  // `pendingConceptSetCallback`, so gating this behind that check (as
+  // before) left the canonical array on the old name after every criteria
+  // reference had already been updated by `updateConceptSetUsages` (#212).
+  upsertConceptSetInCohort(updated)
+
   if (selectedCriteriaContext.value || pendingConceptSetCallback.value) {
     // Assign the concept set (now with final ID) to the context
     assignConceptSetToContext(updated)
+  }
+}
+
+/**
+ * Add-or-replace a concept set in the cohort's canonical `conceptSets[]`,
+ * keyed by id.
+ */
+function upsertConceptSetInCohort(conceptSetRef: ConceptSetReference) {
+  if (!cohortStore.currentCohort) return
+  const existingIndex = cohortStore.currentCohort.conceptSets.findIndex(cs => cs.id === conceptSetRef.id)
+  if (existingIndex === -1) {
+    cohortStore.currentCohort.conceptSets.push(conceptSetRef)
+  } else {
+    cohortStore.currentCohort.conceptSets[existingIndex] = conceptSetRef
   }
 }
 
@@ -2091,17 +2113,10 @@ function assignConceptSetToContext(conceptSetRef: ConceptSetReference) {
   if (!hasRealConceptSetId(conceptSetRef)) {
     conceptSetRef = ensureUniqueConceptSetId(conceptSetRef, cohortStore.currentCohort?.conceptSets || [])
   }
-  
+
   // Add the concept set to the cohort's conceptSets array. This happens on apply/import,
   // not during creation. Cancel just closes the editor without reaching here.
-  if (cohortStore.currentCohort) {
-    const existingIndex = cohortStore.currentCohort.conceptSets.findIndex(cs => cs.id === conceptSetRef.id)
-    if (existingIndex === -1) {
-      cohortStore.currentCohort.conceptSets.push(conceptSetRef)
-    } else {
-      cohortStore.currentCohort.conceptSets[existingIndex] = conceptSetRef
-    }
-  }
+  upsertConceptSetInCohort(conceptSetRef)
 
   // Service path (issue #112): deliver to the requesting component, which
   // embeds the reference itself at whatever nesting depth it lives.

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -1216,6 +1216,45 @@ describe('CohortBuilder', () => {
     expect(vm.hasUnsavedChanges).toBe(true)
   })
 
+  it('handleConceptSetApplied keeps cohort.conceptSets in sync on a pure rename with no selection context (#212)', async () => {
+    // Renaming via the pencil icon sets neither `selectedCriteriaContext` nor
+    // `pendingConceptSetCallback`. Before the fix, only the per-criterion
+    // `event.conceptSet` copies were updated (via `updateConceptSetUsages`),
+    // leaving the cohort's canonical `conceptSets[]` — what
+    // `ConceptSetsListDialog` reads — on the old name.
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const { useCohortStore } = await import('@/stores/cohort')
+    const store = useCohortStore()
+    store.createNewCohort()
+    if (store.currentCohort) {
+      store.currentCohort.conceptSets = [{ id: 7, name: 'Old Name', items: [] }]
+    }
+    entryEventsList(wrapper).vm.$emit('update:events', [
+      { id: 'evt-1', criteriaType: 'X', attributes: [], conceptSet: { id: 7, name: 'Old Name', items: [] } },
+    ])
+    await wrapper.vm.$nextTick()
+
+    // The pencil in the concept sets list opens the editor with no criteria
+    // selection context and no pending callback.
+    ;(wrapper.vm as any).openConceptSetsDialog()
+    await wrapper.vm.$nextTick()
+    conceptSetsListDialog(wrapper).vm.$emit('view', { id: 7, name: 'Old Name', items: [] })
+    await wrapper.vm.$nextTick()
+
+    conceptSetEditor(wrapper).vm.$emit('apply', { id: 7, name: 'Renamed', items: [] })
+    await wrapper.vm.$nextTick()
+
+    expect(entryEventsList(wrapper).props('events')[0].conceptSet).toMatchObject({
+      id: 7,
+      name: 'Renamed',
+    })
+    expect(store.currentCohort?.conceptSets.find(cs => cs.id === 7)).toMatchObject({
+      id: 7,
+      name: 'Renamed',
+    })
+  })
+
   it('applying concept-set changes assigns the applied set to a pending entry-event context', async () => {
     const wrapper = createWrapper()
     await wrapper.vm.$nextTick()


### PR DESCRIPTION
## Problem

Renaming a concept set through the pencil icon updates the name everywhere it is used inside the cohort definition, but the concept set list keeps showing the old name until the cohort is reloaded.

## Cause

`handleConceptSetApplied()` updated each criterion's own `event.conceptSet` copy unconditionally, but only wrote the change into the cohort's canonical `conceptSets` array, which is what `ConceptSetsListDialog` reads, when a selection context or a pending callback was active. A pure rename sets neither, so the canonical array kept the old name while every criterion already showed the new one.

## Fix

Write to the canonical array unconditionally, via a shared upsert helper.

Fixes #212
