### PR TITLE
Match the generation history view action to what the backend can return

### DIFF
--- a/src/components/cohort/CohortGenerationSection.vue
+++ b/src/components/cohort/CohortGenerationSection.vue
@@ -69,6 +69,8 @@
       :source-name="historyDialog.sourceName"
       :source-key="historyDialog.sourceKey"
       :executions="historyExecutions"
+      :latest-result-only="true"
+      @select="onViewRunResults"
     />
   </AtlasCollapsibleSection>
 </template>
@@ -297,6 +299,16 @@ function onExtraAction(actionKey: string, sourceKey: string) {
   drawer.reportType = actionKey
   drawer.open = true
   router.replace({ query: { ...route.query, report: actionKey, source: sourceKey } }).catch(() => {})
+}
+
+// The run id is deliberately unused: cohort results are stored per cohort and
+// source, not per run, so this can only ever show the newest run's report. The
+// dialog disables the action on every older run for the same reason (#217).
+function onViewRunResults() {
+  const sourceKey = historyDialog.sourceKey
+  if (!sourceKey) return
+  historyDialog.open = false
+  onExtraAction('inclusion', sourceKey)
 }
 
 watch(

--- a/src/components/generation/PreviousRunsDialog.vue
+++ b/src/components/generation/PreviousRunsDialog.vue
@@ -33,16 +33,23 @@
       </template>
 
       <template #[`item.actions`]="{ item }">
-        <AtlasIconButton
-          icon="mdi-eye"
-          v-bind="{ ariaLabel: viewLabel }"
-          variant="text"
-          size="sm"
-          tone="primary"
-          :disabled="(item as Row).status !== 'COMPLETED'"
-          :data-testid="`view-btn-${(item as Row).id}`"
-          @click="emit('select', (item as Row).id)"
-        />
+        <AtlasTooltip location="top">
+          <template #activator="{ props: tipProps }">
+            <span v-bind="tipProps">
+              <AtlasIconButton
+                icon="mdi-eye"
+                v-bind="{ ariaLabel: (item as Row).actionLabel }"
+                variant="text"
+                size="sm"
+                tone="primary"
+                :disabled="!(item as Row).viewable"
+                :data-testid="`view-btn-${(item as Row).id}`"
+                @click="emit('select', (item as Row).id)"
+              />
+            </span>
+          </template>
+          <span>{{ (item as Row).actionLabel }}</span>
+        </AtlasTooltip>
       </template>
     </AtlasDataTable>
   </AtlasDialog>
@@ -55,6 +62,7 @@ import {
   AtlasDataTable,
   AtlasChip,
   AtlasIconButton,
+  AtlasTooltip,
 } from '@/components/ui'
 import type { AtlasChipTone } from '@/components/ui'
 import { useI18n } from '@/composables/useI18n'
@@ -68,11 +76,20 @@ interface Props {
   executions: RunTableExecution[]
   selectedId?: number | string | null
   loading?: boolean
+  /**
+   * Set for analyses whose results are not retained per run. Cohort generation
+   * writes `cohort_inclusion_result`/`cohort_inclusion_stats` keyed by
+   * cohort_definition_id + mode_id only, so each run overwrites the last and
+   * WebAPI has no endpoint to fetch an older run's results (#217). Only the
+   * newest completed run stays viewable there.
+   */
+  latestResultOnly?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   selectedId: null,
   loading: false,
+  latestResultOnly: false,
 })
 
 const emit = defineEmits<{
@@ -85,6 +102,14 @@ const em = '—'
 
 const eyebrowText = tv('components.analysisExecution.history', 'HISTORY')
 const viewLabel = tv('components.analysisExecution.viewResults', 'View results')
+const notCompletedLabel = tv(
+  'components.analysisExecution.viewResultsNotCompleted',
+  'Results are available only for completed runs'
+)
+const supersededLabel = tv(
+  'components.analysisExecution.viewResultsSuperseded',
+  'Superseded: only the most recent run keeps its results'
+)
 const emptyText = computed(() =>
   t('components.analysisExecution.noPreviousRuns', 'No previous runs.').value
 )
@@ -149,22 +174,34 @@ interface Row {
   statusTone: AtlasChipTone
   duration: string
   isSelected: boolean
+  viewable: boolean
+  actionLabel: string
 }
 
-const rows = computed<Row[]>(() =>
-  props.executions
+const rows = computed<Row[]>(() => {
+  const sorted = props.executions
     .filter((e) => e.sourceKey === props.sourceKey)
     .slice()
     .sort((a, b) => (b.startTime ?? 0) - (a.startTime ?? 0))
-    .map((e) => ({
+
+  const newestCompletedId = sorted.find((e) => e.status === 'COMPLETED')?.id
+
+  return sorted.map((e) => {
+    const completed = e.status === 'COMPLETED'
+    const superseded = completed && props.latestResultOnly && e.id !== newestCompletedId
+    const viewable = completed && !superseded
+    return {
       id: e.id,
       date: formatDateTime(e.startTime),
       status: e.status,
       statusTone: STATUS_TONE[e.status],
       duration: formatDuration(effectiveDuration(e)),
       isSelected: props.selectedId !== null && props.selectedId !== undefined && e.id === props.selectedId,
-    }))
-)
+      viewable,
+      actionLabel: viewable ? viewLabel : superseded ? supersededLabel : notCompletedLabel,
+    }
+  })
+})
 
 function rowClass(r: Row): string {
   return r.isSelected ? 'prd-row--selected' : ''

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -527,6 +527,8 @@
       "noSources": "No data sources available",
       "history": "HISTORY",
       "viewResults": "View results",
+      "viewResultsNotCompleted": "Results are available only for completed runs",
+      "viewResultsSuperseded": "Superseded: only the most recent run keeps its results",
       "noPreviousRuns": "No previous runs."
     },
     "atlasCohortEditor": {

--- a/tests/component/generation/PreviousRunsDialog.spec.ts
+++ b/tests/component/generation/PreviousRunsDialog.spec.ts
@@ -34,6 +34,7 @@ function mountDialog(props: Partial<{
   executions: RunTableExecution[]
   selectedId: number | string | null
   loading: boolean
+  latestResultOnly: boolean
 }> = {}) {
   setActivePinia(createPinia())
   return mount(PreviousRunsDialog, {
@@ -103,5 +104,63 @@ describe('PreviousRunsDialog', () => {
   it('shows empty state text when there are no executions for the source', () => {
     mountDialog({ executions: [] })
     expect(document.body.textContent || '').toMatch(/No previous runs/i)
+  })
+
+  it('labels the otherwise unexplained eye icon (#217)', () => {
+    mountDialog({ executions: [exec({ id: 7, sourceKey: 'CCAE', status: 'COMPLETED' })] })
+    const btn = document.body.querySelector('[data-testid="view-btn-7"]') as HTMLButtonElement
+    expect(btn.getAttribute('aria-label')).toBe('View results')
+  })
+
+  it('explains why the icon is disabled on a run that never completed (#217)', () => {
+    mountDialog({ executions: [exec({ id: 8, sourceKey: 'CCAE', status: 'FAILED' })] })
+    const btn = document.body.querySelector('[data-testid="view-btn-8"]') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('aria-label')).toBe('Results are available only for completed runs')
+  })
+
+  it('keeps every completed run viewable by default, for analyses that retain per-run results', () => {
+    mountDialog({
+      executions: [
+        exec({ id: 1, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 1 }),
+        exec({ id: 2, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 2 }),
+      ],
+    })
+    expect((document.body.querySelector('[data-testid="view-btn-1"]') as HTMLButtonElement).disabled).toBe(false)
+    expect((document.body.querySelector('[data-testid="view-btn-2"]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('under latestResultOnly, only the newest completed run stays viewable (#217)', () => {
+    // Cohort results are keyed by cohort + source, so each generation
+    // overwrites the last and older runs have nothing left to show.
+    mountDialog({
+      latestResultOnly: true,
+      executions: [
+        exec({ id: 1, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 1 }),
+        exec({ id: 2, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 2 }),
+        exec({ id: 3, sourceKey: 'CCAE', status: 'FAILED', startTime: 3 }),
+      ],
+    })
+    const older = document.body.querySelector('[data-testid="view-btn-1"]') as HTMLButtonElement
+    const newest = document.body.querySelector('[data-testid="view-btn-2"]') as HTMLButtonElement
+
+    expect(newest.disabled).toBe(false)
+    expect(newest.getAttribute('aria-label')).toBe('View results')
+    expect(older.disabled).toBe(true)
+    expect(older.getAttribute('aria-label')).toBe(
+      'Superseded: only the most recent run keeps its results'
+    )
+  })
+
+  it('under latestResultOnly, a later FAILED run does not steal viewability from the newest completed one', () => {
+    mountDialog({
+      latestResultOnly: true,
+      executions: [
+        exec({ id: 1, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 1 }),
+        exec({ id: 2, sourceKey: 'CCAE', status: 'FAILED', startTime: 5 }),
+      ],
+    })
+    expect((document.body.querySelector('[data-testid="view-btn-1"]') as HTMLButtonElement).disabled).toBe(false)
+    expect((document.body.querySelector('[data-testid="view-btn-2"]') as HTMLButtonElement).disabled).toBe(true)
   })
 })

--- a/tests/unit/components/cohort/CohortGenerationSection.spec.ts
+++ b/tests/unit/components/cohort/CohortGenerationSection.spec.ts
@@ -127,6 +127,55 @@ describe('CohortGenerationSection', () => {
     expect(document.querySelector('[data-testid="cohort-report-drawer"]')).not.toBeNull()
   })
 
+  it('opens the inclusion report from the generation history eye icon (#217)', async () => {
+    const wrapper = mountSection(
+      { cohortId: 1 },
+      [{ id: 7, cohortDefinitionId: 1, sourceKey: 'CCAE', status: 'COMPLETE', personCount: 8420 }],
+      [ccae]
+    )
+    await flushPromises()
+
+    await wrapper.find('[data-testid="history-btn-CCAE"]').trigger('click')
+    await flushPromises()
+
+    const eye = document.querySelector('[data-testid="view-btn-7"]') as HTMLButtonElement
+    expect(eye).not.toBeNull()
+    expect(eye.disabled).toBe(false)
+    // The icon carried only an aria-label before, so a sighted mouse user had
+    // no way to tell what it did.
+    expect(eye.getAttribute('aria-label')).toBe('View results')
+
+    eye.click()
+    await flushPromises()
+
+    expect(document.querySelector('[data-testid="cohort-report-drawer"]')).not.toBeNull()
+  })
+
+  it('disables the history eye icon on runs whose results no longer exist (#217)', async () => {
+    // Cohort results are keyed by cohort + source, so a second generation
+    // overwrites the first and WebAPI cannot serve the older run's report.
+    const wrapper = mountSection(
+      { cohortId: 1 },
+      [
+        { id: 1, cohortDefinitionId: 1, sourceKey: 'CCAE', status: 'COMPLETE', personCount: 10, startTime: 1000 },
+        { id: 2, cohortDefinitionId: 1, sourceKey: 'CCAE', status: 'COMPLETE', personCount: 20, startTime: 2000 },
+      ],
+      [ccae]
+    )
+    await flushPromises()
+
+    await wrapper.find('[data-testid="history-btn-CCAE"]').trigger('click')
+    await flushPromises()
+
+    const newest = document.querySelector('[data-testid="view-btn-2"]') as HTMLButtonElement
+    const older = document.querySelector('[data-testid="view-btn-1"]') as HTMLButtonElement
+    expect(newest.disabled).toBe(false)
+    expect(older.disabled).toBe(true)
+    expect(older.getAttribute('aria-label')).toBe(
+      'Superseded: only the most recent run keeps its results'
+    )
+  })
+
   it('disables Inclusion report and Samples buttons for non-complete rows', async () => {
     const wrapper = mountSection(
       { cohortId: 1 },


### PR DESCRIPTION
## Problem

The generation history dialog shows an eye icon with no visible label, so it is not clear what it does. In the cohort builder it is worse than unclear: `CohortGenerationSection.vue` never wired `@select`, so clicking it did nothing at all.

## What the backend can actually serve

Cohort results are not retained per run. `cohort_inclusion_result` and `cohort_inclusion_stats` are keyed by `cohort_definition_id` and `mode_id` only, so every generation overwrites the previous one, and `/cohortdefinition/{id}/report/{sourceKey}/inclusion` accepts no generation id. The results of an older run genuinely no longer exist, so "view this run's results" is not something the API can answer.

Characterization, incidence rate and pathway analyses do keep per-generation results, which is why the same dialog works correctly in those workbenches.

## Fix

Rather than label a button that cannot deliver, make the UI match the backend:

- Every row's action now has a tooltip, so the icon is explained wherever it appears.
- `PreviousRunsDialog` gains a `latestResultOnly` prop, off by default, for analyses that do not retain per-run results. When set, only the newest completed run stays enabled; older completed runs are disabled and their tooltip explains that only the most recent run keeps its results. Runs that never completed keep their existing disabled state, now with a tooltip giving the reason.
- `CohortGenerationSection` sets that prop and wires `@select` to open the inclusion report for the source, so the enabled action does something real.

The three workbenches that retain per-run results are untouched, since the prop defaults to off.

## Verification

Reverting each half of the change fails the corresponding tests: dropping the gating, unwiring `@select`, and dropping the per-row label each break the tests that cover them. All 99 test files touching the dialog and its four consumers pass.

Fixes #217
