### PR TITLE
Fix concept detail chart reusing a different concept's cached result

### DIFF
--- a/src/components/concepts/detail/ConceptDetailContent.vue
+++ b/src/components/concepts/detail/ConceptDetailContent.vue
@@ -127,7 +127,7 @@ watch(() => [props.sourceKey, props.conceptId], load)
 
         <DrilldownDetails
           v-if="domainPath(concept.domainId)"
-          :data="store.drilldownBySource.get(props.sourceKey) ?? null"
+          :data="store.getDrilldown(props.sourceKey, concept.conceptId)"
           :loading="store.isDrilldownLoading"
           :concept-name="concept.conceptName"
           :domain="(domainPath(concept.domainId) as Domain) ?? 'condition'"

--- a/src/stores/concept-detail.ts
+++ b/src/stores/concept-detail.ts
@@ -185,9 +185,22 @@ export const useConceptDetailStore = defineStore('concept-detail', () => {
     )
   }
 
+  // Keyed by source AND concept (`cacheKey`), not source alone. A
+  // source-only key meant that once any concept under a source had been
+  // drilled down, `has(sourceKey)` was true forever for that source, so
+  // every later concept viewed under the same source reused the FIRST
+  // concept's cached result (including a null/empty one) without ever
+  // re-fetching, regardless of which concept was actually being viewed
+  // (#225).
+  function getDrilldown(sourceKey: string, conceptId: number): DrilldownReport | null {
+    return drilldownBySource.value.get(cacheKey(sourceKey, conceptId)) ?? null
+  }
+
   async function loadDrilldown(sourceKey: string): Promise<void> {
     if (!concept.value) return
-    if (drilldownBySource.value.has(sourceKey)) return
+    const conceptId = concept.value.conceptId
+    const key = cacheKey(sourceKey, conceptId)
+    if (drilldownBySource.value.has(key)) return
 
     isDrilldownLoading.value = true
     drilldownErrorBySource.value = new Map(
@@ -197,10 +210,10 @@ export const useConceptDetailStore = defineStore('concept-detail', () => {
       const report = await getConceptDrilldown(
         sourceKey,
         concept.value.domainId,
-        concept.value.conceptId,
+        conceptId,
         concept.value.conceptName,
       )
-      drilldownBySource.value = new Map(drilldownBySource.value).set(sourceKey, report)
+      drilldownBySource.value = new Map(drilldownBySource.value).set(key, report)
     } catch (e) {
       logger.error('ConceptDetail', `loadDrilldown failed for ${sourceKey}`, e)
       // Deliberately not written to drilldownBySource: that map doubles as the
@@ -241,6 +254,7 @@ export const useConceptDetailStore = defineStore('concept-detail', () => {
     children,
     recordCountsBySource,
     drilldownBySource,
+    getDrilldown,
     isLoading,
     isDrilldownLoading,
     error,

--- a/src/views/ConceptDetailView.vue
+++ b/src/views/ConceptDetailView.vue
@@ -113,7 +113,7 @@ watch(() => [props.sourceKey, props.conceptId], load)
 
         <DrilldownDetails
           v-if="domainPath(concept.domainId)"
-          :data="store.drilldownBySource.get(props.sourceKey) ?? null"
+          :data="store.getDrilldown(props.sourceKey, concept.conceptId)"
           :loading="store.isDrilldownLoading"
           :concept-name="concept.conceptName"
           :domain="(domainPath(concept.domainId) as Domain) ?? 'condition'"

--- a/tests/unit/stores/concept-detail.spec.ts
+++ b/tests/unit/stores/concept-detail.spec.ts
@@ -255,7 +255,7 @@ describe('concept-detail store', () => {
     expect(store.isDrilldownLoading).toBe(false)
   })
 
-  it('loadDrilldown fetches the report and caches by source', async () => {
+  it('loadDrilldown fetches the report and caches by source AND concept', async () => {
     (getConceptById as Mock).mockResolvedValue({
       conceptId: 10,
       conceptName: 'D',
@@ -276,10 +276,10 @@ describe('concept-detail store', () => {
     await store.loadDrilldown('SYNPUF1K')
 
     expect(getConceptDrilldown).toHaveBeenCalledWith('SYNPUF1K', 'Condition', 10, 'D')
-    expect(store.drilldownBySource.get('SYNPUF1K')).toEqual({ report: { foo: 1 } })
+    expect(store.getDrilldown('SYNPUF1K', 10)).toEqual({ report: { foo: 1 } })
     expect(store.isDrilldownLoading).toBe(false)
 
-    // Second invocation should short-circuit on the cached entry
+    // Second invocation for the SAME concept should short-circuit on the cached entry
     await store.loadDrilldown('SYNPUF1K')
     expect(getConceptDrilldown).toHaveBeenCalledTimes(1)
   })
@@ -424,7 +424,7 @@ describe('concept-detail store', () => {
     await store.loadDrilldown('SYNPUF1K')
 
     expect(store.drilldownErrorFor('SYNPUF1K')).toBe('Failed to load drilldown')
-    expect(store.drilldownBySource.has('SYNPUF1K')).toBe(false)
+    expect(store.getDrilldown('SYNPUF1K', 10)).toBeNull()
     expect(store.isDrilldownLoading).toBe(false)
 
     ;(getConceptDrilldown as Mock).mockResolvedValueOnce({ report: { foo: 1 } })
@@ -432,7 +432,54 @@ describe('concept-detail store', () => {
 
     expect(getConceptDrilldown).toHaveBeenCalledTimes(2)
     expect(store.drilldownErrorFor('SYNPUF1K')).toBeNull()
-    expect(store.drilldownBySource.get('SYNPUF1K')).toEqual({ report: { foo: 1 } })
+    expect(store.getDrilldown('SYNPUF1K', 10)).toEqual({ report: { foo: 1 } })
+  })
+
+  it('loadDrilldown does not reuse a different concept\'s cached (or empty) result under the same source (#225)', async () => {
+    (getConceptById as Mock)
+      .mockResolvedValueOnce({
+        conceptId: 10,
+        conceptName: 'Metformin',
+        domainId: 'Drug',
+        vocabularyId: 'RxNorm',
+        conceptClassId: 'Ingredient',
+        standardConcept: 'S',
+        conceptCode: '10',
+        invalidReason: null,
+      })
+      .mockResolvedValueOnce({
+        conceptId: 20,
+        conceptName: 'Aspirin',
+        domainId: 'Drug',
+        vocabularyId: 'RxNorm',
+        conceptClassId: 'Ingredient',
+        standardConcept: 'S',
+        conceptCode: '20',
+        invalidReason: null,
+      })
+    ;(getConceptRelated as Mock).mockResolvedValue([])
+    ;(getConceptAncestorAndDescendant as Mock).mockResolvedValue([])
+    ;(getConceptRecordCounts as Mock).mockResolvedValue(new Map())
+    // First concept's drilldown comes back empty/null (e.g. a transient
+    // failure or genuinely no data).
+    ;(getConceptDrilldown as Mock).mockResolvedValueOnce(null)
+
+    const store = useConceptDetailStore()
+    await store.loadConcept('SYNPUF1K', 10)
+    await store.loadDrilldown('SYNPUF1K')
+    expect(store.getDrilldown('SYNPUF1K', 10)).toBeNull()
+
+    // Switching to a different concept under the SAME source must fetch its
+    // own report, not reuse concept 10's cached null.
+    ;(getConceptDrilldown as Mock).mockResolvedValueOnce({ report: { bar: 2 } })
+    await store.loadConcept('SYNPUF1K', 20)
+    await store.loadDrilldown('SYNPUF1K')
+
+    expect(getConceptDrilldown).toHaveBeenCalledTimes(2)
+    expect(getConceptDrilldown).toHaveBeenLastCalledWith('SYNPUF1K', 'Drug', 20, 'Aspirin')
+    expect(store.getDrilldown('SYNPUF1K', 20)).toEqual({ report: { bar: 2 } })
+    // Concept 10's own cached entry is untouched.
+    expect(store.getDrilldown('SYNPUF1K', 10)).toBeNull()
   })
 
   it('reset clears all state', async () => {


### PR DESCRIPTION
## Problem

Concept details show "No detailed data available for this concept." for concepts that do have data, and the charts cannot be brought back by refreshing.

## Cause

The drilldown report cache was keyed by source alone. Once any concept under a source had been drilled down, including one that came back null or empty, the `has()` guard was true forever for that source, so every later concept viewed under the same source silently reused the first concept's cached result instead of fetching its own. The cache lives in memory for the session, so no refresh cleared it.

## Fix

Key the cache by source and concept id together, matching the pattern already used for the rest of this store's per-concept cache.

Fixes #225
