### PR TITLE
Let the user choose which source the search record counts come from

### DIFF
--- a/src/components/concepts/ConceptSearch.vue
+++ b/src/components/concepts/ConceptSearch.vue
@@ -62,6 +62,26 @@
       @add="onAddSelected"
     />
 
+    <!-- Which source the record/person counts come from (#228). -->
+    <div
+      v-if="!store.isEmpty && recordCountSources.length > 0"
+      class="concept-search__count-source"
+    >
+      <AtlasSelect
+        :model-value="effectiveRecordCountSource"
+        :items="recordCountSources"
+        item-title="sourceName"
+        item-value="sourceKey"
+        :label="viewCountsForLabel"
+        density="compact"
+        variant="outlined"
+        hide-details
+        :loading="store.loadingRecordCounts"
+        data-testid="record-count-source"
+        @update:model-value="(v: unknown) => store.setRecordCountSource(String(v))"
+      />
+    </div>
+
     <!-- Results Table -->
     <ConceptTable
       v-model:selected="selected"
@@ -92,7 +112,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { AtlasAlert, AtlasSnackbar, AtlasTextField } from '@/components/ui'
+import { AtlasAlert, AtlasSelect, AtlasSnackbar, AtlasTextField } from '@/components/ui'
 import { useI18n } from '@/composables/useI18n'
 import { useConceptSearchStore } from '@/stores/concept-search'
 import { useConceptSetsStore } from '@/stores/concept-sets'
@@ -114,6 +134,18 @@ const conceptSetsStore = useConceptSetsStore()
 const webapiStore = useWebAPIStore()
 const selectedSourceKey = computed(
   () => webapiStore.getValidVocabularySource() || getSourceKey() || '',
+)
+
+const viewCountsForLabel = t('search.viewCountMessage', 'View record count for:')
+
+// Only sources that can actually report counts. Offering a vocabulary-only
+// source here would just blank the count columns.
+const recordCountSources = computed(() => webapiStore.resultsSources)
+
+// Until the user picks one, counts come from whichever source the search used,
+// which is what happened before this picker existed.
+const effectiveRecordCountSource = computed(
+  () => store.recordCountSourceKey ?? selectedSourceKey.value,
 )
 
 // Concepts already present in the current (in-progress) set — drives the

--- a/src/stores/concept-search.ts
+++ b/src/stores/concept-search.ts
@@ -21,6 +21,11 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
   const allConcepts = ref<Concept[]>([]) // All search results
   const loading = ref<boolean>(false)
   const loadingRecordCounts = ref<boolean>(false)
+  // Which source the record/person counts come from. Independent of the
+  // vocabulary source: the vocabulary knows the concepts, a Results source
+  // knows how often they occur in that data (#228). Null means "follow the
+  // vocabulary source", which is what this did before the picker existed.
+  const recordCountSourceKey = ref<string | null>(null)
   const error = ref<string | null>(null)
 
   // Pagination state
@@ -132,19 +137,7 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
       // A new query changes the available value space — drop stale facets.
       facets.clearFilters()
 
-      loadingRecordCounts.value = true
-      const conceptIds = result.data.map(c => c.conceptId)
-      const recordCounts = await getConceptRecordCounts(sourceKey, conceptIds)
-
-      allConcepts.value = result.data.map(concept => ({
-        ...concept,
-        recordCount: recordCounts.get(concept.conceptId)?.recordCount,
-        descendantRecordCount: recordCounts.get(concept.conceptId)?.descendantRecordCount,
-        personCount: recordCounts.get(concept.conceptId)?.personCount,
-        descendantPersonCount: recordCounts.get(concept.conceptId)?.descendantPersonCount,
-      }))
-
-      loadingRecordCounts.value = false
+      await loadRecordCounts(recordCountSourceKey.value ?? sourceKey)
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       error.value = errorMessage.includes('403')
@@ -154,6 +147,47 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
       allConcepts.value = []
       loading.value = false
       loadingRecordCounts.value = false
+    }
+  }
+
+  /**
+   * Refresh the record and person counts on the current results from one
+   * source, leaving the concepts themselves alone.
+   */
+  async function loadRecordCounts(sourceKey: string): Promise<void> {
+    const current = allConcepts.value
+    if (current.length === 0) return
+
+    loadingRecordCounts.value = true
+    try {
+      const recordCounts = await getConceptRecordCounts(
+        sourceKey,
+        current.map(c => c.conceptId)
+      )
+
+      allConcepts.value = current.map(concept => ({
+        ...concept,
+        recordCount: recordCounts.get(concept.conceptId)?.recordCount,
+        descendantRecordCount: recordCounts.get(concept.conceptId)?.descendantRecordCount,
+        personCount: recordCounts.get(concept.conceptId)?.personCount,
+        descendantPersonCount: recordCounts.get(concept.conceptId)?.descendantPersonCount,
+      }))
+    } finally {
+      loadingRecordCounts.value = false
+    }
+  }
+
+  /**
+   * Point the counts at a different source and refresh them in place. Failing
+   * to reach one source must not blank the results, which are still valid.
+   */
+  async function setRecordCountSource(sourceKey: string): Promise<void> {
+    recordCountSourceKey.value = sourceKey
+    try {
+      await loadRecordCounts(sourceKey)
+    } catch (err) {
+      logger.error('ConceptSearchStore', 'Failed to load record counts', err)
+      error.value = 'Failed to load record counts for the selected source.'
     }
   }
 
