### PR TITLE
Fix attribute concept set picker reverting to unselected for id 0

### DIFF
--- a/src/components/cohort-builder/AttributesEditor.vue
+++ b/src/components/cohort-builder/AttributesEditor.vue
@@ -63,7 +63,7 @@
             <!-- Concept Set Attributes -->
             <template v-else-if="attribute.type === 'conceptSet'">
               <AtlasButton
-                v-if="!attribute.conceptSet || !attribute.conceptSet.id"
+                v-if="!attribute.conceptSet || attribute.conceptSet.id == null"
                 variant="secondary"
                 size="sm"
                 data-testid="attribute-concept-set-picker"

--- a/src/components/cohort-builder/AttributesEditor.vue
+++ b/src/components/cohort-builder/AttributesEditor.vue
@@ -63,7 +63,7 @@
             <!-- Concept Set Attributes -->
             <template v-else-if="attribute.type === 'conceptSet'">
               <AtlasButton
-                v-if="!attribute.conceptSet || attribute.conceptSet.id == null"
+                v-if="!attribute.conceptSet || !hasNumericConceptSetId(attribute.conceptSet)"
                 variant="secondary"
                 size="sm"
                 data-testid="attribute-concept-set-picker"
@@ -345,6 +345,7 @@
 
 <script setup lang="ts">
 import { AtlasButton, AtlasCheckbox, AtlasChip, AtlasDialog, AtlasIcon, AtlasIconButton, AtlasSelect, AtlasTextField } from '@/components/ui'
