### PR TITLE
Fix valid concepts showing as invalid, and the mislabeled validity column header

### DIFF
--- a/src/components/concepts/ConceptSetTable.vue
+++ b/src/components/concepts/ConceptSetTable.vue
@@ -403,7 +403,7 @@ const headers = [
     width: '120px',
   },
   {
-    title: t('columns.validEndDate', 'Validity').value,
+    title: t('columns.validity', 'Validity').value,
     key: 'invalidReason',
     sortable: true,
     width: '90px',

--- a/src/components/concepts/ConceptTable.vue
+++ b/src/components/concepts/ConceptTable.vue
@@ -371,7 +371,7 @@ const headers = computed(() => {
       width: '150px',
     },
     {
-      title: t('columns.validEndDate', 'Validity').value,
+      title: t('columns.validity', 'Validity').value,
       key: 'invalidReason',
       sortable: true,
       width: '100px',

--- a/src/components/concepts/IncludedConceptsTable.vue
+++ b/src/components/concepts/IncludedConceptsTable.vue
@@ -164,7 +164,7 @@ const headers = [
   { title: t('columns.domain', 'Domain').value, key: 'domainId', sortable: true, width: '120px' },
   { title: t('columns.vocabulary', 'Vocabulary').value, key: 'vocabularyId', sortable: true, width: '120px' },
   { title: t('columns.type', 'Type').value, key: 'standardConcept', sortable: true, width: '120px' },
-  { title: t('columns.validEndDate', 'Validity').value, key: 'invalidReason', sortable: true, width: '90px' },
+  { title: t('columns.validity', 'Validity').value, key: 'invalidReason', sortable: true, width: '90px' },
 ]
 
 const emptyMessage = computed(() => {

--- a/src/services/atlas-converter.ts
+++ b/src/services/atlas-converter.ts
@@ -21,6 +21,7 @@ import type {
   AtlasGroup,
 } from '@/models/atlas.types'
 import type { ConceptSetItem } from '@/models/concept-set.types'
+import { normalizeInvalidReason } from '@/utils/api-mappers'
 
 interface AtlasJSON {
   expressionType?: string
@@ -98,7 +99,7 @@ function mapAtlasConceptSetItemToInternal(
     conceptClassId: item.concept.CONCEPT_CLASS_ID ?? '',
     standardConcept: item.concept.STANDARD_CONCEPT ?? null,
     conceptCode: item.concept.CONCEPT_CODE ?? '',
-    invalidReason: item.concept.INVALID_REASON ?? null,
+    invalidReason: normalizeInvalidReason(item.concept.INVALID_REASON),
     includeDescendants: item.includeDescendants ?? false,
     isExcluded: item.isExcluded ?? false,
     includeMapped: item.includeMapped ?? false,

--- a/src/utils/api-mappers.ts
+++ b/src/utils/api-mappers.ts
@@ -55,6 +55,17 @@ export interface ConceptSetAPIResponse extends ConceptSetAPIMetadata {
 }
 
 /**
+ * Concept-set-expression items round-trip through WebAPI with `INVALID_REASON`
+ * set to the literal string `"V"` for valid concepts (the plain
+ * `/vocabulary/{key}/search` endpoint uses `null` instead). Every UI badge
+ * and facet checks `invalidReason` for truthiness, so a raw `"V"` reads as
+ * "invalid" unless it is normalized back to `null` here (see #221).
+ */
+export function normalizeInvalidReason(invalidReason: string | null | undefined): string | null {
+  return invalidReason && invalidReason !== 'V' ? invalidReason : null
+}
+
+/**
  * Map WebAPI concept response (UPPERCASE) to Concept interface (camelCase)
  */
 export function mapConceptFromAPI(raw: {
@@ -119,7 +130,7 @@ export function mapExpressionItemsFromAPI(
       vocabularyId: item.concept.VOCABULARY_ID,
       conceptClassId: item.concept.CONCEPT_CLASS_ID,
       standardConcept: item.concept.STANDARD_CONCEPT,
-      invalidReason: item.concept.INVALID_REASON,
+      invalidReason: normalizeInvalidReason(item.concept.INVALID_REASON),
       isExcluded: item.isExcluded,
       includeDescendants: item.includeDescendants,
       includeMapped: item.includeMapped,

--- a/tests/unit/services/atlas-converter.spec.ts
+++ b/tests/unit/services/atlas-converter.spec.ts
@@ -1360,6 +1360,40 @@ describe('Atlas Converter - Phase 1 Attributes (US1)', () => {
       // Number ID should be preserved
       expect(atlasJSON.ConceptSets[1]?.id).toBe(5)
     })
+
+    it('round-trips a valid concept without it coming back flagged as invalid (#221)', () => {
+      // WebAPI's concept-set-expression format uses the literal string "V"
+      // (not null) for a valid concept's INVALID_REASON. Export already
+      // relies on that sentinel; import must undo it, or every concept set
+      // item that has round-tripped through Atlas JSON renders as invalid.
+      const cohort = createMinimalCohort({
+        conceptSets: [
+          {
+            id: 1,
+            name: 'Test',
+            items: [
+              {
+                conceptId: 8560,
+                conceptName: 'Valid Concept',
+                domainId: 'Condition',
+                vocabularyId: 'SNOMED',
+                conceptClassId: 'Finding',
+                invalidReason: null,
+                includeDescendants: false,
+                isExcluded: false,
+                includeMapped: false,
+              },
+            ],
+          },
+        ],
+      })
+
+      const atlasJSON = convertInternalToAtlas(cohort)
+      expect(atlasJSON.ConceptSets[0]?.expression.items[0]?.concept.INVALID_REASON).toBe('V')
+
+      const converted = convertAtlasToInternal(atlasJSON)
+      expect(converted.conceptSets?.[0]?.items[0]?.invalidReason).toBeNull()
+    })
   })
 
   describe('Event Type Exclude Flags', () => {

--- a/tests/unit/utils/api-mappers.spec.ts
+++ b/tests/unit/utils/api-mappers.spec.ts
@@ -8,6 +8,7 @@ import {
   conceptToConceptSetItem,
   mapConceptSetFromAPI,
   mapConceptSetToAPI,
+  normalizeInvalidReason,
   type ConceptSetAPIResponse
 } from '@/utils/api-mappers'
 import type { Concept, ConceptSet } from '@/models/concept-set.types'
@@ -196,6 +197,52 @@ describe('API Mappers', () => {
       const result = mapConceptSetFromAPI(apiResponse)
 
       expect(result.shared).toBe(false)
+    })
+
+    it('should normalize the "V" (valid) sentinel to null so valid concepts are not flagged as invalid (#221)', () => {
+      const apiResponse: ConceptSetAPIResponse = {
+        id: 1,
+        name: 'Test',
+        expression: {
+          items: [
+            {
+              concept: {
+                CONCEPT_ID: 8560,
+                CONCEPT_NAME: 'Valid Concept',
+                CONCEPT_CODE: 'VC',
+                DOMAIN_ID: 'Condition',
+                VOCABULARY_ID: 'SNOMED',
+                CONCEPT_CLASS_ID: 'Finding',
+                STANDARD_CONCEPT: 'S',
+                INVALID_REASON: 'V'
+              },
+              isExcluded: false,
+              includeDescendants: false,
+              includeMapped: false
+            }
+          ]
+        }
+      }
+
+      const result = mapConceptSetFromAPI(apiResponse)
+
+      expect(result.items[0].invalidReason).toBeNull()
+    })
+  })
+
+  describe('normalizeInvalidReason', () => {
+    it('should treat the "V" sentinel as valid (null)', () => {
+      expect(normalizeInvalidReason('V')).toBeNull()
+    })
+
+    it('should treat null/undefined as valid (null)', () => {
+      expect(normalizeInvalidReason(null)).toBeNull()
+      expect(normalizeInvalidReason(undefined)).toBeNull()
+    })
+
+    it('should pass through a real invalid reason unchanged', () => {
+      expect(normalizeInvalidReason('D')).toBe('D')
+      expect(normalizeInvalidReason('U')).toBe('U')
     })
   })
 


### PR DESCRIPTION
## Problem

In concept set search results, every row shows as invalid, including concepts that are valid, and the column reads "Valid End Date" while displaying a validity flag rather than a date.

## Cause

WebAPI's concept-set-expression format uses the literal string `V` for a valid concept's `INVALID_REASON`, whereas `/vocabulary/{key}/search` uses `null`. Every validity badge and facet tested `invalidReason` for plain truthiness, so a concept that round-tripped through a concept set expression rendered as invalid even when valid. Separately, three tables used the `columns.validEndDate` key, whose text is literally "Valid End Date", as the header for the validity column.

## Fix

Normalise the `V` sentinel back to `null` in the API and Atlas JSON mapping layer, rather than pushing that knowledge into every consumer, and use the `columns.validity` key that already exists and is used correctly elsewhere.

## Scope

This covers the two defects in the report. The suggestions of renaming the column to "Status" and joining valid start and end into a from-to value in the concept details view are design changes rather than bug fixes, and are not included.

Fixes #221