@@ -200,6 +234,7 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
     allConcepts,
     loading,
     loadingRecordCounts,
+    recordCountSourceKey,
     error,
     page,
     itemsPerPage,
@@ -223,6 +258,7 @@ export const useConceptSearchStore = defineStore('concept-search', () => {
     debouncedSearch,
     updateSort,
     updatePagination,
+    setRecordCountSource,
     clearSearch,
   }
 })

--- a/src/stores/webapi.ts
+++ b/src/stores/webapi.ts
@@ -45,6 +45,15 @@ export const useWebAPIStore = defineStore('webapi', () => {
     return sources.value.filter(s => s.daimons?.some(d => d.daimonType === 'Vocabulary'))
   })
 
+  /**
+   * Sources that can report record and person counts. A vocabulary source
+   * knows the concepts; only a source with a Results daimon knows how often
+   * they occur in that data.
+   */
+  const resultsSources = computed(() => {
+    return sources.value.filter(s => s.daimons?.some(d => d.daimonType === 'Results'))
+  })
+
   /** Returns validated vocabulary source key, auto-correcting invalid localStorage values */
   function getValidVocabularySource(): string | null {
     const storedVocab = localStorage.getItem('selectedVocabulary')
@@ -361,6 +370,7 @@ export const useWebAPIStore = defineStore('webapi', () => {
     isLoadingSources,
     // Getters
     sourcesList,
+    resultsSources,
     currentSource,
     activeJobs,
     vocabularySources,

--- a/tests/unit/components/concepts/ConceptSearch.spec.ts
+++ b/tests/unit/components/concepts/ConceptSearch.spec.ts
@@ -40,6 +40,7 @@ vi.mock('@/stores/webapi', () => ({
     sources: [],
     selectedSource: null,
     vocabularySources: [],
+    resultsSources: [],
   }),
 }))
 

--- a/tests/unit/stores/concept-search.record-count-source.spec.ts
+++ b/tests/unit/stores/concept-search.record-count-source.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useConceptSearchStore } from '@/stores/concept-search'
+import { getConceptRecordCounts, searchConcepts } from '@/services/concept-search.service'
+import type { Concept } from '@/models/concept-set.types'
+
+vi.mock('@/services/concept-search.service', () => ({
+  searchConcepts: vi.fn(),
+  getConceptRecordCounts: vi.fn(),
+}))
+
+vi.mock('@/stores/webapi', () => ({
+  useWebAPIStore: vi.fn(() => ({
+    getValidVocabularySource: () => 'VOCAB',
+    resultsSources: [],
+  })),
+}))
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const concept: Concept = {
+  conceptId: 201826,
+  conceptName: 'Type 2 diabetes mellitus',
+  conceptCode: '44054006',
+  domainId: 'Condition',
+  vocabularyId: 'SNOMED',
+  conceptClassId: 'Clinical Finding',
+  standardConcept: 'S',
+  invalidReason: null,
+}
+
+function counts(recordCount: number) {
+  return new Map([
+    [
+      201826,
+      {
+        recordCount,
+        descendantRecordCount: recordCount * 2,
+        personCount: recordCount,
+        descendantPersonCount: recordCount * 2,
+      },
+    ],
+  ])
+}
+
+/**
+ * The vocabulary knows the concepts; only a Results source knows how often
+ * they occur. ATLAS 2.x lets the two be chosen separately (#228).
+ */
+describe('record count source selection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  async function searched() {
+    (searchConcepts as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: [concept],
+    })
+    ;(getConceptRecordCounts as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(counts(10))
+
+    const store = useConceptSearchStore()
+    await store.search('diabetes')
+    return store
+  }
+
+  it('counts come from the vocabulary source until one is chosen', async () => {
+    const store = await searched()
+
+    expect(store.recordCountSourceKey).toBeNull()
+    expect(getConceptRecordCounts).toHaveBeenCalledWith('VOCAB', [201826])
+    expect(store.allConcepts[0]?.recordCount).toBe(10)
+  })
+
+  it('refetches the counts from the chosen source without re-running the search', async () => {
+    const store = await searched()
+    ;(getConceptRecordCounts as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(counts(99))
+
+    await store.setRecordCountSource('SYNPUF')
+
+    expect(store.recordCountSourceKey).toBe('SYNPUF')
+    expect(getConceptRecordCounts).toHaveBeenLastCalledWith('SYNPUF', [201826])
+    expect(searchConcepts).toHaveBeenCalledTimes(1)
+    expect(store.allConcepts[0]?.recordCount).toBe(99)
+    expect(store.allConcepts[0]?.conceptName).toBe('Type 2 diabetes mellitus')
+  })
+
+  it('keeps the chosen source for the next search', async () => {
+    const store = await searched()
+    await store.setRecordCountSource('SYNPUF')
+    ;(getConceptRecordCounts as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(counts(5))
+
+    await store.search('hypertension')
+
+    expect(getConceptRecordCounts).toHaveBeenLastCalledWith('SYNPUF', [201826])
+  })
+
+  it('keeps the results when the chosen source cannot report counts', async () => {
+    const store = await searched()
+    ;(getConceptRecordCounts as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('no results daimon')
+    )
+
+    await store.setRecordCountSource('BROKEN')
+
+    expect(store.allConcepts).toHaveLength(1)
+    expect(store.allConcepts[0]?.conceptName).toBe('Type 2 diabetes mellitus')
+    expect(store.error).toBe('Failed to load record counts for the selected source.')
+    expect(store.loadingRecordCounts).toBe(false)
+  })
+
+  it('does not call the service when there are no results to annotate', async () => {
+    const store = useConceptSearchStore()
+
+    await store.setRecordCountSource('SYNPUF')
+
+    expect(getConceptRecordCounts).not.toHaveBeenCalled()
+    expect(store.recordCountSourceKey).toBe('SYNPUF')
+  })
+})