+import { hasNumericConceptSetId } from '@/utils/concept-set-id'
 import { ref, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import { useAttributeConfig } from '@/composables/useAttributeConfig'

--- a/src/components/cohort-builder/DrugExposureStrategy.vue
+++ b/src/components/cohort-builder/DrugExposureStrategy.vue
@@ -18,7 +18,7 @@
     <!-- Concept Set Selection Button/Chip -->
     <div class="mt-4 mb-4">
       <AtlasButton
-        v-if="!strategy.conceptSet || strategy.conceptSet.id == null"
+        v-if="!strategy.conceptSet || !hasNumericConceptSetId(strategy.conceptSet)"
         variant="secondary"
         icon="mdi-plus"
         :disabled="disabled"
@@ -141,6 +141,7 @@ import { watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import type { ExitCriteria } from '@/models/cohort.types'
 import type { ValidationError } from '@/models/validation.types'
+import { hasNumericConceptSetId } from '@/utils/concept-set-id'
 
 const { tv } = useI18n()
 

--- a/src/components/cohort-builder/EventConceptSetField.vue
+++ b/src/components/cohort-builder/EventConceptSetField.vue
@@ -12,7 +12,7 @@
     </div>
     <div class="event-concept-set-field__input">
       <AtlasButton
-        v-if="!conceptSet || (conceptSet.id == null)"
+        v-if="!conceptSet || !hasNumericConceptSetId(conceptSet)"
         variant="secondary"
         size="sm"
         density="compact"
@@ -41,6 +41,7 @@
 
 <script setup lang="ts">
 import { AtlasButton, AtlasChip, AtlasIcon } from '@/components/ui'
+import { hasNumericConceptSetId } from '@/utils/concept-set-id'
 import { useI18n } from '@/composables/useI18n'
 
 const { t } = useI18n()

--- a/src/utils/concept-set-id.ts
+++ b/src/utils/concept-set-id.ts
@@ -29,8 +29,10 @@ export function hasRealConceptSetId(ref: Pick<ConceptSetReference, 'id'>): boole
  * selectable. But this returns false for placeholder ids (undefined), which is correct
  * since those haven't been assigned yet.
  */
-export function hasNumericConceptSetId(ref: Pick<ConceptSetReference, 'id'>): boolean {
-  return typeof ref.id === 'number' && Number.isFinite(ref.id) && ref.id >= 0
+export function hasNumericConceptSetId(
+  ref: Pick<ConceptSetReference, 'id'> | null | undefined
+): boolean {
+  return !!ref && typeof ref.id === 'number' && Number.isFinite(ref.id) && ref.id >= 0
 }
 
 /**

--- a/tests/component/cohort-builder/AttributesEditor.spec.ts
+++ b/tests/component/cohort-builder/AttributesEditor.spec.ts
@@ -231,6 +231,30 @@ describe('AttributesEditor', () => {
       expect(wrapper.text()).toContain('Male')
     })
 
+    it('still shows the picker for the empty-string placeholder a new attribute is seeded with', () => {
+      // openConceptSetPickerForAttribute seeds `{ id: '', name: '' }`, and
+      // CriteriaEventCard does the same. That is "not chosen yet", so it must
+      // keep offering the picker rather than render an empty chip.
+      const attributes: ConceptSetAttribute[] = [
+        { type: 'conceptSet', attributeKey: 'gender', conceptSet: { id: '', name: '' } },
+      ]
+
+      const wrapper = createWrapper(attributes)
+
+      expect(wrapper.find('[data-testid="attribute-concept-set-picker"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="attribute-selected-concept-set"]').exists()).toBe(false)
+    })
+
+    it('shows the picker when the attribute has no concept set at all', () => {
+      const attributes: ConceptSetAttribute[] = [
+        { type: 'conceptSet', attributeKey: 'gender' },
+      ]
+
+      const wrapper = createWrapper(attributes)
+
+      expect(wrapper.find('[data-testid="attribute-concept-set-picker"]').exists()).toBe(true)
+    })
+
     it('shows the selected concept set chip when its id is 0, not the "select" placeholder (#213)', () => {
       // id 0 is a valid, real concept set id (the first set in an imported
       // cohort). A truthy check on `.id` treated it the same as "unset" and

--- a/tests/component/cohort-builder/AttributesEditor.spec.ts
+++ b/tests/component/cohort-builder/AttributesEditor.spec.ts
@@ -230,6 +230,29 @@ describe('AttributesEditor', () => {
       expect(conceptSetChip.exists()).toBe(true)
       expect(wrapper.text()).toContain('Male')
     })
+
+    it('shows the selected concept set chip when its id is 0, not the "select" placeholder (#213)', () => {
+      // id 0 is a valid, real concept set id (the first set in an imported
+      // cohort). A truthy check on `.id` treated it the same as "unset" and
+      // reverted to the picker button instead of showing the chip.
+      const attributes: ConceptSetAttribute[] = [
+        {
+          type: 'conceptSet',
+          attributeKey: 'gender',
+          conceptSet: {
+            id: 0,
+            name: 'First Concept Set',
+          },
+        },
+      ]
+
+      const wrapper = createWrapper(attributes)
+
+      const conceptSetChip = wrapper.find('[data-testid="attribute-selected-concept-set"]')
+      expect(conceptSetChip.exists()).toBe(true)
+      expect(wrapper.text()).toContain('First Concept Set')
+      expect(wrapper.find('[data-testid="attribute-concept-set-picker"]').exists()).toBe(false)
+    })
   })
 
   describe('Edit and Remove', () => {


### PR DESCRIPTION
## Problem

The same selected concept set renders by name in one place and as `#0` in another.

## Cause

The concept set attribute editor decided between the picker button and the selected-set chip with a truthy test on the id:

```
v-if="!attribute.conceptSet || !attribute.conceptSet.id"
```

`0` is a valid concept set id, being the first set in an imported cohort, so the check misfired on it and offered the picker even though a set was selected.

## Fix

Two placeholders mean "nothing chosen here", and the predicate has to reject both while accepting `0`:

- `null` / `undefined`, when the attribute carries no concept set at all
- `''`, which is what `openConceptSetPickerForAttribute` seeds a new attribute with (`AttributesEditor.vue:633`); `CriteriaEventCard.vue:591` seeds the same shape

`hasNumericConceptSetId` in `src/utils/concept-set-id.ts` already encodes exactly that rule: a finite non-negative number counts as chosen, so `0` qualifies while `null`, `undefined` and `''` do not. The templates use it instead of an ad-hoc comparison, keeping an explicit guard alongside so the `v-else` branch stays narrowed for TypeScript. The helper now accepts a missing reference so callers need not test twice.

`DrugExposureStrategy` and `EventConceptSetField` carried the same comparison against the same placeholder, so they move to the helper as well.

## Verification

Three cases now pin the predicate from both sides: id `0` shows the chip, the `''` placeholder shows the picker, and an absent concept set shows the picker. Restoring the original truthy test fails the first; restoring a plain `id == null` test fails the second. Full suite passes: 8257 tests.

Fixes #213
