### PR TITLE
Stop feature analysis presets being opened, copied or deleted (#265)

### DIFF
--- a/src/components/analysis/AnalysisDataTable.vue
+++ b/src/components/analysis/AnalysisDataTable.vue
@@ -12,6 +12,7 @@
     <template #[`item.${nameKey}`]="{ item }">
       <div class="analysis-data-table__name-cell">
         <a
+          v-if="canOpenItem(item)"
           href="#"
           class="analysis-data-table__name-link"
           :data-testid="testid ? `${testid}-row-name` : undefined"
@@ -19,6 +20,13 @@
         >
           {{ getName(item) }}
         </a>
+        <span
+          v-else
+          class="analysis-data-table__name-static"
+          :data-testid="testid ? `${testid}-row-name` : undefined"
+        >
+          {{ getName(item) }}
+        </span>
         <div
           v-if="hasTags(item)"
           class="analysis-data-table__tag-rail"
@@ -69,6 +77,7 @@
     <template #[`item.actions`]="{ item }">
       <div class="analysis-data-table__row-actions">
         <AtlasIconButton
+          v-if="canOpenItem(item)"
           icon="mdi-pencil"
           v-bind="{ ariaLabel: t('configuration.tagManagement.edit', 'Edit').value }"
           variant="text"
@@ -164,6 +173,12 @@ interface Props {
    */
   canCopyItem?: (item: T) => boolean
   canDeleteItem?: (item: T) => boolean
+  /**
+   * Whether a row can be opened in an editor. Rows that cannot render their
+   * name as plain text and drop the edit action, so a read-only row such as a
+   * feature analysis preset does not invite a click that goes nowhere.
+   */
+  canOpenItem?: (item: T) => boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -178,6 +193,7 @@ const props = withDefaults(defineProps<Props>(), {
   descriptionLimit: 80,
   canCopyItem: () => () => true,
   canDeleteItem: () => () => true,
+  canOpenItem: () => () => true,
 })
 
 defineEmits<{
@@ -304,6 +320,11 @@ function formatUser(user: unknown): string {
 
 .analysis-data-table__name-link:hover {
   text-decoration: underline;
+}
+
+.analysis-data-table__name-static {
+  color: var(--atlas-color-on-surface);
+  font-weight: 500;
 }
 
 .analysis-data-table__tag-rail {

--- a/src/views/FeatureAnalysesView.vue
+++ b/src/views/FeatureAnalysesView.vue
@@ -37,8 +37,9 @@
       :items-per-page="itemsPerPage"
       :empty-text="t('common.noData', 'No feature analyses yet.').value"
       testid="feature-analyses-table"
-      :can-copy-item="item => canCopy && !!item.id"
-      :can-delete-item="item => entityAccess.canDelete(item.id)"
+      :can-open-item="item => !isPreset(item)"
+      :can-copy-item="item => !isPreset(item) && canCopy && !!item.id"
+      :can-delete-item="item => !isPreset(item) && entityAccess.canDelete(item.id)"
       @open="handleOpen"
       @copy="handleCopy"
       @delete="handleDeleteClick"
@@ -181,11 +182,22 @@ function handleCreate() {
   router.push('/feature-analyses/new')
 }
 
+/**
+ * Built-in PRESET feature analyses are shipped with WebAPI and are shared by
+ * every characterization, so they are read-only: they cannot be opened in the
+ * editor, copied or deleted. See OHDSI/Atlas3#265.
+ */
+function isPreset(item: FeatureAnalysisListItem): boolean {
+  return item.type === 'PRESET'
+}
+
 function handleOpen(item: FeatureAnalysisListItem) {
+  if (isPreset(item)) return
   router.push(`/feature-analyses/${item.id}`)
 }
 
 async function handleCopy(item: FeatureAnalysisListItem) {
+  if (isPreset(item)) return
   const copied = await store.copy(item.id)
   if (copied?.id) {
     router.push(`/feature-analyses/${copied.id}`)
@@ -193,6 +205,7 @@ async function handleCopy(item: FeatureAnalysisListItem) {
 }
 
 function handleDeleteClick(item: FeatureAnalysisListItem) {
+  if (isPreset(item)) return
   selectedFA.value = item
   showDeleteDialog.value = true
 }

--- a/tests/unit/views/FeatureAnalysesView.presets.spec.ts
+++ b/tests/unit/views/FeatureAnalysesView.presets.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * FeatureAnalysesView — PRESET rows are read-only (OHDSI/Atlas3#265)
+ *
+ * Built-in PRESET feature analyses ship with WebAPI and are shared by every
+ * characterization, so the list must not offer to open, copy or delete them.
+ * Non-PRESET rows (CRITERIA_SET / CUSTOM_FE) keep all three actions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { setActivePinia, createPinia } from 'pinia'
+import { createRouter, createMemoryHistory, type Router } from 'vue-router'
+
+import type { FeatureAnalysisListItem } from '@/models/feature-analysis.types'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+vi.mock('@/services/feature-analysis.service', () => ({
+  listFeatureAnalyses: vi.fn(),
+  getFeatureAnalysis: vi.fn(),
+  createFeatureAnalysis: vi.fn(),
+  updateFeatureAnalysis: vi.fn(),
+  deleteFeatureAnalysis: vi.fn(),
+  copyFeatureAnalysis: vi.fn(),
+  listFeatureAnalysisDomains: vi.fn(),
+  listFeatureAnalysisAggregates: vi.fn(),
+}))
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { listFeatureAnalyses, copyFeatureAnalysis } from '@/services/feature-analysis.service'
+import { success } from '@/types/api'
+import FeatureAnalysesView from '@/views/FeatureAnalysesView.vue'
+import AnalysisDataTable from '@/components/analysis/AnalysisDataTable.vue'
+import { useAuthStore } from '@/stores/auth'
+import { emptyEntityAccess } from '@/models/auth.types'
+
+const vuetify = createVuetify({ components, directives })
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+const PRESET_ROW: FeatureAnalysisListItem = {
+  id: 1,
+  name: 'Demographics Gender',
+  type: 'PRESET',
+  domain: 'Demographics',
+  statType: 'PREVALENCE',
+  createdBy: { login: 'system', name: 'System' },
+  createdDate: 1737000000000,
+  modifiedDate: 1737500000000,
+}
+
+const CRITERIA_ROW: FeatureAnalysisListItem = {
+  id: 2,
+  name: 'Conditions Criteria',
+  type: 'CRITERIA_SET',
+  domain: 'Condition',
+  statType: 'PREVALENCE',
+  createdBy: 'ohdsi',
+  createdDate: 1737100000000,
+  modifiedDate: 1737200000000,
+}
+
+const sampleList: FeatureAnalysisListItem[] = [PRESET_ROW, CRITERIA_ROW]
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/analysis/feature-analyses',
+        name: 'feature-analyses',
+        component: { template: '<div />' },
+      },
+      { path: '/feature-analyses', redirect: { name: 'feature-analyses' } },
+      { path: '/feature-analyses/new', name: 'feature-analysis-new', component: { template: '<div />' } },
+      { path: '/feature-analyses/:id', name: 'feature-analysis-edit', component: { template: '<div />' } },
+    ],
+  })
+}
+
+async function mountView() {
+  const router = makeRouter()
+  await router.push('/feature-analyses')
+  await router.isReady()
+
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const authStore = useAuthStore()
+  // Full rights: the only thing that may block an action is the PRESET rule.
+  authStore.setUser({
+    login: 'tester',
+    displayName: 'tester',
+    permissionIdx: {
+      create: ['create:feature-analysis'],
+      read: ['read:feature-analysis'],
+      write: ['write:feature-analysis'],
+      delete: ['delete:feature-analysis'],
+    },
+    entityAccess: emptyEntityAccess(),
+  })
+
+  const wrapper = mount(FeatureAnalysesView, {
+    global: { plugins: [vuetify, pinia, router] },
+  })
+
+  await flushPromises()
+  return { wrapper, router }
+}
+
+type Wrapper = Awaited<ReturnType<typeof mountView>>['wrapper']
+
+/** Locate the `<tr>` whose text contains the given analysis name. */
+function rowFor(wrapper: Wrapper, name: string) {
+  const row = wrapper.findAll('tbody tr').find(tr => tr.text().includes(name))
+  if (!row) throw new Error(`No table row found for "${name}"`)
+  return row
+}
+
+function actionButton(wrapper: Wrapper, name: string, ariaLabel: string) {
+  const btn = rowFor(wrapper, name).find(`button[aria-label="${ariaLabel}"]`)
+  if (!btn.exists()) throw new Error(`No "${ariaLabel}" button in row "${name}"`)
+  return btn
+}
+
+/** Wait out router.push()'s own microtask/macrotask chain. */
+async function settle() {
+  await flushPromises()
+  await new Promise<void>(resolve => setTimeout(resolve, 0))
+  await flushPromises()
+}
+
+describe('FeatureAnalysesView — PRESET rows are read-only', () => {
+  let mounted: Awaited<ReturnType<typeof mountView>> | null = null
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+  })
+
+  afterEach(() => {
+    mounted?.wrapper.unmount()
+    mounted = null
+  })
+
+  it('renders a PRESET name as plain text, with no link to click', async () => {
+    mounted = await mountView()
+    const { wrapper } = mounted
+
+    const presetRow = rowFor(wrapper, 'Demographics Gender')
+    expect(presetRow.find('a').exists()).toBe(false)
+    expect(presetRow.get('.analysis-data-table__name-static').text()).toBe('Demographics Gender')
+
+    // The editable row alongside it still offers the link.
+    expect(rowFor(wrapper, 'Conditions Criteria').find('a').exists()).toBe(true)
+  })
+
+  it('ignores an open event raised for a PRESET row', async () => {
+    mounted = await mountView()
+    const { wrapper, router } = mounted
+    const startPath = router.currentRoute.value.path
+
+    wrapper.findComponent(AnalysisDataTable).vm.$emit('open', PRESET_ROW)
+    await settle()
+
+    expect(router.currentRoute.value.path).toBe(startPath)
+  })
+
+  it('disables copy and delete on a PRESET row', async () => {
+    mounted = await mountView()
+    const { wrapper } = mounted
+
+    expect(actionButton(wrapper, 'Demographics Gender', 'Copy').attributes('disabled')).toBeDefined()
+    expect(actionButton(wrapper, 'Demographics Gender', 'Delete').attributes('disabled')).toBeDefined()
+  })
+
+  it('ignores copy and delete events raised for a PRESET row', async () => {
+    mounted = await mountView()
+    const { wrapper } = mounted
+    const table = wrapper.findComponent(AnalysisDataTable)
+
+    table.vm.$emit('copy', PRESET_ROW)
+    table.vm.$emit('delete', PRESET_ROW)
+    await settle()
+
+    expect(vi.mocked(copyFeatureAnalysis)).not.toHaveBeenCalled()
+    // The delete confirmation dialog must not have opened.
+    expect(wrapper.text()).not.toContain('Delete feature analysis')
+  })
+
+  it('still opens the editor for a CRITERIA_SET row', async () => {
+    mounted = await mountView()
+    const { wrapper, router } = mounted
+
+    await rowFor(wrapper, 'Conditions Criteria').get('a').trigger('click')
+    await settle()
+
+    expect(router.currentRoute.value.path).toBe('/feature-analyses/2')
+  })
+
+  it('still enables copy and delete on a CRITERIA_SET row', async () => {
+    mounted = await mountView()
+    const { wrapper } = mounted
+
+    expect(actionButton(wrapper, 'Conditions Criteria', 'Copy').attributes('disabled')).toBeUndefined()
+    expect(actionButton(wrapper, 'Conditions Criteria', 'Delete').attributes('disabled')).toBeUndefined()
+  })
+
+  it('still opens the delete dialog for a CRITERIA_SET row', async () => {
+    mounted = await mountView()
+    const { wrapper } = mounted
+
+    await actionButton(wrapper, 'Conditions Criteria', 'Delete').trigger('click')
+    await settle()
+
+    expect(document.body.textContent).toContain('Conditions Criteria')
+  })
+})


### PR DESCRIPTION
## Problem

Built-in `PRESET` feature analyses appear in the Feature Analysis list as ordinary rows. Clicking one opens the full design editor, and the row offers copy and delete alongside it. Presets are shipped with WebAPI and are not yours to change, so presenting them as editable entities is misleading — even where permissions would refuse the write.

## What changes

Preset rows are now read-only. The name is plain text rather than a link, and the edit, copy and delete actions are not offered, so the row no longer invites a click that goes nowhere. Rows for your own feature analyses are unchanged.

Fixes #265