### PR TITLE
Show Close instead of Cancel when a cohort has no unsaved changes

### DIFF
--- a/src/components/cohort/CohortToolbarActions.vue
+++ b/src/components/cohort/CohortToolbarActions.vue
@@ -2,6 +2,7 @@
   <div class="cohort-toolbar-actions">
     <AtlasButton
       variant="ghost"
+      data-testid="cohort-close-btn"
       @click="$emit('cancel')"
     >
       <AtlasIcon class="d-md-none">

--- a/src/components/cohort/CohortToolbarActions.vue
+++ b/src/components/cohort/CohortToolbarActions.vue
@@ -7,7 +7,7 @@
       <AtlasIcon class="d-md-none">
         mdi-close
       </AtlasIcon>
-      <span class="d-none d-md-inline">{{ t('common.cancel') }}</span>
+      <span class="d-none d-md-inline">{{ isDirty ? t('common.cancel', 'Cancel') : t('common.close', 'Close') }}</span>
     </AtlasButton>
 
     <AtlasMenu>

--- a/tests/e2e/concepts-tabs-and-cohort-builder.spec.ts
+++ b/tests/e2e/concepts-tabs-and-cohort-builder.spec.ts
@@ -94,26 +94,34 @@ test.describe('Cohort Builder - Breadcrumb Navigation', () => {
     // CohortBuilderView.vue passes hide-internal-breadcrumb to CohortBuilder,
     // so the internal <cohort-breadcrumb> (CohortBreadcrumb.vue) never
     // renders in the real app: the hero header (eyebrow + inline title)
-    // replaced it, and "back to cohorts" is now the toolbar Cancel button
+    // replaced it, and "back to cohorts" is now the toolbar close button
     // (CohortToolbarActions.vue, which emits 'cancel' -> handleCancel() ->
     // router.push('/cohorts')). The old selectors targeted classes that
     // either never existed or were style-only dead text, and the tautology
     // assertion below them passed regardless of what was found.
-    const cancelButton = page.getByRole('button', { name: /^cancel$/i })
-    await expect(cancelButton).toBeVisible()
+    //
+    // The cohort has just been opened and not edited, so the button reads
+    // "Close"; it only says "Cancel" once there are unsaved changes (#220).
+    // By test id, not by name: the navbar carries its own "Close" control, so
+    // an accessible-name lookup matches two buttons.
+    const closeButton = page.getByTestId('cohort-close-btn')
+    await expect(closeButton).toBeVisible()
+    await expect(closeButton).toHaveText(/close/i)
   })
 
-  test('should navigate back to cohorts list when clicking Cancel', async ({ page }) => {
+  test('should navigate back to cohorts list when clicking Close', async ({ page }) => {
     await page.goto('/#/cohorts/1')
     await waitForPageReady(page)
 
     // Ensure no overlays are blocking
     await waitForOverlaysToClose(page)
 
-    const cancelButton = page.getByRole('button', { name: /^cancel$/i })
-    await expect(cancelButton).toBeVisible()
+    // Unedited cohort, so the button reads "Close" rather than "Cancel" (#220).
+    const closeButton = page.getByTestId('cohort-close-btn')
+    await expect(closeButton).toBeVisible()
+    await expect(closeButton).toHaveText(/close/i)
 
-    await cancelButton.click()
+    await closeButton.click()
     await page.waitForTimeout(1000)
 
     // Verify navigation to cohorts list

--- a/tests/unit/components/cohort/CohortToolbarActions.spec.ts
+++ b/tests/unit/components/cohort/CohortToolbarActions.spec.ts
@@ -96,6 +96,17 @@ describe('CohortToolbarActions', () => {
       const cancelBtn = buttons.find(btn => btn.text().includes('Cancel') || btn.html().includes('mdi-close'))
       expect(cancelBtn?.props('disabled')).toBeFalsy()
     })
+
+    it('reads "Close" when there are no unsaved changes, not "Cancel" (#220)', () => {
+      const wrapper = mountComponent({ isDirty: false })
+      expect(wrapper.text()).toContain('Close')
+      expect(wrapper.text()).not.toContain('Cancel')
+    })
+
+    it('reads "Cancel" when there are unsaved changes to discard (#220)', () => {
+      const wrapper = mountComponent({ isDirty: true })
+      expect(wrapper.text()).toContain('Cancel')
+    })
   })
 
   describe('Save Button', () => {


### PR DESCRIPTION
## Problem

Opening a cohort definition shows a "Cancel" button in the header even when nothing has been edited, which reads as more alarming than it should.

## Fix

Show "Close" when the cohort is not dirty and keep "Cancel", with its existing discard confirmation, when it is. This is a label change only: the confirmation already fired only when `hasUnsavedChanges` was true, and the route-leave guard checks that flag directly.

Fixes #220
