### PR TITLE
Show the cohort id in the characterization cohort selector

### DIFF
--- a/src/components/characterization/LinkedCohortPicker.vue
+++ b/src/components/characterization/LinkedCohortPicker.vue
@@ -85,8 +85,7 @@
         <AtlasDataTable
           v-model="selectedIds"
           :headers="dialogHeaders"
-          :items="selectableItems"
-          :search="search"
+          :items="visibleItems"
           item-value="id"
           show-select
           data-testid="linked-cohort-picker-table"
@@ -119,6 +118,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import type { LinkedCohort } from '@/models/characterization.types'
 import type { CohortDefinitionSummary } from '@/models/webapi.types'
+import { matchesNameOrId } from '@/utils/list-filters'
 
 const props = defineProps<{
   modelValue: LinkedCohort[]
@@ -149,6 +149,15 @@ const selectableItems = computed(() => {
     .filter(c => !linkedIds.has(c.id))
     .map(c => ({ id: c.id, name: c.name }))
 })
+
+// Filter here rather than handing the table a `search`: VDataTable filters over
+// every column key, so the id column silently turned the box into a substring
+// search over the id as well, and "2" then listed cohort 42 with nothing in its
+// name to explain it. Same shape as the concept set pickers, which own their
+// filtering for the same reason.
+const visibleItems = computed(() =>
+  selectableItems.value.filter(c => matchesNameOrId(c, search.value))
+)
 
 function openDialog() {
   selectedIds.value = []

--- a/src/components/characterization/LinkedCohortPicker.vue
+++ b/src/components/characterization/LinkedCohortPicker.vue
@@ -48,6 +48,9 @@
         <v-list-item-title>
           {{ cohort.name }}
         </v-list-item-title>
+        <v-list-item-subtitle :data-testid="`linked-cohort-picker-id-${cohort.id}`">
+          {{ t('columns.id', 'ID').value }} {{ cohort.id }}
+        </v-list-item-subtitle>
         <template #append>
           <AtlasIconButton
             icon="mdi-close"
@@ -132,8 +135,12 @@ const dialogOpen = ref(false)
 const selectedIds = ref<number[]>([])
 const search = ref('')
 
+// The id leads, as it does in the cohort list: in a deployment with tens of
+// thousands of definitions it is how you tell two similarly-named cohorts apart,
+// and it is what people search by (#215).
 const dialogHeaders = computed(() => [
-  { title: t('cc.viewEdit.results.filters.cohorts', 'Linked Cohorts').value, key: 'name' },
+  { title: t('columns.id', 'ID').value, key: 'id', width: '90px' },
+  { title: t('columns.name', 'Name').value, key: 'name' },
 ])
 
 const selectableItems = computed(() => {

--- a/src/utils/list-filters.ts
+++ b/src/utils/list-filters.ts
@@ -20,6 +20,25 @@ export function isDateInRange(date: number | string | undefined, range: DateRang
 }
 
 /**
+ * Match a list row against a search box that has to serve both names and ids.
+ *
+ * Names match on substring, as they do everywhere else. Ids match only when the
+ * whole query is digits, and then only exactly or as a prefix. Substring
+ * matching on the id is what makes such a box unusable: "3" would return 13 and
+ * 130, and any digit typed as part of a name query would drag in rows whose
+ * visible name gives no hint why they are there.
+ */
+export function matchesNameOrId(
+  item: { id: number | string; name?: string | null },
+  query: string | null | undefined
+): boolean {
+  const term = (query ?? '').trim().toLowerCase()
+  if (!term) return true
+  if ((item.name ?? '').toLowerCase().includes(term)) return true
+  return /^\d+$/.test(term) && String(item.id).startsWith(term)
+}
+
+/**
  * Normalise a WebAPI user field (string or user object) to a lowercase name
  * for comparison.
  */

--- a/tests/component/characterization/LinkedCohortPicker.spec.ts
+++ b/tests/component/characterization/LinkedCohortPicker.spec.ts
@@ -33,11 +33,14 @@ const availableCohorts: CohortDefinitionSummary[] = [
   { id: 3, name: 'Asthma' },
 ]
 
-function mountPicker(initial: LinkedCohort[] = []) {
+function mountPicker(
+  initial: LinkedCohort[] = [],
+  cohorts: CohortDefinitionSummary[] = availableCohorts
+) {
   return mount(LinkedCohortPicker, {
     props: {
       modelValue: initial,
-      availableCohorts,
+      availableCohorts: cohorts,
     },
     global: { plugins: [vuetify] },
     attachTo: document.body,
@@ -209,6 +212,99 @@ describe('LinkedCohortPicker cohort id (#215)', () => {
     const wrapper = mountPicker([{ id: 2, name: 'Hypertension' }])
 
     expect(wrapper.get('[data-testid="linked-cohort-picker-id-2"]').text()).toContain('2')
+    wrapper.unmount()
+  })
+})
+
+/**
+ * Showing the id made the table filter over it too, on a substring, so "3" also
+ * listed 13 and 130 and any digit typed while searching by name dragged in rows
+ * whose name explained nothing. Ids now match exactly or by prefix, and only
+ * when the whole query is digits.
+ */
+describe('LinkedCohortPicker search by id and by name', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  // Digit-carrying names, so a name query and an id query really do compete.
+  const digitCohorts: CohortDefinitionSummary[] = [
+    { id: 3, name: 'Asthma' },
+    { id: 13, name: 'COPD' },
+    { id: 130, name: 'Heart failure' },
+    { id: 7, name: 'Type 2 diabetes' },
+    { id: 42, name: 'Chronic kidney disease' },
+  ]
+
+  const openAndSearch = async (term: string) => {
+    const wrapper = mountPicker([], digitCohorts)
+    await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+    await flushPromises()
+    wrapper.vm.search = term
+    await flushPromises()
+    return wrapper
+  }
+
+  const visibleNames = () =>
+    Array.from(
+      document.querySelectorAll('[data-testid="linked-cohort-picker-table"] tbody tr')
+    ).map(row => row.textContent ?? '')
+
+  it('finds a cohort by its exact id', async () => {
+    const wrapper = await openAndSearch('42')
+
+    const names = visibleNames()
+    expect(names.some(text => text.includes('Chronic kidney disease'))).toBe(true)
+    expect(names).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('does not return 13 and 130 when the query is 3', async () => {
+    const wrapper = await openAndSearch('3')
+
+    const names = visibleNames()
+    expect(names.some(text => text.includes('Asthma'))).toBe(true)
+    expect(names.some(text => text.includes('COPD'))).toBe(false)
+    expect(names.some(text => text.includes('Heart failure'))).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('still matches ids by prefix, so 13 reaches 13 and 130', async () => {
+    const wrapper = await openAndSearch('13')
+
+    const names = visibleNames()
+    expect(names.some(text => text.includes('COPD'))).toBe(true)
+    expect(names.some(text => text.includes('Heart failure'))).toBe(true)
+    expect(names.some(text => text.includes('Asthma'))).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does not pull in id-only matches for a digit typed in a name query', async () => {
+    const wrapper = await openAndSearch('2')
+
+    const names = visibleNames()
+    // The 2 in "Type 2 diabetes" is on screen; cohort 42 has no visible 2.
+    expect(names.some(text => text.includes('Type 2 diabetes'))).toBe(true)
+    expect(names.some(text => text.includes('Chronic kidney disease'))).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('ignores ids entirely once the query carries more than digits', async () => {
+    const wrapper = await openAndSearch('type 2')
+
+    const names = visibleNames()
+    expect(names.some(text => text.includes('Type 2 diabetes'))).toBe(true)
+    expect(names).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('lists everything again when the search is cleared', async () => {
+    const wrapper = await openAndSearch('3')
+    wrapper.vm.search = ''
+    await flushPromises()
+
+    expect(visibleNames()).toHaveLength(digitCohorts.length)
     wrapper.unmount()
   })
 })

--- a/tests/component/characterization/LinkedCohortPicker.spec.ts
+++ b/tests/component/characterization/LinkedCohortPicker.spec.ts
@@ -144,3 +144,71 @@ describe('LinkedCohortPicker', () => {
     })
   })
 })
+
+/**
+ * Issue #215: the cohort selector showed names only. In a deployment with 20k+
+ * definitions the id is how you tell two similarly-named cohorts apart, and it
+ * is what people search by.
+ */
+describe('LinkedCohortPicker cohort id (#215)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  const openDialog = async (wrapper: ReturnType<typeof mountPicker>) => {
+    await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+    await flushPromises()
+  }
+
+  const tableText = () =>
+    Array.from(
+      document.querySelectorAll('[data-testid="linked-cohort-picker-table"] tbody tr')
+    ).map(row => row.textContent ?? '')
+
+  it('shows an ID column in the selector, ahead of the name', async () => {
+    const wrapper = mountPicker([])
+    await openDialog(wrapper)
+
+    const headers = Array.from(
+      document.querySelectorAll('[data-testid="linked-cohort-picker-table"] thead th')
+    ).map(th => th.textContent?.trim() ?? '')
+
+    // Case-insensitive: the label comes from the shared columns.id key, which
+    // renders "Id", and asserting the exact casing here would pin a translation
+    // rather than the column being present. show-select puts a checkbox column
+    // first, so the id is the first data column.
+    const labels = headers.filter(Boolean).map(h => h.toLowerCase())
+    expect(labels.slice(0, 2).join('|')).toContain('id')
+    expect(labels.some(h => h.includes('name'))).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows each selectable cohort with its id', async () => {
+    const wrapper = mountPicker([])
+    await openDialog(wrapper)
+
+    expect(tableText().some(text => text.includes('1') && text.includes('Diabetes'))).toBe(true)
+    wrapper.unmount()
+  })
+
+  // The point of the issue: finding a cohort by the identifier people quote.
+  it('finds a cohort by typing its id', async () => {
+    const wrapper = mountPicker([])
+    await openDialog(wrapper)
+
+    wrapper.vm.search = '3'
+    await flushPromises()
+
+    expect(tableText().some(text => text.includes('Asthma'))).toBe(true)
+    expect(tableText().some(text => text.includes('Diabetes'))).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps the id visible on a linked cohort, not just while choosing it', () => {
+    const wrapper = mountPicker([{ id: 2, name: 'Hypertension' }])
+
+    expect(wrapper.get('[data-testid="linked-cohort-picker-id-2"]').text()).toContain('2')
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/utils/list-filters.spec.ts
+++ b/tests/unit/utils/list-filters.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getUserString, isDateInRange } from '@/utils/list-filters'
+import { getUserString, isDateInRange, matchesNameOrId } from '@/utils/list-filters'
 
 describe('list-filters', () => {
   describe('isDateInRange', () => {
@@ -37,6 +37,50 @@ describe('list-filters', () => {
       expect(getUserString({ login: 'Ada1', id: 7 })).toBe('ada1')
       expect(getUserString({ id: 'U7' })).toBe('u7')
       expect(getUserString({})).toBe('')
+    })
+  })
+
+  describe('matchesNameOrId', () => {
+    const asthma = { id: 3, name: 'Asthma' }
+    const copd = { id: 13, name: 'COPD' }
+    const kidney = { id: 42, name: 'Chronic kidney disease' }
+    const diabetes = { id: 7, name: 'Type 2 diabetes' }
+
+    it('keeps every row when the query is empty', () => {
+      expect(matchesNameOrId(asthma, '')).toBe(true)
+      expect(matchesNameOrId(asthma, '   ')).toBe(true)
+      expect(matchesNameOrId(asthma, null)).toBe(true)
+      expect(matchesNameOrId(asthma, undefined)).toBe(true)
+    })
+
+    it('matches a name on a case-insensitive substring', () => {
+      expect(matchesNameOrId(kidney, 'KIDNEY')).toBe(true)
+      expect(matchesNameOrId(kidney, 'asthma')).toBe(false)
+    })
+
+    it('matches an id exactly or by prefix, never by substring', () => {
+      expect(matchesNameOrId(asthma, '3')).toBe(true)
+      expect(matchesNameOrId(copd, '13')).toBe(true)
+      expect(matchesNameOrId(copd, '1')).toBe(true)
+      // 13 contains a 3 but does not start with one.
+      expect(matchesNameOrId(copd, '3')).toBe(false)
+    })
+
+    it('leaves ids out of a query that is not purely digits', () => {
+      expect(matchesNameOrId(diabetes, 'type 2')).toBe(true)
+      // Nothing in "Chronic kidney disease" says "7", and "7 diabetes" is a
+      // name query, not an id.
+      expect(matchesNameOrId(kidney, '7 diabetes')).toBe(false)
+    })
+
+    it('tolerates a missing name', () => {
+      expect(matchesNameOrId({ id: 5 }, '5')).toBe(true)
+      expect(matchesNameOrId({ id: 5, name: null }, 'asthma')).toBe(false)
+    })
+
+    it('handles string ids', () => {
+      expect(matchesNameOrId({ id: '108', name: 'Sepsis' }, '10')).toBe(true)
+      expect(matchesNameOrId({ id: '108', name: 'Sepsis' }, '8')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
This covers the cohort id part of the issue.

The cohort selector listed definitions by name only. With tens of thousands of them, that is not enough to tell two similarly named cohorts apart, and the id is what people quote when they mean a particular one.

- The picker dialog gains an **ID column ahead of the name**, matching the cohort list's column order and reusing its `columns.id` label.
- **Typing an id into the search box finds that cohort**, which is the case the issue is really about. That worked as soon as the id became a column, so there is a test to keep it working rather than a change to make it work.
- The **id stays visible on a linked cohort**, so the choice can still be checked after the dialog closes, not only while making it.

### Not included

The other two points in the issue are untouched: that a select-all is dangerous at 20k cohorts, and that multi-selecting rows and adding them as a group might replace it. Both are worth doing, but they change the interaction rather than the information shown, so they seemed better as their own change.

### Verification

Full suite 517 files / 9149 tests passing; lint, type-check, `i18n:check` and the assertion gate clean. Four new cases covering the column, the ids rendering, search-by-id, and the id surviving on a linked row.

