### PR TITLE
Add a free-text filter over vocabulary search results

### DIFF
--- a/src/components/concepts/ConceptFacetFilters.vue
+++ b/src/components/concepts/ConceptFacetFilters.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="concept-facet-filters">
     <div class="concept-facet-filters__bar">
+      <AtlasTextField
+        :model-value="resultFilter"
+        :label="filterResultsLabel"
+        density="compact"
+        variant="outlined"
+        hide-details
+        clearable
+        prepend-inner-icon="mdi-magnify"
+        class="concept-facet-filters__text"
+        data-testid="concept-result-filter"
+        @update:model-value="(v: string | number) => emit('update:resultFilter', String(v ?? ''))"
+      />
+
       <AtlasMenu
         v-model="menuOpen"
         :close-on-content-click="false"
@@ -105,21 +118,24 @@ import {
   type FacetKey,
   type FacetOption,
 } from '@/composables/useConceptFacets'
-import { AtlasAutocomplete, AtlasButton, AtlasCard, AtlasChip, AtlasMenu, AtlasSpacer } from '@/components/ui'
+import { AtlasAutocomplete, AtlasButton, AtlasCard, AtlasChip, AtlasMenu, AtlasSpacer, AtlasTextField } from '@/components/ui'
 
 interface Props {
   facetOptions: Record<FacetKey, FacetOption[]>
   selected: Record<FacetKey, string[]>
   activeFilterCount: number
+  resultFilter?: string
   facets?: Pick<FacetDefinition, 'key' | 'label'>[]
 }
 
 interface Emits {
   (e: 'update:facet', payload: { key: FacetKey; values: string[] }): void
+  (e: 'update:resultFilter', value: string): void
   (e: 'clear'): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  resultFilter: '',
   facets: () => CONCEPT_FACETS,
 })
 const emit = defineEmits<Emits>()
@@ -127,6 +143,7 @@ const { t } = useI18n()
 
 const filtersLabel = t('common.filters', 'Filters')
 const clearAllLabel = t('search.clearAllSelections', 'Clear all')
+const filterResultsLabel = t('search.filterResults', 'Filter results')
 const menuOpen = ref(false)
 
 // Translate facet labels via the existing column i18n keys.