### PR DESCRIPTION
## Gap

The concept search table shows record and person counts, but nothing indicates which data source produced them, and there is no way to change it. The counts were fetched from whichever source the vocabulary search itself used.

## What 2.x does

ATLAS 2.x treats the vocabulary and the counts as separate choices. Its search page renders a dropdown above the results:

```html
<span data-bind="text: ko.i18n('search.viewCountMessage', 'View record counts for:')"></span>
<select data-bind="options: resultSources, optionsText: 'sourceName',
                   optionsValue: 'sourceKey', value: currentResultSourceKey,
                   event: { change: refreshRecordCounts }"></select>
```

`resultSources` is the sources that have results and that the user may read, and changing it calls `loadDensity` again over the rows already returned.

## Change

- The store gains a record-count source defaulting to `null`, meaning "follow the vocabulary source". Behaviour is therefore unchanged until the user picks one.
- Choosing a source refreshes the counts **in place** rather than re-running the search, and the choice persists across later searches.
- The list offers only sources carrying a `Results` daimon, added as `resultsSources` on the WebAPI store alongside the existing `vocabularySources`. A vocabulary-only source would just blank the count columns.
- A source that cannot report counts leaves the concepts on screen and surfaces the failure, rather than emptying results that are still valid.

The existing `search.viewCountMessage` locale key is reused, so no new translation is introduced.

## Verification

New `concept-search.record-count-source.spec.ts` covers the default following the vocabulary source, refetching from a chosen source without re-running the search, the choice persisting into the next search, a failing source leaving results intact, and no service call when there is nothing to annotate. Making the search ignore the chosen source fails one case, and swallowing the count failure fails another. Full suite passes: 6658 unit and 1579 component tests.

Fixes #228
