### PR TITLE
Let the cohort and analysis lists be sorted by column (#263)

### DIFF
--- a/src/components/analysis/AnalysisDataTable.vue
+++ b/src/components/analysis/AnalysisDataTable.vue
@@ -1,10 +1,10 @@
 <template>
   <AtlasDataTable
+    v-model:sort-by="sortByModel"
     :headers="headers"
     :items="items"
     :loading="loading"
     :items-per-page="itemsPerPage"
-    :sort-by="sortBy"
     hide-default-footer
     class="analysis-data-table"
     :data-testid="testid"
@@ -138,7 +138,7 @@
 
 <script setup lang="ts" generic="T extends { id?: number }">
 import { AtlasChip, AtlasDataTable, AtlasIcon, AtlasIconButton, AtlasSkeleton } from '@/components/ui'
-import { computed, useSlots } from 'vue'
+import { computed, ref, useSlots, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import { formatDate, formatRelativeTime } from '@/utils/date-format'
 import { tagColor, tagContrastColor } from '@/utils/tag-color'
@@ -188,6 +188,19 @@ defineEmits<{
 
 const { t } = useI18n()
 const slots = useSlots()
+
+/**
+ * `sortBy` is the column the list opens on, not a fixed order. Passing it
+ * straight down pinned the table to that value, so header clicks were
+ * emitted and discarded and every analysis list was stuck on last-modified.
+ */
+const sortByModel = ref<{ key: string; order: 'asc' | 'desc' }[]>([...props.sortBy])
+watch(
+  () => props.sortBy,
+  v => {
+    sortByModel.value = [...v]
+  }
+)
 
 // Forward any item.<key> or other custom slots that the consumer passed
 // in but that we don't render ourselves.

--- a/src/components/cohort/CohortTable.vue
+++ b/src/components/cohort/CohortTable.vue
@@ -77,30 +77,105 @@
       >
         <thead>
           <tr>
-            <th class="cohort-table__col-id">
-              {{ t('columns.id', 'ID').value }}
+            <th
+              class="cohort-table__col-id"
+              :aria-sort="ariaSort('id')"
+            >
+              <button
+                type="button"
+                class="cohort-table__sort"
+                data-testid="cohort-table-sort-id"
+                @click="toggleSort('id')"
+              >
+                {{ t('columns.id', 'ID').value }}
+                <AtlasIcon
+                  v-if="sortKey === 'id'"
+                  :icon="sortIcon"
+                  size="xs"
+                />
+              </button>
             </th>
-            <th class="cohort-table__col-name">
-              {{ t('columns.name', 'Name').value }}
+            <th
+              class="cohort-table__col-name"
+              :aria-sort="ariaSort('name')"
+            >
+              <button
+                type="button"
+                class="cohort-table__sort"
+                data-testid="cohort-table-sort-name"
+                @click="toggleSort('name')"
+              >
+                {{ t('columns.name', 'Name').value }}
+                <AtlasIcon
+                  v-if="sortKey === 'name'"
+                  :icon="sortIcon"
+                  size="xs"
+                />
+              </button>
             </th>
             <th class="cohort-table__col-tags">
               {{ t('common.tags', 'Tags').value }}
             </th>
-            <th class="cohort-table__col-author">
-              {{ t('columns.author', 'Author').value }}
+            <th
+              class="cohort-table__col-author"
+              :aria-sort="ariaSort('createdBy')"
+            >
+              <button
+                type="button"
+                class="cohort-table__sort"
+                data-testid="cohort-table-sort-author"
+                @click="toggleSort('createdBy')"
+              >
+                {{ t('columns.author', 'Author').value }}
+                <AtlasIcon
+                  v-if="sortKey === 'createdBy'"
+                  :icon="sortIcon"
+                  size="xs"
+                />
+              </button>
             </th>
-            <th class="cohort-table__col-date">
-              {{ t('columns.created', 'Created').value }}
+            <th
+              class="cohort-table__col-date"
+              :aria-sort="ariaSort('createdDate')"
+            >
+              <button
+                type="button"
+                class="cohort-table__sort"
+                data-testid="cohort-table-sort-created"
+                @click="toggleSort('createdDate')"
+              >
+                {{ t('columns.created', 'Created').value }}
+                <AtlasIcon
+                  v-if="sortKey === 'createdDate'"
+                  :icon="sortIcon"
+                  size="xs"
+                />
+              </button>
             </th>
-            <th class="cohort-table__col-date">
-              {{ t('columns.modified', 'Modified').value }}
+            <th
+              class="cohort-table__col-date"
+              :aria-sort="ariaSort('modifiedDate')"
+            >
+              <button
+                type="button"
+                class="cohort-table__sort"
+                data-testid="cohort-table-sort-modified"
+                @click="toggleSort('modifiedDate')"
+              >
+                {{ t('columns.updated', 'Updated').value }}
+                <AtlasIcon
+                  v-if="sortKey === 'modifiedDate'"
+                  :icon="sortIcon"
+                  size="xs"
+                />
+              </button>
             </th>
             <th class="cohort-table__col-actions" />
           </tr>
         </thead>
         <tbody>
           <tr
-            v-for="cohort in cohorts"
+            v-for="cohort in sortedCohorts"
             :key="cohort.id"
             class="cohort-table__row"
             data-testid="cohort-table-row"
@@ -192,7 +267,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from '@/composables/useI18n'
 import { useEntityAccessFor } from '@/composables/useEntityAccess'
@@ -232,6 +307,56 @@ defineEmits<{
   'tag-click': [tagName: string]
   'show-info': [cohort: CohortDefinitionSummary]
 }>()
+
+type SortKey = 'id' | 'name' | 'createdBy' | 'createdDate' | 'modifiedDate'
+
+// Opens on most recently modified, matching the concept set list.
+const sortKey = ref<SortKey>('modifiedDate')
+const sortOrder = ref<'asc' | 'desc'>('desc')
+
+const sortIcon = computed(() => (sortOrder.value === 'asc' ? 'mdi-arrow-up' : 'mdi-arrow-down'))
+
+function ariaSort(key: SortKey): 'ascending' | 'descending' | 'none' {
+  if (sortKey.value !== key) return 'none'
+  return sortOrder.value === 'asc' ? 'ascending' : 'descending'
+}
+
+function toggleSort(key: SortKey) {
+  if (sortKey.value === key) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+    return
+  }
+  sortKey.value = key
+  // Names read best A to Z; ids and dates most useful newest first.
+  sortOrder.value = key === 'name' || key === 'createdBy' ? 'asc' : 'desc'
+}
+
+function sortValue(cohort: CohortDefinitionSummary, key: SortKey): string | number {
+  switch (key) {
+    case 'id':
+      return cohort.id ?? 0
+    case 'name':
+      return (cohort.name ?? '').toLowerCase()
+    case 'createdBy':
+      return formatUser(cohort.createdBy).toLowerCase()
+    case 'createdDate':
+      return cohort.createdDate ? new Date(cohort.createdDate).getTime() : 0
+    case 'modifiedDate':
+      return cohort.modifiedDate ? new Date(cohort.modifiedDate).getTime() : 0
+  }
+}
+
+const sortedCohorts = computed(() => {
+  const key = sortKey.value
+  const direction = sortOrder.value === 'asc' ? 1 : -1
+  // Copy first: the prop array belongs to the caller.
+  return [...props.cohorts].sort((a, b) => {
+    const left = sortValue(a, key)
+    const right = sortValue(b, key)
+    if (left === right) return 0
+    return left > right ? direction : -direction
+  })
+})
 
 const isFiltered = computed(
   () => Boolean(props.searchQuery) || (props.selectedTags?.length ?? 0) > 0
@@ -285,6 +410,24 @@ function openCohort(cohort: CohortDefinitionSummary) {
 <style scoped>
 .cohort-table__grid {
   background: rgb(var(--v-theme-surface));
+}
+.cohort-table__sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+.cohort-table__sort:hover {
+  color: var(--atlas-color-on-surface);
+}
+.cohort-table__sort:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
 }
 .cohort-table__row {
   cursor: pointer;

--- a/tests/component/cohort/CohortTable.spec.ts
+++ b/tests/component/cohort/CohortTable.spec.ts
@@ -151,4 +151,88 @@ describe('CohortTable', () => {
     await wrapper.find('[data-testid=cohort-table-row]').trigger('click')
     expect(push).toHaveBeenCalledWith('/cohorts/1')
   })
+
+  /** Regression: OHDSI/Atlas3#263 — the headers were inert text. */
+  describe('column sorting (Atlas3#263)', () => {
+    const rows: CohortDefinitionSummary[] = [
+      {
+        id: 3,
+        name: 'Zoledronic acid',
+        createdBy: { name: 'carol' },
+        createdDate: '2026-03-01T00:00:00Z',
+        modifiedDate: '2026-03-02T00:00:00Z',
+      },
+      {
+        id: 1,
+        name: 'Aspirin',
+        createdBy: { name: 'alice' },
+        createdDate: '2026-01-01T00:00:00Z',
+        modifiedDate: '2026-05-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        name: 'metformin',
+        createdBy: { name: 'bob' },
+        createdDate: '2026-02-01T00:00:00Z',
+        modifiedDate: '2026-04-01T00:00:00Z',
+      },
+    ] as never
+
+    function names(wrapper: ReturnType<typeof makeWrapper>) {
+      return wrapper
+        .findAll('[data-testid=cohort-table-row]')
+        .map(r => r.findAll('td')[1]!.text().split('\n')[0]!.trim())
+    }
+
+    it('opens on most recently modified, like the concept set list', () => {
+      expect(names(makeWrapper({ cohorts: rows }))).toEqual([
+        'Aspirin',
+        'metformin',
+        'Zoledronic acid',
+      ])
+    })
+
+    it('sorts by id, and reverses on a second click', async () => {
+      const wrapper = makeWrapper({ cohorts: rows })
+
+      await wrapper.find('[data-testid=cohort-table-sort-id]').trigger('click')
+      expect(names(wrapper)).toEqual(['Zoledronic acid', 'metformin', 'Aspirin'])
+
+      await wrapper.find('[data-testid=cohort-table-sort-id]').trigger('click')
+      expect(names(wrapper)).toEqual(['Aspirin', 'metformin', 'Zoledronic acid'])
+    })
+
+    it('sorts by name case-insensitively, ascending first', async () => {
+      const wrapper = makeWrapper({ cohorts: rows })
+
+      await wrapper.find('[data-testid=cohort-table-sort-name]').trigger('click')
+      expect(names(wrapper)).toEqual(['Aspirin', 'metformin', 'Zoledronic acid'])
+    })
+
+    it('sorts by author and by created date', async () => {
+      const wrapper = makeWrapper({ cohorts: rows })
+
+      await wrapper.find('[data-testid=cohort-table-sort-author]').trigger('click')
+      expect(names(wrapper)).toEqual(['Aspirin', 'metformin', 'Zoledronic acid'])
+
+      await wrapper.find('[data-testid=cohort-table-sort-created]').trigger('click')
+      expect(names(wrapper)).toEqual(['Zoledronic acid', 'metformin', 'Aspirin'])
+    })
+
+    it('reports the active sort to assistive technology', async () => {
+      const wrapper = makeWrapper({ cohorts: rows })
+
+      await wrapper.find('[data-testid=cohort-table-sort-name]').trigger('click')
+
+      const headers = wrapper.findAll('th')
+      expect(headers[1]!.attributes('aria-sort')).toBe('ascending')
+      expect(headers[0]!.attributes('aria-sort')).toBe('none')
+    })
+
+    it('does not reorder the array it was given', () => {
+      const given = [...rows]
+      makeWrapper({ cohorts: given })
+      expect(given.map(c => c.id)).toEqual([3, 1, 2])
+    })
+  })
 })


### PR DESCRIPTION
## Problem

The concept set list can be sorted by clicking a column header. The cohort definition list cannot (#263).

The four analysis lists have the opposite problem: their headers look sortable and react to a click, but the order never actually changes.

## Cause

Two different causes behind the same symptom. The cohort list is a hand-written table whose headers were plain text, so there was nothing to click. The analysis lists did emit the user's choice, but the sort order was fixed by the caller and the choice was discarded, leaving every list pinned to last-modified.

## What changes

The cohort definition list can now be sorted by ID, name, author, created and updated, and opens on most recently updated so it behaves like the concept set list. The sort order is announced to screen readers as well as shown.

Clicking a header in the analysis lists now re-sorts them.

The cohort list's "Modified" column is relabelled "Updated" — the name ATLAS 2.x used, and the one the concept set list already uses.

Fixes #263
Refs #273 — this covers the column-label inconsistency and makes the existing analysis columns sortable. Adding the missing ID column to the analysis search screens is not part of this change.