### PR TITLE
Fix Generate staying disabled after the first characterization save

### DIFF
--- a/src/views/CharacterizationBuilderView.vue
+++ b/src/views/CharacterizationBuilderView.vue
@@ -501,7 +501,11 @@ async function handleSave() {
           t('characterizations.editor.saveSuccess', 'Characterization saved').value,
           'success'
         )
-        store.markClean()
+        // Unlike the update branch, there was previously no hydrateFrom() call
+        // here, so draft.value.id (and therefore draftId/isEditing) stayed
+        // null after the very first save. Generate stayed disabled forever
+        // because its gate checks characterizationId == null (#223).
+        hydrateFrom(created)
         await router.push(`/characterizations/${created.id}`)
       } else {
         showSnackbar(t('cc.fa.saveError', 'Failed to save characterization').value, 'error')

--- a/tests/component/characterization/CharacterizationBuilderView.spec.ts
+++ b/tests/component/characterization/CharacterizationBuilderView.spec.ts
@@ -261,6 +261,16 @@ describe('CharacterizationBuilderView', () => {
     expect(createCharacterization).toHaveBeenCalledTimes(1)
     const payload = vi.mocked(createCharacterization).mock.calls[0]![0]!
     expect(payload.name).toBe('My new characterization')
+
+    // #223: after the first save, the draft's id must be hydrated from the
+    // server response so `characterization-id` (and therefore the Generate
+    // button's disabled gate) reflects the now-saved characterization,
+    // instead of staying null forever.
+    await flushPromises()
+    const workbenchAfterSave = mounted.wrapper.findComponent({
+      name: 'CharacterizationWorkbench',
+    })
+    expect(workbenchAfterSave.props('characterizationId')).toBe(99)
   })
 
   it('Save in edit mode calls updateCharacterization', async () => {


### PR DESCRIPTION
## Problem

After creating a characterization, adding a cohort and features, naming it and saving successfully, the Generate buttons stay disabled and still claim the characterization must be saved first.

## Cause

The update branch of `handleSave()` re-hydrated the draft from the server response, but the create branch never did, so `draft.value.id` stayed `null` forever after the first save even though the save succeeded and the dirty flag was cleared. Generate gates on `characterizationId == null`, so it never re-enabled. The subsequent route change does not re-hydrate either, since hydration only runs on mount.

## Fix

Call `hydrateFrom(created)` on the create path, mirroring the update path.

Fixes #223
