### PR TITLE
Allow one concept to appear more than once with different flags

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -1159,23 +1159,26 @@ function onRemoveConcept(concept: Concept) {
   hasUnsavedChanges.value = true
 }
 
-function onRemoveFromSet(conceptId: number) {
-  store.removeConceptFromSet(conceptId)
+// These address one row rather than a concept id: the same concept can hold
+// several rows with different flags, and removing or toggling by id would take
+// its siblings with it (#226).
+function onRemoveFromSet(item: ConceptSetItem) {
+  store.removeConceptItem(item)
   hasUnsavedChanges.value = true
 }
 
-function onToggleDescendants(conceptId: number) {
-  store.toggleConceptFlag(conceptId, 'includeDescendants')
+function onToggleDescendants(item: ConceptSetItem) {
+  store.toggleConceptItemFlag(item, 'includeDescendants')
   hasUnsavedChanges.value = true
 }
 
-function onToggleMapped(conceptId: number) {
-  store.toggleConceptFlag(conceptId, 'includeMapped')
+function onToggleMapped(item: ConceptSetItem) {
+  store.toggleConceptItemFlag(item, 'includeMapped')
   hasUnsavedChanges.value = true
 }
 
-function onToggleExclude(conceptId: number) {
-  store.toggleConceptFlag(conceptId, 'isExcluded')
+function onToggleExclude(item: ConceptSetItem) {
+  store.toggleConceptItemFlag(item, 'isExcluded')
   hasUnsavedChanges.value = true
 }
 
@@ -1337,22 +1340,17 @@ function parseJsonImport() {
 }
 
 function applyJsonItems() {
-  // Add each concept then align its flags to the imported values. A new concept
-  // is created with flags=false; an already-present concept is left in place
-  // (`addConceptToSet` no-ops on duplicates). The store only exposes a *toggle*,
-  // so we toggle only when the current value differs from the imported one —
-  // setting flags absolutely. A blind `if (item.flag) toggle(...)` would instead
-  // FLIP an existing concept's flags on re-import, silently destroying the
-  // user's settings.
+  // Import stays a merge of one row per concept: align an existing row's flags
+  // to the imported values, and only add when the concept is absent. Adding
+  // unconditionally would now append a second row whenever the imported flags
+  // differ from the ones already stored (#226).
   for (const item of jsonItems.value) {
-    store.addConceptToSet(item)
     const current = store.currentSet?.items.find(i => i.conceptId === item.conceptId)
-    if (!current) continue
-    if (current.isExcluded !== item.isExcluded) store.toggleConceptFlag(item.conceptId, 'isExcluded')
-    if (current.includeDescendants !== item.includeDescendants)
-      store.toggleConceptFlag(item.conceptId, 'includeDescendants')
-    if (current.includeMapped !== item.includeMapped)
-      store.toggleConceptFlag(item.conceptId, 'includeMapped')
+    if (current) {
+      store.setConceptItemFlags(current, item)
+    } else {
+      store.addConceptToSet(item, item)
+    }
   }
   hasUnsavedChanges.value = true
   activeTab.value = 'selected'

--- a/src/components/concepts/ConceptSetTable.vue
+++ b/src/components/concepts/ConceptSetTable.vue
@@ -274,10 +274,10 @@ const resolvedSourceKey = computed(
 )
 
 const emit = defineEmits<{
-  'toggle:descendants': [conceptId: number]
-  'toggle:mapped': [conceptId: number]
-  'toggle:exclude': [conceptId: number]
-  remove: [conceptId: number]
+  'toggle:descendants': [item: ConceptSetItem]
+  'toggle:mapped': [item: ConceptSetItem]
+  'toggle:exclude': [item: ConceptSetItem]
+  remove: [item: ConceptSetItem]
   'view-concept': [payload: { conceptId: number; sourceKey: string }]
 }>()
 
@@ -449,19 +449,19 @@ function resetFilters() {
 }
 
 function onToggleDescendants(item: ConceptSetItem) {
-  emit('toggle:descendants', item.conceptId)
+  emit('toggle:descendants', item)
 }
 
 function onToggleMapped(item: ConceptSetItem) {
-  emit('toggle:mapped', item.conceptId)
+  emit('toggle:mapped', item)
 }
 
 function onToggleExclude(item: ConceptSetItem) {
-  emit('toggle:exclude', item.conceptId)
+  emit('toggle:exclude', item)
 }
 
 function onRemove(item: ConceptSetItem) {
-  emit('remove', item.conceptId)
+  emit('remove', item)
 }
 </script>
 

--- a/src/components/concepts/detail/ConceptHierarchyDialog.vue
+++ b/src/components/concepts/detail/ConceptHierarchyDialog.vue
@@ -228,8 +228,8 @@ const visibleById = computed(() => {
 
 const selectedVisible = computed(() => selected.value.filter(id => visibleById.value.has(id)))
 
-// addConceptToSet silently refuses duplicates, so count what actually landed
-// rather than what was ticked.
+// addConceptToSet refuses a row that repeats a concept AND its flags, so count
+// what actually landed rather than what was ticked.
 function onAdd() {
   if (!conceptSets.currentSet) return
   const lookup = visibleById.value

--- a/src/stores/concept-sets.ts
+++ b/src/stores/concept-sets.ts
@@ -441,16 +441,33 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
       return
     }
 
-    const exists = currentSet.value.items.some(item => item.conceptId === concept.conceptId)
+    const item: ConceptSetItem = conceptToConceptSetItem(concept, flags)
 
-    if (exists) {
-      error.value = 'Concept already exists in this set'
+    // One concept may appear more than once with different flags. "Include
+    // descendants of X" plus "exclude X" is how a set expresses "X's
+    // descendants but not X itself", which ATLAS 2.x supports (it pushes items
+    // without deduplicating, and resolution is a DISTINCT union of the
+    // includes minus the excludes). Only an exact repeat of the same flag
+    // combination is a no-op worth refusing (#226).
+    if (currentSet.value.items.some(existing => hasSameFlags(existing, item))) {
+      error.value = 'Concept already exists in this set with the same options'
       return
     }
 
-    const item: ConceptSetItem = conceptToConceptSetItem(concept, flags)
     currentSet.value.items.push(item)
     error.value = null
+  }
+
+  // Items reaching the store from an expression payload can carry the flags
+  // unset rather than false, so compare them normalized. Otherwise an existing
+  // row would read as "different flags" and get a pointless twin.
+  function hasSameFlags(a: ConceptSetItem, b: ConceptSetItem): boolean {
+    return (
+      a.conceptId === b.conceptId &&
+      !a.isExcluded === !b.isExcluded &&
+      !a.includeDescendants === !b.includeDescendants &&
+      !a.includeMapped === !b.includeMapped
+    )
   }
 
   /**
@@ -467,6 +484,10 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
 
   /**
    * Toggle concept flags (descendants, mapped, exclude)
+   *
+   * Addresses the first row for the concept. Since a concept can now hold more
+   * than one row, prefer `toggleConceptItemFlag` wherever the specific row is
+   * known.
    */
   function toggleConceptFlag(
     conceptId: number,
@@ -482,6 +503,81 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     if (item) {
       item[flag] = !item[flag]
     }
+  }
+
+  /**
+   * Remove one specific row. A concept can appear more than once with
+   * different flags, so removing by concept id alone would take its siblings
+   * with it (#226).
+   */
+  function removeConceptItem(target: ConceptSetItem) {
+    if (!currentSet.value) {
+      error.value = 'No concept set selected'
+      return
+    }
+
+    const index = indexOfItem(target)
+    if (index !== -1) {
+      currentSet.value.items.splice(index, 1)
+    }
+  }
+
+  /**
+   * Toggle a flag on one specific row, leaving that concept's other rows
+   * alone. Refuses a toggle that would make the row an exact copy of a
+   * sibling, which `addConceptToSet` would equally have refused.
+   */
+  function toggleConceptItemFlag(
+    target: ConceptSetItem,
+    flag: 'includeDescendants' | 'includeMapped' | 'isExcluded'
+  ) {
+    if (!currentSet.value) {
+      error.value = 'No concept set selected'
+      return
+    }
+
+    const index = indexOfItem(target)
+    if (index === -1) return
+
+    const item = currentSet.value.items[index]
+    if (!item) return
+
+    const updated: ConceptSetItem = { ...item, [flag]: !item[flag] }
+    if (currentSet.value.items.some((other, i) => i !== index && hasSameFlags(other, updated))) {
+      error.value = 'Another entry for this concept already uses those options'
+      return
+    }
+
+    item[flag] = !item[flag]
+    error.value = null
+  }
+
+  /**
+   * Set all three flags on one specific row at once.
+   */
+  function setConceptItemFlags(target: ConceptSetItem, flags: ConceptAddFlags) {
+    if (!currentSet.value) {
+      error.value = 'No concept set selected'
+      return
+    }
+
+    const item = currentSet.value.items[indexOfItem(target)]
+    if (!item) return
+
+    if (flags.isExcluded !== undefined) item.isExcluded = flags.isExcluded
+    if (flags.includeDescendants !== undefined) item.includeDescendants = flags.includeDescendants
+    if (flags.includeMapped !== undefined) item.includeMapped = flags.includeMapped
+  }
+
+  /**
+   * Locate a row by object identity, falling back to its concept-and-flags
+   * signature for callers holding a copy rather than the stored object.
+   */
+  function indexOfItem(target: ConceptSetItem): number {
+    const items = currentSet.value?.items ?? []
+    const byReference = items.indexOf(target)
+    if (byReference !== -1) return byReference
+    return items.findIndex(item => hasSameFlags(item, target))
   }
 
   /**
@@ -1005,6 +1101,9 @@ export const useConceptSetsStore = defineStore('concept-sets', () => {
     removeConceptFromSet,
     toggleConceptFlag,
     isConceptInSet,
+    removeConceptItem,
+    toggleConceptItemFlag,
+    setConceptItemFlags,
 
     // Pythia agent partial-update entry-point
     applyProposal,

--- a/tests/unit/components/concepts/ConceptSetEditor.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetEditor.spec.ts
@@ -554,48 +554,52 @@ describe('ConceptSetEditor', () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()
     store.currentSet = mockConceptSet
-    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptFlag')
+    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptItemFlag')
+    const row = store.currentSet!.items[0]!
 
     // Component is stubbed, so we can manually call the handler
-    await wrapper.vm.onToggleDescendants(313217)
+    await wrapper.vm.onToggleDescendants(row)
 
-    expect(toggleFlagSpy).toHaveBeenCalledWith(313217, 'includeDescendants')
+    expect(toggleFlagSpy).toHaveBeenCalledWith(row, 'includeDescendants')
   })
 
   it('should toggle mapped when ConceptSetTable emits toggle:mapped', async () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()
     store.currentSet = mockConceptSet
-    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptFlag')
+    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptItemFlag')
+    const row = store.currentSet!.items[0]!
 
     // Component is stubbed, so we can manually call the handler
-    await wrapper.vm.onToggleMapped(313217)
+    await wrapper.vm.onToggleMapped(row)
 
-    expect(toggleFlagSpy).toHaveBeenCalledWith(313217, 'includeMapped')
+    expect(toggleFlagSpy).toHaveBeenCalledWith(row, 'includeMapped')
   })
 
   it('should toggle exclude when ConceptSetTable emits toggle:exclude', async () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()
     store.currentSet = mockConceptSet
-    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptFlag')
+    const toggleFlagSpy = vi.spyOn(store, 'toggleConceptItemFlag')
+    const row = store.currentSet!.items[0]!
 
     // Component is stubbed, so we can manually call the handler
-    await wrapper.vm.onToggleExclude(313217)
+    await wrapper.vm.onToggleExclude(row)
 
-    expect(toggleFlagSpy).toHaveBeenCalledWith(313217, 'isExcluded')
+    expect(toggleFlagSpy).toHaveBeenCalledWith(row, 'isExcluded')
   })
 
   it('should remove concept when ConceptSetTable emits remove', async () => {
     const wrapper = mountComponent({ conceptSet: mockConceptSet })
     const store = useConceptSetsStore()
     store.currentSet = mockConceptSet
-    const removeConceptSpy = vi.spyOn(store, 'removeConceptFromSet')
+    const removeConceptSpy = vi.spyOn(store, 'removeConceptItem')
+    const row = store.currentSet!.items[0]!
 
     // Component is stubbed, so we can manually call the handler
-    await wrapper.vm.onRemoveFromSet(313217)
+    await wrapper.vm.onRemoveFromSet(row)
 
-    expect(removeConceptSpy).toHaveBeenCalledWith(313217)
+    expect(removeConceptSpy).toHaveBeenCalledWith(row)
   })
 
   it('should display item count in selected tab', async () => {
@@ -782,7 +786,6 @@ describe('ConceptSetEditor', () => {
       const store = useConceptSetsStore()
       store.currentSet = { name: 'Set', items: [] }
       const addSpy = vi.spyOn(store, 'addConceptToSet')
-      const toggleSpy = vi.spyOn(store, 'toggleConceptFlag')
 
       const vm = wrapper.vm as unknown as {
         jsonInput: string
@@ -816,9 +819,17 @@ describe('ConceptSetEditor', () => {
       expect(vm.jsonItems).toHaveLength(1)
 
       vm.applyJsonItems()
-      expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({ conceptId: 201826 }))
-      // includeDescendants flag should be restored via toggle.
-      expect(toggleSpy).toHaveBeenCalledWith(201826, 'includeDescendants')
+      // The imported flags now go in with the add rather than being toggled on
+      // afterwards, so a concept absent from the set lands in one step (#226).
+      expect(addSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ conceptId: 201826 }),
+        expect.objectContaining({ includeDescendants: true })
+      )
+      expect(store.currentSet?.items).toHaveLength(1)
+      expect(store.currentSet?.items[0]).toMatchObject({
+        conceptId: 201826,
+        includeDescendants: true,
+      })
     })
 
     it('does not flip the flags of a concept already in the set on re-import', () => {

--- a/tests/unit/components/concepts/ConceptSetTable.spec.ts
+++ b/tests/unit/components/concepts/ConceptSetTable.spec.ts
@@ -127,7 +127,7 @@ describe('ConceptSetTable', () => {
     await checkboxes[0].vm.$emit('update:modelValue', false)
 
     expect(wrapper.emitted('toggle:descendants')).toBeTruthy()
-    expect(wrapper.emitted('toggle:descendants')![0]).toEqual([192855])
+    expect(wrapper.emitted('toggle:descendants')![0]![0]).toMatchObject({ conceptId: 192855 })
   })
 
   it('should emit toggle:mapped when mapped checkbox is clicked', async () => {
@@ -140,7 +140,7 @@ describe('ConceptSetTable', () => {
     await checkboxes[1].vm.$emit('update:modelValue', true)
 
     expect(wrapper.emitted('toggle:mapped')).toBeTruthy()
-    expect(wrapper.emitted('toggle:mapped')![0]).toEqual([192855])
+    expect(wrapper.emitted('toggle:mapped')![0]![0]).toMatchObject({ conceptId: 192855 })
   })
 
   it('should emit toggle:exclude when exclude checkbox is clicked', async () => {
@@ -153,7 +153,7 @@ describe('ConceptSetTable', () => {
     await checkboxes[2].vm.$emit('update:modelValue', true)
 
     expect(wrapper.emitted('toggle:exclude')).toBeTruthy()
-    expect(wrapper.emitted('toggle:exclude')![0]).toEqual([192855])
+    expect(wrapper.emitted('toggle:exclude')![0]![0]).toMatchObject({ conceptId: 192855 })
   })
 
   it('should emit remove when delete button is clicked', async () => {
@@ -166,7 +166,7 @@ describe('ConceptSetTable', () => {
     await deleteButtons[0].trigger('click')
 
     expect(wrapper.emitted('remove')).toBeTruthy()
-    expect(wrapper.emitted('remove')![0]).toEqual([192855])
+    expect(wrapper.emitted('remove')![0]![0]).toMatchObject({ conceptId: 192855 })
   })
 
   it('should display concept type badges', () => {

--- a/tests/unit/stores/concept-sets.add-flags.spec.ts
+++ b/tests/unit/stores/concept-sets.add-flags.spec.ts
@@ -95,15 +95,27 @@ describe('addConceptToSet — add-time flags (#163)', () => {
     })
   })
 
-  it('still rejects a duplicate regardless of the flags supplied', () => {
+  // ATLAS 2.x pushes items without deduplicating, and resolution is a DISTINCT
+  // union of the includes minus the excludes, so "include descendants of X"
+  // plus "exclude X" is how a set says "X's descendants but not X" (#226).
+  it('accepts the same concept again under a different set of flags', () => {
     const s = store()
     s.addConceptToSet(concept, { includeDescendants: true })
     s.addConceptToSet(concept, { isExcluded: true })
 
+    expect(s.currentSet?.items).toHaveLength(2)
+    expect(s.currentSet?.items[0]).toMatchObject({ includeDescendants: true, isExcluded: false })
+    expect(s.currentSet?.items[1]).toMatchObject({ includeDescendants: false, isExcluded: true })
+    expect(s.error).toBeNull()
+  })
+
+  it('still refuses an exact repeat of the same concept and flags', () => {
+    const s = store()
+    s.addConceptToSet(concept, { includeDescendants: true })
+    s.addConceptToSet(concept, { includeDescendants: true })
+
     expect(s.currentSet?.items).toHaveLength(1)
-    expect(s.currentSet?.items[0]?.includeDescendants).toBe(true)
-    expect(s.currentSet?.items[0]?.isExcluded).toBe(false)
-    expect(s.error).toBe('Concept already exists in this set')
+    expect(s.error).toBe('Concept already exists in this set with the same options')
   })
 
   it('keeps flags independent per concept', () => {

--- a/tests/unit/stores/concept-sets.duplicate-rows.spec.ts
+++ b/tests/unit/stores/concept-sets.duplicate-rows.spec.ts
@@ -129,4 +129,22 @@ describe('per-row edits when a concept appears more than once', () => {
 
     expect(s.currentSet?.items.map(i => i.conceptId)).toEqual([313217, 999])
   })
+
+  describe('with no concept set open', () => {
+    it('reports the missing set rather than mutating nothing silently', () => {
+      const s = useConceptSetsStore()
+      const row = { conceptId: 1 } as never
+
+      s.removeConceptItem(row)
+      expect(s.error).toBe('No concept set selected')
+
+      s.error = null
+      s.toggleConceptItemFlag(row, 'isExcluded')
+      expect(s.error).toBe('No concept set selected')
+
+      s.error = null
+      s.setConceptItemFlags(row, { isExcluded: true })
+      expect(s.error).toBe('No concept set selected')
+    })
+  })
 })

--- a/tests/unit/stores/concept-sets.duplicate-rows.spec.ts
+++ b/tests/unit/stores/concept-sets.duplicate-rows.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useConceptSetsStore } from '@/stores/concept-sets'
+import type { Concept } from '@/models/concept-set.types'
+
+vi.mock('@/services/concept-set.service', () => ({
+  getConceptSets: vi.fn().mockResolvedValue([]),
+  getConceptSetById: vi.fn(),
+  createConceptSet: vi.fn(),
+  updateConceptSet: vi.fn(),
+  deleteConceptSet: vi.fn(),
+  getConceptSetExpression: vi.fn(),
+  getConceptSetItems: vi.fn(),
+  saveConceptSetItems: vi.fn(),
+  checkConceptSetName: vi.fn(),
+}))
+
+vi.mock('@/services/concept-search.service', () => ({
+  getRecommendedConcepts: vi.fn(),
+  getConceptRecordCounts: vi.fn(),
+  compareConceptSets: vi.fn(),
+  resolveConceptSetExpression: vi.fn(),
+  getMappedSourceCodes: vi.fn(),
+}))
+
+vi.mock('@/stores/webapi', () => ({
+  useWebAPIStore: vi.fn(() => ({ getValidVocabularySource: () => 'SRC', sources: [] })),
+}))
+
+const concept: Concept = {
+  conceptId: 313217,
+  conceptName: 'Atrial fibrillation',
+  conceptCode: '49436004',
+  domainId: 'Condition',
+  vocabularyId: 'SNOMED',
+  conceptClassId: 'Clinical Finding',
+  standardConcept: 'S',
+  invalidReason: null,
+}
+
+const other: Concept = { ...concept, conceptId: 999, conceptName: 'Other' }
+
+/**
+ * Once one concept can hold several rows, every edit has to name the row it
+ * means. Addressing by concept id would hit the row's siblings too (#226).
+ */
+describe('per-row edits when a concept appears more than once', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  function storeWithBothRows() {
+    const s = useConceptSetsStore()
+    s.currentSet = { name: 'Test', items: [] }
+    // The "descendants of X but not X itself" pair.
+    s.addConceptToSet(concept, { includeDescendants: true })
+    s.addConceptToSet(concept, { isExcluded: true })
+    return s
+  }
+
+  it('removes only the row it was given', () => {
+    const s = storeWithBothRows()
+    const excludedRow = s.currentSet!.items[1]!
+
+    s.removeConceptItem(excludedRow)
+
+    expect(s.currentSet?.items).toHaveLength(1)
+    expect(s.currentSet?.items[0]).toMatchObject({
+      conceptId: 313217,
+      includeDescendants: true,
+      isExcluded: false,
+    })
+  })
+
+  it('toggles a flag on the row it was given, leaving its sibling alone', () => {
+    const s = storeWithBothRows()
+    const excludedRow = s.currentSet!.items[1]!
+
+    s.toggleConceptItemFlag(excludedRow, 'includeMapped')
+
+    expect(s.currentSet?.items[0]).toMatchObject({ includeMapped: false })
+    expect(s.currentSet?.items[1]).toMatchObject({ includeMapped: true })
+  })
+
+  it('refuses a toggle that would make two rows identical', () => {
+    const s = useConceptSetsStore()
+    s.currentSet = { name: 'Test', items: [] }
+    s.addConceptToSet(concept, { includeDescendants: true })
+    s.addConceptToSet(concept, { includeDescendants: false })
+
+    // Turning the second row's descendants on would duplicate the first row,
+    // which addConceptToSet would equally have refused.
+    s.toggleConceptItemFlag(s.currentSet!.items[1]!, 'includeDescendants')
+
+    expect(s.currentSet?.items[1]).toMatchObject({ includeDescendants: false })
+    expect(s.error).toBe('Another entry for this concept already uses those options')
+  })
+
+  it('accepts a copy of the row rather than the stored object', () => {
+    const s = storeWithBothRows()
+    const copy = { ...s.currentSet!.items[1]! }
+
+    s.removeConceptItem(copy)
+
+    expect(s.currentSet?.items).toHaveLength(1)
+    expect(s.currentSet?.items[0]).toMatchObject({ includeDescendants: true })
+  })
+
+  it('sets all flags on one row at once', () => {
+    const s = storeWithBothRows()
+
+    s.setConceptItemFlags(s.currentSet!.items[0]!, {
+      isExcluded: false,
+      includeDescendants: false,
+      includeMapped: true,
+    })
+
+    expect(s.currentSet?.items[0]).toMatchObject({
+      includeDescendants: false,
+      includeMapped: true,
+      isExcluded: false,
+    })
+    expect(s.currentSet?.items[1]).toMatchObject({ isExcluded: true, includeMapped: false })
+  })
+
+  it('leaves other concepts untouched', () => {
+    const s = storeWithBothRows()
+    s.addConceptToSet(other)
+
+    s.removeConceptItem(s.currentSet!.items[0]!)
+
+    expect(s.currentSet?.items.map(i => i.conceptId)).toEqual([313217, 999])
+  })
+})

--- a/tests/unit/stores/concept-sets.spec.ts
+++ b/tests/unit/stores/concept-sets.spec.ts
@@ -507,7 +507,7 @@ describe('Concept Sets Store', () => {
 
         store.addConceptToSet(mockConcept)
 
-        expect(store.error).toBe('Concept already exists in this set')
+        expect(store.error).toBe('Concept already exists in this set with the same options')
       })
 
       it('should clear error on successful add', () => {


### PR DESCRIPTION
## Problem

Search for a concept, add it to a set, then tick a different inclusion option (Descendants, Mapped or Exclude) and try to add it again. Nothing happens and the set keeps a single row.

That makes a standard idiom impossible to express: "include the descendants of X" plus "exclude X itself" is how a concept set says "X's descendants but not X", and it needs two rows for the same concept.

## Why two rows are legitimate

ATLAS 2.x allows this. `addItemsToConceptSet` in `js/components/conceptset/utils.js` does a plain `items.push(...itemsToAdd)` with no deduplication, and WebAPI resolves an expression as `select distinct I.concept_id` over the union of the includes, with the excludes subtracted separately. The two rows therefore combine rather than contradict each other.

Atlas3 refused any second row for a concept whatever its flags:

```ts
const exists = currentSet.value.items.some(item => item.conceptId === concept.conceptId)
if (exists) {
  error.value = 'Concept already exists in this set'
  return
}
```

## Fix

Accept a repeat whose flag combination differs, and keep refusing an exact repeat, which would only add a row that changes nothing. Flags are compared normalized, because items arriving from an expression payload can leave them unset rather than `false`.

## Consequence: row identity

Once a concept can hold several rows, its id is no longer a usable handle, and the id-based operations were quietly wrong:

- `removeConceptFromSet(conceptId)` filtered out **every** matching row, so removing one row of a pair deleted its sibling too.
- `toggleConceptFlag(conceptId, flag)` mutated the **first** match, so editing the second row silently edited the first.

The editor therefore addresses a row by the item itself. `removeConceptItem` and `toggleConceptItemFlag` replace the id-based calls, and `ConceptSetTable` emits the row rather than its concept id. Lookup is by object identity with a concept-and-flags fallback, so a caller holding a copy still resolves. A toggle that would make two rows identical is refused, matching what the add path already does.

`setConceptItemFlags` sets all three flags on one row at once. JSON import uses it to preserve its existing merge behaviour of one row per concept: it previously relied on add being a no-op for an already-present concept and then toggled the flags into place, which would now append a second row whenever the imported flags differed.

The id-based `removeConceptFromSet` and `toggleConceptFlag` remain for callers that legitimately mean "this concept", such as unselecting from the search results.

## Note on a replaced test

`concept-sets.add-flags.spec.ts` contained a test asserting a duplicate is refused "regardless of the flags supplied", which encodes exactly the behaviour this issue reports as wrong. It is replaced by the two cases that now apply: a differing flag combination is accepted, an exact repeat is still refused.

## Verification

New `concept-sets.duplicate-rows.spec.ts` covers per-row removal, per-row toggling with the sibling untouched, the refused collision, resolving from a copy of the row, setting all flags at once, and other concepts being unaffected. Restoring the blanket deduplication fails 6 of 13 cases, and restoring id-based removal fails 3 of 6. Full suite passes: 6660 unit and 2395 component tests.

Fixes #226
