### PR TITLE
Fix wrong share icon on cohort export button

### DIFF
--- a/src/components/cohort/CohortToolbarActions.vue
+++ b/src/components/cohort/CohortToolbarActions.vue
@@ -14,7 +14,7 @@
       <template #activator="{ props: menuProps }">
         <AtlasIconButton
           v-bind="{ ...menuProps, ariaLabel: t('common.export', 'Export').value }"
-          icon="mdi-export-variant"
+          icon="mdi-download"
           variant="text"
           size="sm"
           data-testid="export-btn"

--- a/tests/unit/components/cohort/CohortToolbarActions.spec.ts
+++ b/tests/unit/components/cohort/CohortToolbarActions.spec.ts
@@ -226,6 +226,13 @@ describe('CohortToolbarActions', () => {
       expect(wrapper.find('[data-testid="export-btn"]').exists()).toBe(true)
     })
 
+    it('uses a download icon, not a share icon, since the menu only offers download/copy/view-JSON actions (#219)', () => {
+      const wrapper = mountComponent()
+      const exportBtn = wrapper.find('[data-testid="export-btn"]')
+      expect(exportBtn.html()).toContain('mdi-download')
+      expect(exportBtn.html()).not.toContain('mdi-export-variant')
+    })
+
     it('emits export-download when the JSON download item is clicked', async () => {
       const wrapper = mountComponent({}, { attachTo: document.body })
       await wrapper.find('[data-testid="export-btn"]').trigger('click')


### PR DESCRIPTION
## Problem

The cohort definition toolbar shows a share icon (`mdi-export-variant`), which suggests it produces a link, but every option in the menu downloads or loads JSON.

## Fix

Use `mdi-download`, matching the other export buttons in the app and what the menu actually does.

Fixes #219