@@ -180,6 +197,11 @@ function removeValue(key: FacetKey, value: string) {
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.concept-facet-filters__text {
+  max-width: 260px;
+  flex: 1 1 200px;
 }
 
 .concept-facet-filters__count {

--- a/src/components/concepts/ConceptSearch.vue
+++ b/src/components/concepts/ConceptSearch.vue
@@ -49,8 +49,10 @@
       :facet-options="store.facetOptions"
       :selected="store.selectedFacets"
       :active-filter-count="store.activeFacetCount"
+      :result-filter="store.resultFilter"
       class="concept-search__filters"
       @update:facet="({ key, values }) => store.setFacet(key, values)"
+      @update:result-filter="(v: string) => store.setResultFilter(v)"
       @clear="store.clearFacets()"
     />
 

--- a/src/components/concepts/ConceptSearchInline.vue
+++ b/src/components/concepts/ConceptSearchInline.vue
@@ -42,8 +42,10 @@
       :facet-options="store.facetOptions"
       :selected="store.selectedFacets"
       :active-filter-count="store.activeFacetCount"
+      :result-filter="store.resultFilter"
       class="mb-4"
       @update:facet="({ key, values }) => store.setFacet(key, values)"
+      @update:result-filter="(v: string) => store.setResultFilter(v)"
       @clear="store.clearFacets()"
     />
 

--- a/src/composables/useConceptFacets.ts
+++ b/src/composables/useConceptFacets.ts
@@ -43,16 +43,44 @@ export const CONCEPT_FACETS: FacetDefinition<Concept>[] = [
   { key: 'invalidReason', label: 'Validity', display: c => (c.invalidReason ? 'Invalid' : 'Valid') },
 ]
 
+/**
+ * Fields a free-text filter matches against, mirroring the columns the results
+ * table shows. ATLAS 2.x offers the same narrowing as a "Filter:" box over the
+ * rows already returned.
+ */
+export function conceptSearchText(c: Concept): string {
+  return [
+    String(c.conceptId ?? ''),
+    c.conceptName ?? '',
+    c.conceptCode ?? '',
+    c.domainId ?? '',
+    c.vocabularyId ?? '',
+    c.conceptClassId ?? '',
+  ].join(' ')
+}
+
 export function useConceptFacets<T = Concept>(
   concepts: Ref<T[]>,
-  definitions: MaybeRefOrGetter<FacetDefinition<T>[]> = CONCEPT_FACETS as FacetDefinition<T>[]
+  definitions: MaybeRefOrGetter<FacetDefinition<T>[]> = CONCEPT_FACETS as FacetDefinition<T>[],
+  searchText: (item: T) => string = conceptSearchText as unknown as (item: T) => string
 ) {
   const selected = ref<Record<FacetKey, string[]>>({})
+  const textFilter = ref<string>('')
 
   const facets = computed(() => toValue(definitions))
+  const normalizedText = computed(() => textFilter.value.trim().toLowerCase())
 
   function selectionFor(key: FacetKey): string[] {
     return selected.value[key] ?? []
+  }
+
+  /**
+   * Applied everywhere the facet selections are, so the option counts describe
+   * the rows actually on screen rather than the whole result set.
+   */
+  function matchesText(item: T): boolean {
+    if (!normalizedText.value) return true
+    return searchText(item).toLowerCase().includes(normalizedText.value)
   }
 
   /** Does an item pass every facet's selection except the excluded one? */
@@ -66,14 +94,16 @@ export function useConceptFacets<T = Concept>(
     return true
   }
 
-  const filteredConcepts = computed(() => concepts.value.filter(c => matchesExcept(c, null)))
+  const filteredConcepts = computed(() =>
+    concepts.value.filter(c => matchesText(c) && matchesExcept(c, null))
+  )
 
   const facetOptions = computed<Record<FacetKey, FacetOption[]>>(() => {
     const result: Record<FacetKey, FacetOption[]> = {}
     for (const facet of facets.value) {
       const counts = new Map<string, number>()
       for (const c of concepts.value) {
-        if (!matchesExcept(c, facet.key)) continue
+        if (!matchesText(c) || !matchesExcept(c, facet.key)) continue
         const value = facet.display(c)
         counts.set(value, (counts.get(value) ?? 0) + 1)
       }
@@ -84,17 +114,33 @@ export function useConceptFacets<T = Concept>(
     return result
   })
 
-  const activeFilterCount = computed(() =>
-    facets.value.reduce((n, f) => n + (selectionFor(f.key).length > 0 ? 1 : 0), 0)
+  const activeFilterCount = computed(
+    () =>
+      facets.value.reduce((n, f) => n + (selectionFor(f.key).length > 0 ? 1 : 0), 0) +
+      (normalizedText.value ? 1 : 0)
   )
 
   function setFacet(key: FacetKey, values: string[]) {
     selected.value = { ...selected.value, [key]: values }
   }
 
-  function clearFilters() {
-    selected.value = {}
+  function setTextFilter(value: string) {
+    textFilter.value = value
   }
 
-  return { selected, facetOptions, filteredConcepts, activeFilterCount, setFacet, clearFilters }
+  function clearFilters() {
+    selected.value = {}
+    textFilter.value = ''
+  }
+
+  return {
+    selected,
+    textFilter,
+    facetOptions,
+    filteredConcepts,
+    activeFilterCount,
+    setFacet,
+    setTextFilter,
+    clearFilters,
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2900,7 +2900,8 @@
     "advancedOptions": "Advanced Options",
     "buttonTitle": "Search",
     "classification": "Classification",
-    "clearAllSelections": "Clear All Selections",
+    "filterResults": "Filter results",
+      "clearAllSelections": "Clear All Selections",
     "domains": "Domains",
     "headingTitle": "Search",
     "loadingMessage": {

--- a/src/stores/concept-search.ts
+++ b/src/stores/concept-search.ts
@@ -43,6 +43,11 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
     { deep: true }
   )
 
+  // Same for the free-text filter over the returned rows.
+  watch(facets.textFilter, () => {
+    page.value = 1
+  })
+
   // ============================================================================
   // Getters
   // ============================================================================
@@ -215,7 +220,9 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
     facetOptions: facets.facetOptions,
     selectedFacets: facets.selected,
     activeFacetCount: facets.activeFilterCount,
+    resultFilter: facets.textFilter,
     setFacet: facets.setFacet,
+    setResultFilter: facets.setTextFilter,
     clearFacets: facets.clearFilters,
 
     // Actions

--- a/tests/unit/composables/useConceptFacets.text-filter.spec.ts
+++ b/tests/unit/composables/useConceptFacets.text-filter.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useConceptFacets } from '@/composables/useConceptFacets'
+import type { Concept } from '@/models/concept-set.types'
+
+function concept(overrides: Partial<Concept>): Concept {
+  return {
+    conceptId: 1,
+    conceptName: 'Concept',
+    conceptCode: '000',
+    domainId: 'Condition',
+    vocabularyId: 'SNOMED',
+    conceptClassId: 'Clinical Finding',
+    standardConcept: 'S',
+    invalidReason: null,
+    ...overrides,
+  }
+}
+
+const rows = [
+  concept({ conceptId: 201826, conceptName: 'Type 2 diabetes mellitus', conceptCode: '44054006' }),
+  concept({ conceptId: 4193704, conceptName: 'Type 1 diabetes mellitus', conceptCode: '46635009' }),
+  concept({
+    conceptId: 320128,
+    conceptName: 'Essential hypertension',
+    conceptCode: '59621000',
+    vocabularyId: 'ICD10CM',
+  }),
+]
+
+/**
+ * ATLAS 2.x narrows the rows already returned with a "Filter:" box over the
+ * results table (OHDSI/Atlas3#227).
+ */
+describe('free-text filter over search results', () => {
+  it('returns everything when the filter is empty or whitespace', () => {
+    const f = useConceptFacets(ref(rows))
+    expect(f.filteredConcepts.value).toHaveLength(3)
+
+    f.setTextFilter('   ')
+    expect(f.filteredConcepts.value).toHaveLength(3)
+  })
+
+  it('matches concept name case-insensitively', () => {
+    const f = useConceptFacets(ref(rows))
+    f.setTextFilter('DIABETES')
+
+    expect(f.filteredConcepts.value.map(c => c.conceptId)).toEqual([201826, 4193704])
+  })
+
+  it('matches concept id and concept code too', () => {
+    const f = useConceptFacets(ref(rows))
+
+    f.setTextFilter('320128')
+    expect(f.filteredConcepts.value.map(c => c.conceptName)).toEqual(['Essential hypertension'])
+
+    f.setTextFilter('46635009')
+    expect(f.filteredConcepts.value.map(c => c.conceptId)).toEqual([4193704])
+  })
+
+  it('matches vocabulary and domain', () => {
+    const f = useConceptFacets(ref(rows))
+    f.setTextFilter('icd10')
+
+    expect(f.filteredConcepts.value.map(c => c.conceptId)).toEqual([320128])
+  })
+
+  it('combines with facet selections rather than replacing them', () => {
+    const f = useConceptFacets(ref(rows))
+    f.setFacet('vocabularyId', ['SNOMED'])
+    f.setTextFilter('type 1')
+
+    expect(f.filteredConcepts.value.map(c => c.conceptId)).toEqual([4193704])
+  })
+
+  it('narrows the facet option counts to the rows still on screen', () => {
+    const f = useConceptFacets(ref(rows))
+    f.setTextFilter('diabetes')
+
+    const vocab = f.facetOptions.value.vocabularyId
+    expect(vocab).toEqual([{ value: 'SNOMED', label: 'SNOMED (2)', count: 2 }])
+  })
+
+  it('counts as an active filter and is cleared with the others', () => {
+    const f = useConceptFacets(ref(rows))
+    expect(f.activeFilterCount.value).toBe(0)
+
+    f.setTextFilter('diabetes')
+    expect(f.activeFilterCount.value).toBe(1)
+
+    f.setFacet('vocabularyId', ['SNOMED'])
+    expect(f.activeFilterCount.value).toBe(2)
+
+    f.clearFilters()
+    expect(f.activeFilterCount.value).toBe(0)
+    expect(f.textFilter.value).toBe('')
+    expect(f.filteredConcepts.value).toHaveLength(3)
+  })
+
+  it('yields nothing when the filter matches no row', () => {
+    const f = useConceptFacets(ref(rows))
+    f.setTextFilter('no such concept')
+
+    expect(f.filteredConcepts.value).toEqual([])
+  })
+})


### PR DESCRIPTION
## Gap

ATLAS 2.x lets you narrow the rows a search has already returned by typing into a filter box above the results. Atlas3 offered the facet dropdowns but nothing equivalent, so a broad search could only be cut down by picking facet values.

## What 2.x does

The search page renders a `faceted-datatable`, whose `dom` string includes the datatable's own search input and relabels it:

```js
self.dom = '<<"row vertical-align"<"col-xs-6"<"dt-btn"B>l><"col-xs-6 search"f>>…'
language: { search: 'Filter: ' }
```

It is a client-side filter over the rows already fetched, matching across the visible columns.

## Change

The filter lives in `useConceptFacets` rather than in the store's pagination getter, so it sits alongside the other filtering and the store keeps its current shape.

- Matches concept id, name, code, domain, vocabulary and class, case-insensitively.
- Applies wherever the facet selections apply, so the facet option counts describe the rows actually on screen rather than the whole result set.
- Counts towards the active-filter badge and is reset by "Clear all", so results narrowed to nothing can be explained from the UI.
- Changing it returns to page 1, matching what a facet selection already does.

It appears as a compact field in the existing filter bar, next to the Filters button, on both the full search view and the inline one.

## Verification

New `useConceptFacets.text-filter.spec.ts` covers the empty and whitespace cases, name matching, id and code matching, vocabulary matching, combining with a facet selection, narrowed option counts, the active-filter count and clearing, and a term matching nothing. Removing the filter from `filteredConcepts` fails 5 of the 8. Full suite passes: 6661 unit and 1579 component tests.

Fixes #227
