### PR TITLE
Report characterization generations that failed (#276)

### DIFF
--- a/src/components/characterization/CharacterizationRunMeta.vue
+++ b/src/components/characterization/CharacterizationRunMeta.vue
@@ -47,6 +47,13 @@
         </div>
       </div>
     </div>
+    <div
+      v-if="execution.status === 'FAILED' && execution.exitMessage"
+      class="char-run-meta__error"
+      data-testid="char-run-meta-error"
+    >
+      {{ execution.exitMessage }}
+    </div>
   </AtlasCard>
 </template>
 
@@ -95,4 +102,11 @@ const durationLabel = computed<string>(() => {
   color: rgba(var(--v-theme-on-surface), 0.6);
 }
 .char-run-meta__value { font-size: 0.85rem; font-weight: 500; }
+.char-run-meta__error {
+  margin-top: 12px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: rgb(var(--v-theme-error));
+  word-break: break-word;
+}
 </style>

--- a/src/components/characterization/CharacterizationWorkbench.vue
+++ b/src/components/characterization/CharacterizationWorkbench.vue
@@ -318,9 +318,14 @@ watch(
     }
     await store.loadExecutions(id)
     if (selectedExecutionId.value === null) {
-      const completed = store.executions.find(e => e.status === 'COMPLETED')
-      if (completed) {
-        await router.replace({ query: { ...route.query, run: String(completed.id) } })
+      // Prefer a run with results, but fall back to a failed one rather than
+      // selecting nothing: with only failed runs the workbench would sit on
+      // its empty state and never report that the generation failed.
+      const selectable =
+        store.executions.find(e => e.status === 'COMPLETED') ??
+        store.executions.find(e => e.status === 'FAILED')
+      if (selectable) {
+        await router.replace({ query: { ...route.query, run: String(selectable.id) } })
       }
     }
   },

--- a/src/components/generation/DataSourceRunTable.vue
+++ b/src/components/generation/DataSourceRunTable.vue
@@ -255,8 +255,29 @@ interface Row {
   personCount?: number
 }
 
+function executionId(e: RunTableExecution): number {
+  const id = typeof e.id === 'number' ? e.id : Number(e.id)
+  return Number.isFinite(id) ? id : 0
+}
+
+/**
+ * Newest run first. A run with no startTime has not started yet, so it is the
+ * newest, not the oldest: falling back to 0 sorted a job that died before
+ * recording a start time behind every older run, hiding the failure the user
+ * needs to see. Ids are assigned in creation order and break the tie.
+ */
+function compareRecency(a: RunTableExecution, b: RunTableExecution): number {
+  const aStarted = a.startTime !== undefined
+  const bStarted = b.startTime !== undefined
+  if (aStarted !== bStarted) return aStarted ? 1 : -1
+  if (aStarted && bStarted && a.startTime !== b.startTime) {
+    return b.startTime! - a.startTime!
+  }
+  return executionId(b) - executionId(a)
+}
+
 const latestBySource = computed(() => {
-  const sorted = [...props.executions].sort((a, b) => (b.startTime ?? 0) - (a.startTime ?? 0))
+  const sorted = [...props.executions].sort(compareRecency)
   const map = new Map<string, RunTableExecution>()
   for (const e of sorted) {
     if (!map.has(e.sourceKey)) map.set(e.sourceKey, e)

--- a/src/composables/useCharacterizationResults.ts
+++ b/src/composables/useCharacterizationResults.ts
@@ -34,11 +34,22 @@ export function useCharacterizationResults() {
         getCharacterizationResults(executionId, {}),
       ])
       if (!execResult.success) throw execResult.error
+
+      // Keep the execution even when the result queries fail. A run that
+      // failed has no results to fetch, so treating that as a total failure
+      // discarded the one object carrying the reason and left the UI showing
+      // "no runs" instead of the failure.
+      execution.value = execResult.data
+
+      if (execResult.data.status === 'FAILED') {
+        error.value = execResult.data.exitMessage || 'Generation failed'
+        return false
+      }
+
       if (!countResult.success) throw countResult.error
       if (!resultsResult.success) throw resultsResult.error
 
       const mapped = mapCharacterizationResults(resultsResult.data)
-      execution.value = execResult.data
       resultCount.value = countResult.data
       prevalence.value = mapped.prevalence
       distribution.value = mapped.distribution

--- a/tests/component/generation/DataSourceRunTable.spec.ts
+++ b/tests/component/generation/DataSourceRunTable.spec.ts
@@ -235,4 +235,45 @@ describe('DataSourceRunTable extensions', () => {
     const mdcrBtn = w.find('[data-testid="run-btn-MDCR"]')
     expect(mdcrBtn.text()).not.toMatch(/Cancel/i)
   })
+
+  /**
+   * Regression: OHDSI/Atlas3#276. A job that dies at startup never records a
+   * startTime. Treating that as time zero sorted it behind every older run,
+   * so the row kept showing the previous success and the failure vanished.
+   */
+  describe('latest run per source (Atlas3#276)', () => {
+    function ccaeStatus(w: ReturnType<typeof mountTable>) {
+      return w.findAll('tbody tr')[0]!.text()
+    }
+
+    it('prefers a failed run with no start time over an older success', () => {
+      const w = mountTable({
+        executions: [
+          exec({ id: 1, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 1_000 }),
+          exec({ id: 2, sourceKey: 'CCAE', status: 'FAILED', startTime: undefined }),
+        ],
+      })
+      expect(ccaeStatus(w)).toContain('FAILED')
+    })
+
+    it('still prefers the most recent run when both have start times', () => {
+      const w = mountTable({
+        executions: [
+          exec({ id: 1, sourceKey: 'CCAE', status: 'FAILED', startTime: 1_000 }),
+          exec({ id: 2, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 2_000 }),
+        ],
+      })
+      expect(ccaeStatus(w)).toContain('COMPLETED')
+    })
+
+    it('breaks a tie between two unstarted runs on the newer id', () => {
+      const w = mountTable({
+        executions: [
+          exec({ id: 5, sourceKey: 'CCAE', status: 'FAILED', startTime: undefined }),
+          exec({ id: 9, sourceKey: 'CCAE', status: 'PENDING', startTime: undefined }),
+        ],
+      })
+      expect(ccaeStatus(w)).toContain('PENDING')
+    })
+  })
 })

--- a/tests/unit/composables/useCharacterizationResults.spec.ts
+++ b/tests/unit/composables/useCharacterizationResults.spec.ts
@@ -80,4 +80,58 @@ describe('useCharacterizationResults', () => {
     expect(ok).toBe(false)
     expect(r.error.value).toBe('boom')
   })
+
+  /**
+   * Regression: OHDSI/Atlas3#276. A failed run has no results, so the count
+   * and result queries fail too. Discarding the execution alongside them threw
+   * away the only object saying the generation failed, and the workbench fell
+   * back to "no runs".
+   */
+  describe('failed generations (Atlas3#276)', () => {
+    const failedExec = {
+      id: 92,
+      sourceKey: 'SYNPUF5PCT',
+      status: 'FAILED',
+      startTime: 0,
+      executionDuration: 0,
+      exitMessage: 'permission denied for schema synpuf5pct_results_v3',
+    }
+
+    beforeEach(() => {
+      mockExec.mockResolvedValue(success(failedExec as any))
+      mockCount.mockResolvedValue(failure(new ApiError('no results', 500, null)))
+      mockResults.mockResolvedValue(failure(new ApiError('no results', 500, null)))
+    })
+
+    it('keeps the execution even though the result queries failed', async () => {
+      const r = useCharacterizationResults()
+      const ok = await r.load(92)
+
+      expect(ok).toBe(false)
+      expect(r.execution.value).not.toBeNull()
+      expect(r.execution.value!.status).toBe('FAILED')
+      expect(r.execution.value!.id).toBe(92)
+    })
+
+    it('surfaces the reason the job gave', async () => {
+      const r = useCharacterizationResults()
+      await r.load(92)
+      expect(r.error.value).toBe('permission denied for schema synpuf5pct_results_v3')
+    })
+
+    it('falls back to a generic reason when the job gave none', async () => {
+      mockExec.mockResolvedValue(success({ ...failedExec, exitMessage: undefined } as any))
+      const r = useCharacterizationResults()
+      await r.load(92)
+      expect(r.error.value).toBe('Generation failed')
+    })
+
+    it('still reports a genuine fetch failure on a run that did not fail', async () => {
+      mockExec.mockResolvedValue(success({ ...failedExec, status: 'COMPLETED' } as any))
+      const r = useCharacterizationResults()
+      const ok = await r.load(92)
+      expect(ok).toBe(false)
+      expect(r.error.value).toBe('no results')
+    })
+  })
 })


### PR DESCRIPTION
## Problem

A characterization generation that fails does not appear in the generation status at all. After starting a run that then fails, the page reports that no runs have started, even though the server recorded the failed execution.

## Cause

Loading a run fetched the execution, its result count and its results together, and discarded all three if any one of them failed. A failed run has no results, so those queries fail with it — taking the execution down with them. The execution is the only object that says the run failed, so every failed run disappeared and the view fell back to showing none.

Two related problems sat behind that: runs were ordered by start date, so a job that died before recording one sorted as the oldest run for its source rather than the newest; and the exit message returned by the server was never displayed.

## What changes

Failed runs now appear in the generation status with the reason the job reported. When there is no completed run for a source, the failed one is selected rather than nothing. A job that never recorded a start time is treated as the most recent run for its source, and the server's exit message is shown alongside it.

Fixes #276