### PR TITLE
feat(theme): show the theme selector by default and start in light mode

### DIFF
--- a/src/components/shared/NavBar.vue
+++ b/src/components/shared/NavBar.vue
@@ -290,7 +290,7 @@ const showFeedbackButton = ref(true)
 const showLanguageSelector = ref(true)
 const showConfigButton = ref(true)
 const showUserMenu = ref(true)
-const showThemeToggle = ref(false)
+const showThemeToggle = ref(true)
 const feedbackUrl = ref('https://forms.office.com/r/2JzrYy1yDP')
 const logoNavigateTo = ref('/')
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,7 +140,7 @@ async function initializeApp() {
   // Resolve and apply the active theme before mount so there is no
   // light-to-dark flash on first paint.
   const themeStore = useThemeStore()
-  themeStore.initialize(defaultThemeMode ?? 'system')
+  themeStore.initialize(defaultThemeMode ?? 'light')
   vuetify.theme.change(themeStore.resolved)
   setChartTheme(themeStore.resolved)
   watch(

--- a/src/models/PluginModels.ts
+++ b/src/models/PluginModels.ts
@@ -114,8 +114,8 @@ export interface PluginManifest {
       landingLogoUrl?: string // Custom landing-page hero logo URL/path (replaces bundled atlas-loading.svg)
       chartColors?: string[] // Categorical chart palette override; multi-series charts cycle through it
       treemapGradient?: string[] // Color-by-value gradient override (light -> dark), used by treemaps
-      defaultMode?: 'light' | 'dark' | 'system' // Theme the deployment starts in
-      enableDarkMode?: boolean // Show the dark-mode toggle in the nav bar (opt-in per deployment; default: false)
+      defaultMode?: 'light' | 'dark' | 'system' // Theme the deployment starts in (default: 'light')
+      enableDarkMode?: boolean // Show the dark-mode toggle in the nav bar (default: true)
     }
     header?: {
       showNavBar?: boolean // Show/hide the entire navigation bar (default: true)

--- a/src/services/PluginConfigService.ts
+++ b/src/services/PluginConfigService.ts
@@ -122,7 +122,7 @@ export class PluginConfigService {
   }
 
   showThemeToggle(): boolean {
-    return this.manifest?.settings?.theme?.enableDarkMode ?? false
+    return this.manifest?.settings?.theme?.enableDarkMode ?? true
   }
 
   getAccentColor(): string | null {

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -30,7 +30,7 @@ export const useThemeStore = defineStore('theme', () => {
     return preference.value
   })
 
-  function initialize(fallback: ThemeMode = 'system') {
+  function initialize(fallback: ThemeMode = 'light') {
     if (initialized) return
     initialized = true
     preference.value = readStored() ?? fallback

--- a/tests/e2e/dark-mode-a11y.spec.ts
+++ b/tests/e2e/dark-mode-a11y.spec.ts
@@ -73,10 +73,8 @@ test.describe('dark mode colour contrast', () => {
       // a loading/error state in CI, so the scan covers different pixels in each
       // environment — the reason this suite passed locally and failed in CI.
       await setupAnalysisListMocks(page)
-      // Dark mode is opt-in per deployment (settings.theme.enableDarkMode,
-      // default false) — patch the manifest response so the toggle this
-      // suite exercises is actually present, without touching the shipped
-      // default in public/config/plugins.json.
+      // Pins settings.theme.enableDarkMode explicitly so the toggle this suite
+      // exercises stays present even if a deployment manifest turns it off.
       await enableDarkModeToggle(page)
       await enableDarkMode(page)
       await page.goto(route.path)

--- a/tests/e2e/dark-mode-visual.spec.ts
+++ b/tests/e2e/dark-mode-visual.spec.ts
@@ -107,10 +107,8 @@ for (const mode of ['light', 'dark'] as const) {
         // and a loading/error state in CI. Applied to every route because it also
         // pins the clock the relative-date cells render against.
         await setupAnalysisListMocks(page)
-        // Dark mode is opt-in per deployment (settings.theme.enableDarkMode,
-        // default false) — patch the manifest response so the toggle this
-        // suite exercises is actually present, without touching the shipped
-        // default in public/config/plugins.json.
+        // Pins settings.theme.enableDarkMode explicitly so the toggle this suite
+        // exercises stays present even if a deployment manifest turns it off.
         await enableDarkModeToggle(page)
         await forceUnauthenticated(page)
         await setTheme(page, mode)

--- a/tests/unit/components/shared/NavBar.spec.ts
+++ b/tests/unit/components/shared/NavBar.spec.ts
@@ -124,7 +124,7 @@ vi.mock('@/services/PluginConfigService', () => ({
     showLanguageSelector: () => true,
     showConfigButton: () => true,
     showUserMenu: () => true,
-    showThemeToggle: vi.fn(() => false),
+    showThemeToggle: vi.fn(() => true),
     getFeedbackUrl: () => 'https://forms.office.com/r/2JzrYy1yDP',
     getLogoNavigateTo: () => '/'
   }
@@ -183,7 +183,7 @@ describe('NavBar', () => {
     vi.mocked(generatePluginMenuItems).mockReturnValue([])
     vi.mocked(usePermissions).mockReturnValue(mockPermissions)
     vi.mocked(usePluginMounts).mockReturnValue({ items: computed(() => []) })
-    vi.mocked(pluginConfigService.showThemeToggle).mockReturnValue(false)
+    vi.mocked(pluginConfigService.showThemeToggle).mockReturnValue(true)
   })
 
   describe('Component Rendering', () => {
@@ -486,16 +486,16 @@ describe('NavBar', () => {
   })
 
   describe('Theme toggle', () => {
-    it('should not render ThemeToggle by default', () => {
+    it('should render ThemeToggle by default', () => {
       const wrapper = mountComponent()
-      expect(wrapper.findComponent({ name: 'ThemeToggle' }).exists()).toBe(false)
+      expect(wrapper.findComponent({ name: 'ThemeToggle' }).exists()).toBe(true)
     })
 
-    it('should render ThemeToggle when enabled by deployment config', async () => {
-      vi.mocked(pluginConfigService.showThemeToggle).mockReturnValue(true)
+    it('should not render ThemeToggle when disabled by deployment config', async () => {
+      vi.mocked(pluginConfigService.showThemeToggle).mockReturnValue(false)
       const wrapper = mountComponent()
       await flushPromises()
-      expect(wrapper.findComponent({ name: 'ThemeToggle' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'ThemeToggle' }).exists()).toBe(false)
     })
   })
 

--- a/tests/unit/services/PluginConfigService.spec.ts
+++ b/tests/unit/services/PluginConfigService.spec.ts
@@ -295,11 +295,11 @@ describe('PluginConfigService', () => {
   })
 
   describe('showThemeToggle', () => {
-    it('should return false before loading (no manifest)', () => {
-      expect(service.showThemeToggle()).toBe(false)
+    it('should return true before loading (no manifest)', () => {
+      expect(service.showThemeToggle()).toBe(true)
     })
 
-    it('should return false when the manifest omits it', async () => {
+    it('should return true when the manifest omits it', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -313,7 +313,7 @@ describe('PluginConfigService', () => {
 
       await service.loadConfig()
 
-      expect(service.showThemeToggle()).toBe(false)
+      expect(service.showThemeToggle()).toBe(true)
     })
 
     it('should return false when explicitly disabled', async () => {
@@ -350,7 +350,7 @@ describe('PluginConfigService', () => {
       expect(service.showThemeToggle()).toBe(true)
     })
 
-    it('should return false when config fails to load and falls back to defaults', async () => {
+    it('should return true when config fails to load and falls back to defaults', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
@@ -359,7 +359,7 @@ describe('PluginConfigService', () => {
 
       await expect(service.loadConfig()).rejects.toThrow('Failed to load plugins.json')
 
-      expect(service.showThemeToggle()).toBe(false)
+      expect(service.showThemeToggle()).toBe(true)
     })
   })
 

--- a/tests/unit/stores/theme.spec.ts
+++ b/tests/unit/stores/theme.spec.ts
@@ -28,39 +28,54 @@ describe('theme store', () => {
     vi.unstubAllGlobals()
   })
 
-  it('defaults to system when nothing is stored', () => {
+  it('defaults to light when nothing is stored', () => {
     mockMatchMedia(false)
     const store = useThemeStore()
     store.initialize()
-    expect(store.preference).toBe('system')
+    expect(store.preference).toBe('light')
+  })
+
+  it('stays light when nothing is stored and the OS prefers dark', () => {
+    mockMatchMedia(true)
+    const store = useThemeStore()
+    store.initialize()
+    expect(store.resolved).toBe('light')
   })
 
   it('resolves system to dark when the OS prefers dark', () => {
     mockMatchMedia(true)
     const store = useThemeStore()
-    store.initialize()
+    store.initialize('system')
     expect(store.resolved).toBe('dark')
   })
 
   it('resolves system to light when the OS prefers light', () => {
     mockMatchMedia(false)
     const store = useThemeStore()
-    store.initialize()
+    store.initialize('system')
     expect(store.resolved).toBe('light')
   })
 
   it('follows a live OS change while the preference is system', () => {
     const media = mockMatchMedia(false)
     const store = useThemeStore()
-    store.initialize()
+    store.initialize('system')
     media.emit(true)
     expect(store.resolved).toBe('dark')
+  })
+
+  it('ignores a live OS change while the default light preference applies', () => {
+    const media = mockMatchMedia(false)
+    const store = useThemeStore()
+    store.initialize()
+    media.emit(true)
+    expect(store.resolved).toBe('light')
   })
 
   it('ignores the OS once an explicit preference is set', () => {
     const media = mockMatchMedia(false)
     const store = useThemeStore()
-    store.initialize()
+    store.initialize('system')
     store.setPreference('dark')
     media.emit(false)
     expect(store.resolved).toBe('dark')
@@ -94,6 +109,15 @@ describe('theme store', () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'neon')
     const store = useThemeStore()
     store.initialize()
+    expect(store.preference).toBe('light')
+  })
+
+  it('restores a stored system preference', () => {
+    mockMatchMedia(true)
+    localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    const store = useThemeStore()
+    store.initialize()
     expect(store.preference).toBe('system')
+    expect(store.resolved).toBe('dark')
   })
 })


### PR DESCRIPTION
## Problem

Dark mode shipped, but two defaults in the deployment-config layer left it in a broken state:

1. **The theme selector never appeared.** `PluginConfigService.showThemeToggle()` resolved `settings.theme.enableDarkMode` to `false` when the key was absent, and neither `src/config/plugins.json` nor `public/config/plugins.json` sets it. The nav toggle was hidden on every deployment.
2. **The OS overrode the intended default.** Bootstrap called `themeStore.initialize(defaultThemeMode ?? 'system')`. With `settings.theme.defaultMode` unset in both manifests, the fallback was `'system'`, which the store resolves against `matchMedia('(prefers-color-scheme: dark)')`. On a dark-configured OS the app opened in dark on first load, with nothing in `localStorage` to override it and no visible selector to change it.

## Changes

- `services/PluginConfigService.ts` — `enableDarkMode ?? true`, so the selector is opt-out per deployment rather than opt-in.
- `main.ts` and `stores/theme.ts` — the fallback preference is `'light'`. The `prefers-color-scheme` query now applies only when `'system'` is chosen explicitly: by the user from the selector, or by a deployment via `theme.defaultMode`.
- `components/shared/NavBar.vue` — `showThemeToggle` starts at `true`, matching the other default-on nav flags, so there is no hide-then-show flicker before `onMounted` reads the manifest.
- `models/PluginModels.ts` — schema doc comments updated to the new defaults.

Both shipped manifests are left untouched, so the code defaults govern out of the box, and a deployment can still set `theme.enableDarkMode: false` or `theme.defaultMode` to get the old behaviour.

## Tests

- New store coverage: OS prefers dark with nothing stored still resolves light; a live OS change does not move the default light preference; a stored `system` preference still round-trips and follows the OS.
- Updated `PluginConfigService` and `NavBar` expectations for the flipped default.
- The dark-mode e2e suites keep pinning `enableDarkMode: true` via the manifest-patch helper so they stay independent of the shipped default; their stale "opt-in, default false" comments are corrected.

Verified with `npm run type-check`, `eslint`, and `vitest run` over `tests/unit/{stores,services,ui,models}` (2745 passed, 4 skipped) and `tests/unit/components/shared` + `tests/component/ui` (298 passed). The Playwright suites were not run locally.
