### PR TITLE
Show progress while the concept hierarchy switches between tree and flat

### DIFF
--- a/src/components/concepts/detail/ConceptHierarchyDialog.vue
+++ b/src/components/concepts/detail/ConceptHierarchyDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import {
   AtlasDialog,
@@ -83,6 +83,31 @@ const classFilter = ref<string | null>(null)
 const domainFilter = ref<string | null>(null)
 const vocabularyFilter = ref<string | null>(null)
 const view = ref<'tree' | 'flat'>('tree')
+const switchingView = ref(false)
+
+/**
+ * Switching view re-renders every row, which takes seconds on a concept with
+ * a large subtree and looked like nothing had happened, so the button got
+ * clicked again (#207).
+ *
+ * The yield matters: flipping `view` in the same tick that sets the flag lets
+ * Vue batch both, and the expensive render blocks the frame, so the spinner
+ * never reaches the screen. Handing control back to the event loop first lets
+ * it paint before the work starts.
+ */
+async function setView(next: 'tree' | 'flat') {
+  // The guard is not redundant with the buttons' disabled state: a click can
+  // land in the window between setting the flag and the DOM reflecting it.
+  if (next === view.value || switchingView.value) return
+
+  switchingView.value = true
+  await nextTick()
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  view.value = next
+  await nextTick()
+  switchingView.value = false
+}
 
 const anchorDescendants = computed(() =>
   hierarchy.value.filter(c => c.relationships.some(r => r.relationshipName === 'Has descendant of'))
@@ -391,8 +416,9 @@ const anchorCounts = computed(() => detail.recordCountsBySource.get(props.source
             type="button"
             :class="{ on: view === 'tree' }"
             :aria-pressed="view === 'tree'"
+            :disabled="switchingView"
             data-testid="hierarchy-view-tree"
-            @click="view = 'tree'"
+            @click="setView('tree')"
           >
             {{ t('components.conceptHierarchyDialog.treeView', 'Tree').value }}
           </button>
@@ -400,8 +426,9 @@ const anchorCounts = computed(() => detail.recordCountsBySource.get(props.source
             type="button"
             :class="{ on: view === 'flat' }"
             :aria-pressed="view === 'flat'"
+            :disabled="switchingView"
             data-testid="hierarchy-view-flat"
-            @click="view = 'flat'"
+            @click="setView('flat')"
           >
             {{ t('components.conceptHierarchyDialog.flatView', 'Flat').value }}
           </button>
@@ -426,6 +453,21 @@ const anchorCounts = computed(() => detail.recordCountsBySource.get(props.source
           </tr>
         </thead>
         <tbody>
+          <tr
+            v-if="switchingView"
+            data-testid="hierarchy-view-switching"
+          >
+            <td colspan="8">
+              <AtlasProgressCircular
+                indeterminate
+                size="16"
+              />
+              <span class="view-switching__label">
+                {{ t('components.conceptHierarchyDialog.switchingView', 'Rebuilding the list…').value }}
+              </span>
+            </td>
+          </tr>
+
           <tr class="section-row">
             <td colspan="8">
               {{ t('components.conceptHierarchyDialog.ancestors', 'Ancestors').value }}
@@ -492,7 +534,7 @@ const anchorCounts = computed(() => detail.recordCountsBySource.get(props.source
           </tr>
 
           <template
-            v-for="{ row, depth, key } in treeRows"
+            v-for="{ row, depth, key } in (switchingView ? [] : treeRows)"
             :key="key"
           >
             <ConceptHierarchyRow
@@ -587,6 +629,7 @@ const anchorCounts = computed(() => detail.recordCountsBySource.get(props.source
 .ancestor { opacity: 0.8; }
 .anchor { background: var(--atlas-color-primary-tint); font-weight: 600; }
 .toolbar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
+.view-switching__label { margin-inline-start: 8px; font-size: 12px; }
 .view-toggle button { border: 1px solid rgba(0, 0, 0, 0.25); background: none; padding: 2px 10px; font-size: 12px; }
 .view-toggle button.on { background: var(--atlas-color-primary-tint-strong); font-weight: 600; }
 .dialog-footer { border-top: 1px solid var(--atlas-color-outline); padding-top: 10px; margin-top: 10px; }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1842,6 +1842,7 @@
     "conceptHierarchyDialog": {
       "title": "Hierarchy · {concept}",
       "viewFullHierarchy": "View full hierarchy",
+      "switchingView": "Rebuilding the list…",
       "treeView": "Tree",
       "flatView": "Flat",
       "filterPlaceholder": "Filter by name or code…",

--- a/tests/component/concepts/detail/ConceptHierarchyDialog.spec.ts
+++ b/tests/component/concepts/detail/ConceptHierarchyDialog.spec.ts
@@ -71,6 +71,14 @@ let activeWrapper: VueWrapper | null = null
 // that automatically between tests, so a leftover dialog from a prior test
 // would still satisfy document.querySelector lookups here — track and
 // unmount the wrapper after each test to keep body clean.
+// Switching view yields a macrotask before rebuilding the rows, so the loading
+// row can paint first (#207). Flush that before asserting on the new rows.
+async function flushViewSwitch(wrapper: { vm: { $nextTick: () => Promise<void> } }) {
+  await wrapper.vm.$nextTick()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await wrapper.vm.$nextTick()
+}
+
 function mountDialog(overrides: Partial<{ concept: Concept }> = {}) {
   activeWrapper = mount(ConceptHierarchyDialog, {
     props: { modelValue: true, concept: overrides.concept ?? concept, sourceKey: 'SYNPUF1K' },
@@ -528,7 +536,7 @@ describe('toolbar', () => {
 
     const flat = document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLElement
     flat.click()
-    await wrapper.vm.$nextTick()
+    await flushViewSwitch(wrapper)
 
     const rows = document.querySelectorAll('[data-descendant-row]')
     expect(rows).toHaveLength(
@@ -549,7 +557,7 @@ describe('toolbar', () => {
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
     ;(document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLElement).click()
-    await wrapper.vm.$nextTick()
+    await flushViewSwitch(wrapper)
 
     // 4050872 "Pneumonia due to parasitic infestation" exists only in 443410's
     // own expansion payload, never in the anchor's ancestorAndDescendant
@@ -576,7 +584,7 @@ describe('toolbar', () => {
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
     ;(document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLElement).click()
-    await wrapper.vm.$nextTick()
+    await flushViewSwitch(wrapper)
 
     // 257315 "Bacterial pneumonia" is both a distance-2 descendant in the
     // anchor's own payload and a distance-1 child returned by expanding
@@ -609,7 +617,7 @@ describe('toolbar', () => {
     await new Promise(r => setTimeout(r, 0))
     await wrapper.vm.$nextTick()
     ;(document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLElement).click()
-    await wrapper.vm.$nextTick()
+    await flushViewSwitch(wrapper)
 
     const anchorDescendantIds = new Set(
       PNEUMONIA_ANCESTOR_AND_DESCENDANT.filter(c =>
@@ -634,7 +642,7 @@ describe('toolbar', () => {
     input.dispatchEvent(new Event('input'))
     await wrapper.vm.$nextTick()
     ;(document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLElement).click()
-    await wrapper.vm.$nextTick()
+    await flushViewSwitch(wrapper)
 
     expect(input.value).toBe('Aspiration')
     expect(document.querySelectorAll('[data-descendant-row]')).toHaveLength(1)
@@ -701,5 +709,99 @@ describe('toolbar', () => {
     for (const child of INFECTIVE_PNEUMONIA_CHILDREN.filter(c => c.conceptId !== 4215807)) {
       expect(document.querySelector(`[data-testid="hierarchy-row-${child.conceptId}"]`)).toBeNull()
     }
+  })
+})
+
+describe('view switch feedback (#207)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    ;(getConceptRecordCounts as Mock).mockResolvedValue(new Map())
+    ;(getConceptAncestorAndDescendant as Mock).mockResolvedValue(INFECTIVE_PNEUMONIA_PAYLOAD)
+    useConceptDetailStore().hierarchy = PNEUMONIA_ANCESTOR_AND_DESCENDANT
+  })
+
+  afterEach(() => {
+    activeWrapper?.unmount()
+    activeWrapper = null
+    document.body.innerHTML = ''
+  })
+
+  const tree = () => document.querySelector('[data-testid="hierarchy-view-tree"]') as HTMLButtonElement
+  const flat = () => document.querySelector('[data-testid="hierarchy-view-flat"]') as HTMLButtonElement
+  const spinner = () => document.querySelector('[data-testid="hierarchy-view-switching"]')
+
+  it('shows nothing while the current view is settled', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    expect(spinner()).toBeNull()
+    expect(document.querySelectorAll('[data-descendant-row]').length).toBeGreaterThan(0)
+  })
+
+  // The switch has to reach the screen before the rows are rebuilt, otherwise
+  // the expensive render blocks the frame and the user sees nothing happen.
+  it('paints a loading row before rebuilding the rows', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    flat().click()
+    await wrapper.vm.$nextTick()
+
+    expect(spinner()).not.toBeNull()
+    expect(document.querySelectorAll('[data-descendant-row]')).toHaveLength(0)
+  })
+
+  it('disables both view buttons while the switch is in flight', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    flat().click()
+    await wrapper.vm.$nextTick()
+
+    expect(flat().disabled).toBe(true)
+    expect(tree().disabled).toBe(true)
+  })
+
+  it('clears the loading row and re-enables the buttons once the rows are up', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    flat().click()
+    await flushViewSwitch(wrapper)
+
+    expect(spinner()).toBeNull()
+    expect(flat().disabled).toBe(false)
+    expect(flat().getAttribute('aria-pressed')).toBe('true')
+    expect(document.querySelectorAll('[data-descendant-row]').length).toBeGreaterThan(0)
+  })
+
+  it('ignores a click on the view already showing', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    tree().click()
+    await wrapper.vm.$nextTick()
+
+    expect(spinner()).toBeNull()
+    expect(document.querySelectorAll('[data-descendant-row]').length).toBeGreaterThan(0)
+  })
+
+  // The reporter clicked repeatedly because nothing appeared to happen. The
+  // disabled buttons swallow those extra clicks, so the view still settles on
+  // the one first asked for rather than ping-ponging.
+  it('settles on the first requested view despite rapid repeated clicks', async () => {
+    const wrapper = mountDialog()
+    await wrapper.vm.$nextTick()
+
+    flat().click()
+    await wrapper.vm.$nextTick()
+    flat().click()
+    tree().click()
+    await flushViewSwitch(wrapper)
+
+    expect(spinner()).toBeNull()
+    expect(flat().getAttribute('aria-pressed')).toBe('true')
+    expect(tree().getAttribute('aria-pressed')).toBe('false')
   })
 })


### PR DESCRIPTION
## Problem

Open the hierarchy viewer on a concept with a large subtree (the report used `501700 · RxNorm · 10582 · Drug`) and switch between Tree and Flat. It takes a couple of seconds with no sign anything is happening, so the button gets clicked again.

## Why a flag alone would not have worked

Rebuilding the row list is synchronous. Setting a loading flag in the same tick as the view change lets Vue batch both into a single update, and the expensive render then blocks the frame, so the spinner never reaches the screen. The switch therefore sets the flag, hands control back to the event loop so it can paint, and only then swaps the view:

```ts
switchingView.value = true
await nextTick()
await new Promise(resolve => setTimeout(resolve, 0))

view.value = next
await nextTick()
switchingView.value = false
```

## Change

- While the switch is in flight the rows are held back and a loading row takes their place, so the table is visibly working rather than apparently frozen.
- Both view buttons are disabled for the duration, so the extra clicks the delay used to invite cannot queue up behind it.
- A guard also rejects a re-entrant call, which is not redundant with `disabled`: a click can land in the window between setting the flag and the DOM reflecting it.
- Clicking the view already showing stays a no-op and shows nothing.

## Note on scope

This makes the wait legible, not shorter. Rendering thousands of rows at once is the underlying cost; virtualising the table would be the way to remove it, which is a larger change than this issue asks for.

## Verification

Six new cases cover the settled state, the loading row appearing before the rows are rebuilt, both buttons being disabled mid-switch, everything clearing afterwards, a click on the current view being ignored, and rapid repeated clicks still settling on the view first asked for. Collapsing the yield so the flag and the view change share a tick fails 3 of them.

Existing toolbar tests drove the toggle and asserted on the new rows after a single tick, which no longer covers the deferred swap, so they now go through a helper that flushes it. Full suite passes: 6653 unit and 1585 component tests.

Fixes #207
