### PR TITLE
Enable save and delete on a freshly created entity (#274, #268)

### DIFF
--- a/src/services/auth/entityOwnership.ts
+++ b/src/services/auth/entityOwnership.ts
@@ -2,24 +2,39 @@ import type { EntityAccessKind } from '@/models/auth.types'
 import { logger } from '@/utils/logger'
 
 /**
- * Grant the current user ownership of an entity that was just created.
+ * Bring client-side permissions back in step after the user created an entity.
  *
- * WebAPI only reports per-entity grants through `/user/me`, which the client
- * fetches at startup. A POST that succeeds means the server accepted the user
- * as the creator, so the grant is recorded locally rather than making the user
- * reload the page before they can save or delete what they just created.
+ * WebAPI reports per-entity grants only through `/user/me`, which the client
+ * fetches at startup, so a newly created entity has no grant until the next
+ * page load and the editor's Save and Delete actions stay disabled on the
+ * thing the user just made.
+ *
+ * Two steps, in this order:
+ *
+ * 1. Record the current user as owner of `id`. A POST that succeeded means the
+ *    server accepted them as the creator, so the buttons come alive without
+ *    waiting on a second round trip.
+ * 2. Re-read `/user/me`, which replaces that optimistic grant with what the
+ *    server actually granted. This is what picks up the grants a create
+ *    cascades into (an imported design creates cohorts and concept sets of its
+ *    own) and what corrects step 1 if the server did not grant write after all.
+ *
+ * Step 1 is the fallback for step 2: if `/user/me` cannot be reached the
+ * optimistic grant stands rather than leaving the user stuck.
  *
  * The store is imported lazily to keep the service layer free of a static
  * dependency on Pinia, matching the other store touch points in services.
  */
-export async function registerCreatedEntity(
+export async function syncAccessAfterCreate(
   kind: EntityAccessKind,
   id: string | number | null | undefined
 ): Promise<void> {
   if (id === null || id === undefined || id === '') return
   try {
     const { useAuthStore } = await import('@/stores/auth')
-    useAuthStore().registerOwnedEntity(kind, id)
+    const authStore = useAuthStore()
+    authStore.registerOwnedEntity(kind, id)
+    await authStore.refreshUserContext()
   } catch (error) {
     // A missing Pinia context (tests, plugin sandboxes) must not fail the
     // create call that already succeeded on the server.

--- a/src/services/auth/entityOwnership.ts
+++ b/src/services/auth/entityOwnership.ts
@@ -1,0 +1,28 @@
+import type { EntityAccessKind } from '@/models/auth.types'
+import { logger } from '@/utils/logger'
+
+/**
+ * Grant the current user ownership of an entity that was just created.
+ *
+ * WebAPI only reports per-entity grants through `/user/me`, which the client
+ * fetches at startup. A POST that succeeds means the server accepted the user
+ * as the creator, so the grant is recorded locally rather than making the user
+ * reload the page before they can save or delete what they just created.
+ *
+ * The store is imported lazily to keep the service layer free of a static
+ * dependency on Pinia, matching the other store touch points in services.
+ */
+export async function registerCreatedEntity(
+  kind: EntityAccessKind,
+  id: string | number | null | undefined
+): Promise<void> {
+  if (id === null || id === undefined || id === '') return
+  try {
+    const { useAuthStore } = await import('@/stores/auth')
+    useAuthStore().registerOwnedEntity(kind, id)
+  } catch (error) {
+    // A missing Pinia context (tests, plugin sandboxes) must not fail the
+    // create call that already succeeded on the server.
+    logger.warn('EntityOwnership', `Failed to register ownership of ${kind} ${id}`, error)
+  }
+}

--- a/src/services/characterization.service.ts
+++ b/src/services/characterization.service.ts
@@ -5,6 +5,7 @@
  */
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead } from '@/services/http-client'
 import { unwrap, unwrapList, ApiError, parseOrThrow } from '@/services/api-error'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
 import {
@@ -76,11 +77,13 @@ export async function createCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/cohort-characterization', serializeCharacterization(def))
-    return parseOrThrow(
+    const created = parseOrThrow(
       CharacterizationDefinitionSchema,
       data,
       'Invalid response from POST /cohort-characterization'
     ) as CharacterizationDefinition
+    await registerCreatedEntity('cohortCharacterization', created.id)
+    return created
   }, CONTEXT)
 }
 
@@ -127,11 +130,13 @@ export async function copyCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(`/cohort-characterization/${id}`)
-    return parseOrThrow(
+    const copied = parseOrThrow(
       CharacterizationDefinitionSchema,
       data,
       `Invalid response from POST /cohort-characterization/${id}`
     ) as CharacterizationDefinition
+    await registerCreatedEntity('cohortCharacterization', copied.id)
+    return copied
   }, CONTEXT)
 }
 

--- a/src/services/characterization.service.ts
+++ b/src/services/characterization.service.ts
@@ -5,7 +5,7 @@
  */
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead } from '@/services/http-client'
 import { unwrap, unwrapList, ApiError, parseOrThrow } from '@/services/api-error'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 import { logger } from '@/utils/logger'
 import { type ApiResult } from '@/types/api'
 import {
@@ -82,7 +82,7 @@ export async function createCharacterization(
       data,
       'Invalid response from POST /cohort-characterization'
     ) as CharacterizationDefinition
-    await registerCreatedEntity('cohortCharacterization', created.id)
+    await syncAccessAfterCreate('cohortCharacterization', created.id)
     return created
   }, CONTEXT)
 }
@@ -135,7 +135,7 @@ export async function copyCharacterization(
       data,
       `Invalid response from POST /cohort-characterization/${id}`
     ) as CharacterizationDefinition
-    await registerCreatedEntity('cohortCharacterization', copied.id)
+    await syncAccessAfterCreate('cohortCharacterization', copied.id)
     return copied
   }, CONTEXT)
 }
@@ -177,11 +177,13 @@ export async function importCharacterization(
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/cohort-characterization/import', design)
-    return parseOrThrow(
+    const imported = parseOrThrow(
       CharacterizationDefinitionSchema,
       data,
       'Invalid response from POST /cohort-characterization/import'
     ) as CharacterizationDefinition
+    await syncAccessAfterCreate('cohortCharacterization', imported.id)
+    return imported
   }, CONTEXT)
 }
 

--- a/src/services/cohort-definition.service.ts
+++ b/src/services/cohort-definition.service.ts
@@ -6,6 +6,7 @@
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead, getBaseUrl } from '@/services/http-client'
 import { unwrap, ApiError, parseOrThrow, zodIssues } from '@/services/api-error'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 import { type ApiResult } from '@/types/api'
 import type { RawCohortDefinition } from '@/models/atlas.types'
 import type { CohortDefinition } from '@/models/cohort.types'
@@ -68,10 +69,12 @@ export async function saveCohortDefinition(
 ): Promise<ApiResult<CohortDefinition>> {
   return unwrap(async () => {
     logger.debug(CONTEXT, 'Saving cohort definition', { id: cohort.id, name: cohort.name })
-    const saved = cohort.id
-      ? await httpPut<CohortDefinition>(`/cohortdefinition/${cohort.id}`, cohort)
-      : await httpPost<CohortDefinition>('/cohortdefinition', cohort)
-    return saved
+    if (cohort.id) {
+      return await httpPut<CohortDefinition>(`/cohortdefinition/${cohort.id}`, cohort)
+    }
+    const created = await httpPost<CohortDefinition>('/cohortdefinition', cohort)
+    await registerCreatedEntity('cohortDefinition', created.id)
+    return created
   }, CONTEXT)
 }
 

--- a/src/services/cohort-definition.service.ts
+++ b/src/services/cohort-definition.service.ts
@@ -6,7 +6,7 @@
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete, httpPostRead, getBaseUrl } from '@/services/http-client'
 import { unwrap, ApiError, parseOrThrow, zodIssues } from '@/services/api-error'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 import { type ApiResult } from '@/types/api'
 import type { RawCohortDefinition } from '@/models/atlas.types'
 import type { CohortDefinition } from '@/models/cohort.types'
@@ -73,7 +73,7 @@ export async function saveCohortDefinition(
       return await httpPut<CohortDefinition>(`/cohortdefinition/${cohort.id}`, cohort)
     }
     const created = await httpPost<CohortDefinition>('/cohortdefinition', cohort)
-    await registerCreatedEntity('cohortDefinition', created.id)
+    await syncAccessAfterCreate('cohortDefinition', created.id)
     return created
   }, CONTEXT)
 }

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -16,6 +16,7 @@ import {
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
 import { getSourceKey } from '@/config/webapi'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 
 /**
  * Prefer the source key validated against the sources the server actually
@@ -104,6 +105,7 @@ export async function createConceptSet(
     }
 
     const data = await httpPost<ConceptSetAPIResponse>('/conceptset', metadataPayload)
+    await registerCreatedEntity('conceptSet', data.id)
 
     if ((conceptSet.items?.length || 0) > 0 && data.id) {
       const itemsPayload = (conceptSet.items || []).map(item => ({

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -16,7 +16,7 @@ import {
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
 import { getSourceKey } from '@/config/webapi'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 
 /**
  * Prefer the source key validated against the sources the server actually
@@ -105,7 +105,7 @@ export async function createConceptSet(
     }
 
     const data = await httpPost<ConceptSetAPIResponse>('/conceptset', metadataPayload)
-    await registerCreatedEntity('conceptSet', data.id)
+    await syncAccessAfterCreate('conceptSet', data.id)
 
     if ((conceptSet.items?.length || 0) > 0 && data.id) {
       const itemsPayload = (conceptSet.items || []).map(item => ({

--- a/src/services/feature-analysis.service.ts
+++ b/src/services/feature-analysis.service.ts
@@ -16,7 +16,7 @@ import {
   type CovariateSetting,
 } from '@/models/feature-analysis.types'
 import { z } from 'zod'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 
 const CONTEXT = 'FeatureAnalysisService'
 
@@ -57,7 +57,7 @@ export async function createFeatureAnalysis(
       data,
       'Invalid response from POST /feature-analysis'
     ) as FeatureAnalysis
-    await registerCreatedEntity('feAnalysis', created.id)
+    await syncAccessAfterCreate('feAnalysis', created.id)
     return created
   }, CONTEXT)
 }
@@ -104,7 +104,7 @@ export async function copyFeatureAnalysis(id: number): Promise<ApiResult<Feature
       data,
       `Invalid response from /feature-analysis/${id}/copy`
     ) as FeatureAnalysis
-    await registerCreatedEntity('feAnalysis', copied.id)
+    await syncAccessAfterCreate('feAnalysis', copied.id)
     return copied
   }, CONTEXT)
 }

--- a/src/services/feature-analysis.service.ts
+++ b/src/services/feature-analysis.service.ts
@@ -16,6 +16,7 @@ import {
   type CovariateSetting,
 } from '@/models/feature-analysis.types'
 import { z } from 'zod'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 
 const CONTEXT = 'FeatureAnalysisService'
 
@@ -51,7 +52,13 @@ export async function createFeatureAnalysis(
 ): Promise<ApiResult<FeatureAnalysis>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/feature-analysis', fa)
-    return parseOrThrow(FeatureAnalysisSchema, data, 'Invalid response from POST /feature-analysis') as FeatureAnalysis
+    const created = parseOrThrow(
+      FeatureAnalysisSchema,
+      data,
+      'Invalid response from POST /feature-analysis'
+    ) as FeatureAnalysis
+    await registerCreatedEntity('feAnalysis', created.id)
+    return created
   }, CONTEXT)
 }
 
@@ -92,11 +99,13 @@ export async function deleteFeatureAnalysis(id: number): Promise<ApiResult<void>
 export async function copyFeatureAnalysis(id: number): Promise<ApiResult<FeatureAnalysis>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/feature-analysis/${id}/copy`)
-    return parseOrThrow(
+    const copied = parseOrThrow(
       FeatureAnalysisSchema,
       data,
       `Invalid response from /feature-analysis/${id}/copy`
     ) as FeatureAnalysis
+    await registerCreatedEntity('feAnalysis', copied.id)
+    return copied
   }, CONTEXT)
 }
 

--- a/src/services/incidence-rate.service.ts
+++ b/src/services/incidence-rate.service.ts
@@ -22,7 +22,7 @@ import type {
 } from '@/models/incidence-rate.types'
 import { z } from 'zod'
 import { normalizeCriteriaGroupForCirce } from '@/components/cohort-editor/normalize'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 
 const CONTEXT = 'IncidenceRateService'
 
@@ -89,7 +89,7 @@ export async function createIncidenceRate(ir: IncidenceRate): Promise<ApiResult<
   return unwrap(async () => {
     const data = await httpPost<unknown>('/ir/', encodeIRForSave(ir))
     const created = decodeIRExpression(data)
-    await registerCreatedEntity('incidenceRate', created.id)
+    await syncAccessAfterCreate('incidenceRate', created.id)
     return created
   }, CONTEXT)
 }
@@ -110,7 +110,7 @@ export async function copyIncidenceRate(id: number): Promise<ApiResult<Incidence
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/ir/${id}/copy`)
     const copied = decodeIRExpression(data)
-    await registerCreatedEntity('incidenceRate', copied.id)
+    await syncAccessAfterCreate('incidenceRate', copied.id)
     return copied
   }, CONTEXT)
 }
@@ -149,7 +149,9 @@ export async function exportIncidenceRate(id: number): Promise<unknown> {
  */
 export async function importIncidenceRate(design: unknown): Promise<IncidenceRate> {
   const data = await httpPost<unknown>('/ir/design', design)
-  return decodeIRExpression(data)
+  const imported = decodeIRExpression(data)
+  await syncAccessAfterCreate('incidenceRate', imported.id)
+  return imported
 }
 
 /** POST /ir/{id}/tag/{tagId}. */

--- a/src/services/incidence-rate.service.ts
+++ b/src/services/incidence-rate.service.ts
@@ -22,6 +22,7 @@ import type {
 } from '@/models/incidence-rate.types'
 import { z } from 'zod'
 import { normalizeCriteriaGroupForCirce } from '@/components/cohort-editor/normalize'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 
 const CONTEXT = 'IncidenceRateService'
 
@@ -87,7 +88,9 @@ export async function getIncidenceRate(id: number): Promise<ApiResult<IncidenceR
 export async function createIncidenceRate(ir: IncidenceRate): Promise<ApiResult<IncidenceRate>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/ir/', encodeIRForSave(ir))
-    return decodeIRExpression(data)
+    const created = decodeIRExpression(data)
+    await registerCreatedEntity('incidenceRate', created.id)
+    return created
   }, CONTEXT)
 }
 
@@ -106,7 +109,9 @@ export async function saveIncidenceRate(
 export async function copyIncidenceRate(id: number): Promise<ApiResult<IncidenceRate>> {
   return unwrap(async () => {
     const data = await httpGet<unknown>(`/ir/${id}/copy`)
-    return decodeIRExpression(data)
+    const copied = decodeIRExpression(data)
+    await registerCreatedEntity('incidenceRate', copied.id)
+    return copied
   }, CONTEXT)
 }
 

--- a/src/services/pathway.service.ts
+++ b/src/services/pathway.service.ts
@@ -5,6 +5,7 @@
  */
 import { httpGet, httpPost, httpPostRead, httpPut, httpDelete } from '@/services/http-client'
 import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
 import { type ApiResult } from '@/types/api'
 import { logger } from '@/utils/logger'
 import {
@@ -62,7 +63,13 @@ export async function getPathway(id: number): Promise<ApiResult<Pathway>> {
 export async function createPathway(pathway: Pathway): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>('/pathway-analysis', pathway)
-    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid create response') as Pathway
+    const created = parseOrThrow(
+      PathwaySchema.passthrough(),
+      data,
+      'Invalid create response'
+    ) as Pathway
+    await registerCreatedEntity('pathway', created.id)
+    return created
   }, CONTEXT)
 }
 
@@ -84,7 +91,13 @@ export async function savePathway(id: number, pathway: Pathway): Promise<ApiResu
 export async function copyPathway(id: number): Promise<ApiResult<Pathway>> {
   return unwrap(async () => {
     const data = await httpPost<unknown>(`/pathway-analysis/${id}`, undefined)
-    return parseOrThrow(PathwaySchema.passthrough(), data, 'Invalid copy response') as Pathway
+    const copied = parseOrThrow(
+      PathwaySchema.passthrough(),
+      data,
+      'Invalid copy response'
+    ) as Pathway
+    await registerCreatedEntity('pathway', copied.id)
+    return copied
   }, CONTEXT)
 }
 

--- a/src/services/pathway.service.ts
+++ b/src/services/pathway.service.ts
@@ -5,7 +5,7 @@
  */
 import { httpGet, httpPost, httpPostRead, httpPut, httpDelete } from '@/services/http-client'
 import { unwrap, ApiError, parseOrThrow } from '@/services/api-error'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 import { type ApiResult } from '@/types/api'
 import { logger } from '@/utils/logger'
 import {
@@ -68,7 +68,7 @@ export async function createPathway(pathway: Pathway): Promise<ApiResult<Pathway
       data,
       'Invalid create response'
     ) as Pathway
-    await registerCreatedEntity('pathway', created.id)
+    await syncAccessAfterCreate('pathway', created.id)
     return created
   }, CONTEXT)
 }
@@ -96,7 +96,7 @@ export async function copyPathway(id: number): Promise<ApiResult<Pathway>> {
       data,
       'Invalid copy response'
     ) as Pathway
-    await registerCreatedEntity('pathway', copied.id)
+    await syncAccessAfterCreate('pathway', copied.id)
     return copied
   }, CONTEXT)
 }
@@ -149,7 +149,9 @@ export async function importPathway(design: unknown): Promise<Pathway> {
     logger.error('Pathway', 'importPathway validation', parsed.error)
     throw new Error('Invalid response from POST /pathway-analysis/import')
   }
-  return parsed.data as Pathway
+  const imported = parsed.data as Pathway
+  await syncAccessAfterCreate('pathway', imported.id)
+  return imported
 }
 
 /**

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import type { AuthState, UserInfo } from '@/models/auth.types'
+import type { AuthState, EntityAccessKind, UserInfo } from '@/models/auth.types'
 import { emptyEntityAccess } from '@/models/auth.types'
 import { storageManager } from '@/services/auth/storageManager'
 import { tokenManager } from '@/services/auth/tokenManager'
@@ -104,6 +104,22 @@ export const useAuthStore = defineStore('auth', {
         this.permissions = {}
         this.entityAccess = emptyEntityAccess()
       }
+    },
+
+    /**
+     * Record the current user as owner of an entity they just created.
+     *
+     * The per-entity grant maps come from `/user/me`, which is only fetched at
+     * startup. Without this, a freshly created entity has no grant until the
+     * next page load, so `useEntityAccess` denies write and the editor's
+     * Save/Delete actions stay disabled on the thing the user just made.
+     */
+    registerOwnedEntity(kind: EntityAccessKind, id: string | number | null | undefined) {
+      if (id === null || id === undefined || id === '') return
+      const key = String(id)
+      const map = this.entityAccess[kind]
+      if (map[key]?.isOwner) return
+      map[key] = { accessTypes: ['READ', 'WRITE'], isOwner: true }
     },
 
     setAuthProvider(provider: string | null) {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -122,6 +122,28 @@ export const useAuthStore = defineStore('auth', {
       map[key] = { accessTypes: ['READ', 'WRITE'], isOwner: true }
     },
 
+    /**
+     * Re-read the current subject's authorization snapshot from the server.
+     *
+     * A write can change more grants than the client can predict: importing a
+     * design creates cohorts and concept sets of its own, and the creator's
+     * grant on any of them only exists server-side. Rather than guess, ask
+     * `/user/me` again and let the answer replace what is held locally.
+     *
+     * Returns whether the refresh landed, so callers can keep an optimistic
+     * grant in place when the server could not be reached.
+     */
+    async refreshUserContext(): Promise<boolean> {
+      try {
+        const { authService } = await import('@/services/auth/authService')
+        this.setUser(await authService.fetchUserInfo())
+        return true
+      } catch (error) {
+        logger.warn('Auth', 'Failed to refresh the user authorization snapshot', error)
+        return false
+      }
+    },
+
     setAuthProvider(provider: string | null) {
       this.authProvider = provider
     },

--- a/tests/unit/services/entityOwnership.spec.ts
+++ b/tests/unit/services/entityOwnership.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression: a freshly created entity must be writable without a page reload.
+ *
+ * Per-entity grants only arrive with `/user/me` at startup, so before the fix
+ * a just-created cohort/concept set/characterization had no grant and
+ * `useEntityAccess` denied write — the Save and Delete buttons in the editor
+ * stayed disabled until the user refreshed the page (OHDSI/Atlas3#274, #268).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { useAuthStore } from '@/stores/auth'
+import { emptyEntityAccess } from '@/models/auth.types'
+import { useEntityAccess } from '@/composables/useEntityAccess'
+import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { saveCohortDefinition } from '@/services/cohort-definition.service'
+import { createConceptSet } from '@/services/concept-set.service'
+import { createCharacterization } from '@/services/characterization.service'
+import { createFeatureAnalysis } from '@/services/feature-analysis.service'
+import { createPathway } from '@/services/pathway.service'
+import { createIncidenceRate } from '@/services/incidence-rate.service'
+
+/** A user with no global write permission — access rests entirely on grants. */
+function signInWithoutGlobalWrite() {
+  useAuthStore().setUser({
+    login: 'u',
+    displayName: 'u',
+    permissionIdx: {},
+    entityAccess: emptyEntityAccess(),
+  })
+}
+
+describe('services/auth/entityOwnership', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    mockFetch = vi.fn()
+    global.fetch = mockFetch
+    signInWithoutGlobalWrite()
+  })
+
+  function ok(body: unknown) {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(body) })
+  }
+
+  describe('registerCreatedEntity', () => {
+    it('grants read and write on the newly created entity', async () => {
+      const { canRead, canWrite, canDelete, isOwner } = useEntityAccess('cohortDefinition', 42)
+      expect(canWrite.value).toBe(false)
+
+      await registerCreatedEntity('cohortDefinition', 42)
+
+      expect(canRead.value).toBe(true)
+      expect(canWrite.value).toBe(true)
+      expect(canDelete.value).toBe(true)
+      expect(isOwner.value).toBe(true)
+    })
+
+    it('does not widen access to any other entity', async () => {
+      await registerCreatedEntity('cohortDefinition', 42)
+
+      expect(useEntityAccess('cohortDefinition', 43).canWrite.value).toBe(false)
+      expect(useEntityAccess('conceptSet', 42).canWrite.value).toBe(false)
+    })
+
+    it('ignores an absent id rather than creating a bogus grant', async () => {
+      await registerCreatedEntity('conceptSet', undefined)
+      await registerCreatedEntity('conceptSet', null)
+      await registerCreatedEntity('conceptSet', '')
+
+      expect(useAuthStore().entityAccess.conceptSet).toEqual({})
+    })
+
+    it('leaves an existing grant alone', async () => {
+      const store = useAuthStore()
+      store.entityAccess.pathway['5'] = { accessTypes: ['READ'], isOwner: true }
+
+      await registerCreatedEntity('pathway', 5)
+
+      expect(store.entityAccess.pathway['5']).toEqual({ accessTypes: ['READ'], isOwner: true })
+    })
+  })
+
+  describe('create endpoints register ownership', () => {
+    it('saveCohortDefinition does so on create but not on update', async () => {
+      ok({ id: 7, name: 'c', expression: {} })
+      await saveCohortDefinition({ name: 'c', expression: {} })
+      expect(useEntityAccess('cohortDefinition', 7).canWrite.value).toBe(true)
+
+      ok({ id: 8, name: 'c', expression: {} })
+      await saveCohortDefinition({ id: 8, name: 'c', expression: {} })
+      expect(useEntityAccess('cohortDefinition', 8).canWrite.value).toBe(false)
+    })
+
+    it('createConceptSet does so', async () => {
+      ok({ id: 9, name: 'cs' })
+      await createConceptSet({ name: 'cs', items: [] })
+      expect(useEntityAccess('conceptSet', 9).canWrite.value).toBe(true)
+    })
+
+    it('createCharacterization does so', async () => {
+      const cc = { name: 'cc', cohorts: [], featureAnalyses: [], stratas: [] }
+      ok({ ...cc, id: 11 })
+      await createCharacterization(cc)
+      expect(useEntityAccess('cohortCharacterization', 11).canWrite.value).toBe(true)
+    })
+
+    it('createFeatureAnalysis does so', async () => {
+      const fa = { name: 'fa', type: 'CRITERIA_SET' as const, design: {} }
+      ok({ ...fa, id: 12 })
+      await createFeatureAnalysis(fa)
+      expect(useEntityAccess('feAnalysis', 12).canWrite.value).toBe(true)
+    })
+
+    it('createPathway does so', async () => {
+      ok({ id: 13, name: 'pw' })
+      await createPathway({ name: 'pw' })
+      expect(useEntityAccess('pathway', 13).canWrite.value).toBe(true)
+    })
+
+    it('createIncidenceRate does so', async () => {
+      // The save encoder reads expression.strata, so the design has to carry a
+      // real expression rather than a bare name.
+      const ir = {
+        name: 'ir',
+        expression: {
+          timeAtRisk: {
+            start: { DateField: 'StartDate', Offset: 0 },
+            end: { DateField: 'StartDate', Offset: 0 },
+          },
+          strata: [],
+        },
+      } as unknown as Parameters<typeof createIncidenceRate>[0]
+      ok({ id: 14, name: 'ir' })
+      const created = await createIncidenceRate(ir)
+      expect(created.success).toBe(true)
+      expect(useEntityAccess('incidenceRate', 14).canWrite.value).toBe(true)
+    })
+
+    it('does not register ownership when the server rejects the create', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 403, text: async () => 'denied' })
+      await saveCohortDefinition({ name: 'c', expression: {} })
+      expect(useAuthStore().entityAccess.cohortDefinition).toEqual({})
+    })
+  })
+
+  it('drops the grants when the subject changes', async () => {
+    await registerCreatedEntity('cohortDefinition', 42)
+    expect(useEntityAccess('cohortDefinition', 42).canWrite.value).toBe(true)
+
+    signInWithoutGlobalWrite()
+
+    expect(useEntityAccess('cohortDefinition', 42).canWrite.value).toBe(false)
+  })
+})

--- a/tests/unit/services/entityOwnership.spec.ts
+++ b/tests/unit/services/entityOwnership.spec.ts
@@ -3,8 +3,13 @@
  *
  * Per-entity grants only arrive with `/user/me` at startup, so before the fix
  * a just-created cohort/concept set/characterization had no grant and
- * `useEntityAccess` denied write — the Save and Delete buttons in the editor
+ * `useEntityAccess` denied write: the Save and Delete buttons in the editor
  * stayed disabled until the user refreshed the page (OHDSI/Atlas3#274, #268).
+ *
+ * A create now records the grant locally and then re-reads `/user/me`, so
+ * these cover both halves: the optimistic grant that unblocks the editor at
+ * once, and the server snapshot that overrides it and carries the grants a
+ * create cascaded into.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
@@ -16,13 +21,16 @@ vi.mock('@/utils/logger', () => ({
 import { useAuthStore } from '@/stores/auth'
 import { emptyEntityAccess } from '@/models/auth.types'
 import { useEntityAccess } from '@/composables/useEntityAccess'
-import { registerCreatedEntity } from '@/services/auth/entityOwnership'
+import { syncAccessAfterCreate } from '@/services/auth/entityOwnership'
 import { saveCohortDefinition } from '@/services/cohort-definition.service'
 import { createConceptSet } from '@/services/concept-set.service'
-import { createCharacterization } from '@/services/characterization.service'
+import {
+  createCharacterization,
+  importCharacterization,
+} from '@/services/characterization.service'
 import { createFeatureAnalysis } from '@/services/feature-analysis.service'
-import { createPathway } from '@/services/pathway.service'
-import { createIncidenceRate } from '@/services/incidence-rate.service'
+import { createPathway, importPathway } from '@/services/pathway.service'
+import { createIncidenceRate, importIncidenceRate } from '@/services/incidence-rate.service'
 
 /** A user with no global write permission — access rests entirely on grants. */
 function signInWithoutGlobalWrite() {
@@ -49,12 +57,28 @@ describe('services/auth/entityOwnership', () => {
     mockFetch.mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(body) })
   }
 
-  describe('registerCreatedEntity', () => {
+  /** Queue the `user/me` round trip that follows a create. */
+  function userMe(authz: Record<string, unknown>) {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        user: { login: 'u', name: 'u' },
+        authz: { permissions: [], ...authz },
+      }),
+    })
+  }
+
+  /** Fail the `user/me` round trip that follows a create. */
+  function userMeUnavailable() {
+    mockFetch.mockRejectedValueOnce(new Error('network down'))
+  }
+
+  describe('syncAccessAfterCreate', () => {
     it('grants read and write on the newly created entity', async () => {
       const { canRead, canWrite, canDelete, isOwner } = useEntityAccess('cohortDefinition', 42)
       expect(canWrite.value).toBe(false)
 
-      await registerCreatedEntity('cohortDefinition', 42)
+      await syncAccessAfterCreate('cohortDefinition', 42)
 
       expect(canRead.value).toBe(true)
       expect(canWrite.value).toBe(true)
@@ -63,16 +87,16 @@ describe('services/auth/entityOwnership', () => {
     })
 
     it('does not widen access to any other entity', async () => {
-      await registerCreatedEntity('cohortDefinition', 42)
+      await syncAccessAfterCreate('cohortDefinition', 42)
 
       expect(useEntityAccess('cohortDefinition', 43).canWrite.value).toBe(false)
       expect(useEntityAccess('conceptSet', 42).canWrite.value).toBe(false)
     })
 
     it('ignores an absent id rather than creating a bogus grant', async () => {
-      await registerCreatedEntity('conceptSet', undefined)
-      await registerCreatedEntity('conceptSet', null)
-      await registerCreatedEntity('conceptSet', '')
+      await syncAccessAfterCreate('conceptSet', undefined)
+      await syncAccessAfterCreate('conceptSet', null)
+      await syncAccessAfterCreate('conceptSet', '')
 
       expect(useAuthStore().entityAccess.conceptSet).toEqual({})
     })
@@ -81,15 +105,18 @@ describe('services/auth/entityOwnership', () => {
       const store = useAuthStore()
       store.entityAccess.pathway['5'] = { accessTypes: ['READ'], isOwner: true }
 
-      await registerCreatedEntity('pathway', 5)
+      await syncAccessAfterCreate('pathway', 5)
 
       expect(store.entityAccess.pathway['5']).toEqual({ accessTypes: ['READ'], isOwner: true })
     })
   })
 
+  // Each of these queues a failed `user/me` so the assertion lands on the
+  // optimistic grant; the authoritative refresh has its own block below.
   describe('create endpoints register ownership', () => {
     it('saveCohortDefinition does so on create but not on update', async () => {
       ok({ id: 7, name: 'c', expression: {} })
+      userMeUnavailable()
       await saveCohortDefinition({ name: 'c', expression: {} })
       expect(useEntityAccess('cohortDefinition', 7).canWrite.value).toBe(true)
 
@@ -100,6 +127,7 @@ describe('services/auth/entityOwnership', () => {
 
     it('createConceptSet does so', async () => {
       ok({ id: 9, name: 'cs' })
+      userMeUnavailable()
       await createConceptSet({ name: 'cs', items: [] })
       expect(useEntityAccess('conceptSet', 9).canWrite.value).toBe(true)
     })
@@ -107,6 +135,7 @@ describe('services/auth/entityOwnership', () => {
     it('createCharacterization does so', async () => {
       const cc = { name: 'cc', cohorts: [], featureAnalyses: [], stratas: [] }
       ok({ ...cc, id: 11 })
+      userMeUnavailable()
       await createCharacterization(cc)
       expect(useEntityAccess('cohortCharacterization', 11).canWrite.value).toBe(true)
     })
@@ -114,12 +143,14 @@ describe('services/auth/entityOwnership', () => {
     it('createFeatureAnalysis does so', async () => {
       const fa = { name: 'fa', type: 'CRITERIA_SET' as const, design: {} }
       ok({ ...fa, id: 12 })
+      userMeUnavailable()
       await createFeatureAnalysis(fa)
       expect(useEntityAccess('feAnalysis', 12).canWrite.value).toBe(true)
     })
 
     it('createPathway does so', async () => {
       ok({ id: 13, name: 'pw' })
+      userMeUnavailable()
       await createPathway({ name: 'pw' })
       expect(useEntityAccess('pathway', 13).canWrite.value).toBe(true)
     })
@@ -138,6 +169,7 @@ describe('services/auth/entityOwnership', () => {
         },
       } as unknown as Parameters<typeof createIncidenceRate>[0]
       ok({ id: 14, name: 'ir' })
+      userMeUnavailable()
       const created = await createIncidenceRate(ir)
       expect(created.success).toBe(true)
       expect(useEntityAccess('incidenceRate', 14).canWrite.value).toBe(true)
@@ -150,8 +182,82 @@ describe('services/auth/entityOwnership', () => {
     })
   })
 
+  describe('the server has the last word on what was granted', () => {
+    it('replaces the optimistic grant with the one user/me reports', async () => {
+      ok({ id: 7, name: 'c', expression: {} })
+      userMe({ cohortDefinitionAccess: { '7': { accessTypes: ['READ'], isOwner: false } } })
+
+      await saveCohortDefinition({ name: 'c', expression: {} })
+
+      const access = useEntityAccess('cohortDefinition', 7)
+      expect(access.canRead.value).toBe(true)
+      expect(access.canWrite.value).toBe(false)
+      expect(access.isOwner.value).toBe(false)
+    })
+
+    it('picks up grants on entities the create cascaded into', async () => {
+      ok({ id: 11, name: 'cc', cohorts: [], featureAnalyses: [], stratas: [] })
+      userMe({
+        cohortCharacterizationAccess: { '11': { accessTypes: ['WRITE'], isOwner: true } },
+        cohortDefinitionAccess: { '77': { accessTypes: ['WRITE'], isOwner: true } },
+      })
+
+      await importCharacterization({})
+
+      expect(useEntityAccess('cohortCharacterization', 11).canWrite.value).toBe(true)
+      expect(useEntityAccess('cohortDefinition', 77).canWrite.value).toBe(true)
+    })
+
+    it('keeps the optimistic grant when user/me cannot be reached', async () => {
+      ok({ id: 7, name: 'c', expression: {} })
+      userMeUnavailable()
+
+      await saveCohortDefinition({ name: 'c', expression: {} })
+
+      expect(useEntityAccess('cohortDefinition', 7).canWrite.value).toBe(true)
+    })
+
+    it('reports the create as successful even when the refresh fails', async () => {
+      ok({ id: 7, name: 'c', expression: {} })
+      userMeUnavailable()
+
+      const result = await saveCohortDefinition({ name: 'c', expression: {} })
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('import endpoints register ownership', () => {
+    it('importCharacterization does so', async () => {
+      ok({ id: 21, name: 'cc', cohorts: [], featureAnalyses: [], stratas: [] })
+      userMeUnavailable()
+
+      await importCharacterization({})
+
+      expect(useEntityAccess('cohortCharacterization', 21).canWrite.value).toBe(true)
+    })
+
+    it('importPathway does so', async () => {
+      ok({ id: 22, name: 'pw' })
+      userMeUnavailable()
+
+      await importPathway({})
+
+      expect(useEntityAccess('pathway', 22).canWrite.value).toBe(true)
+    })
+
+    it('importIncidenceRate does so', async () => {
+      ok({ id: 23, name: 'ir' })
+      userMeUnavailable()
+
+      await importIncidenceRate({})
+
+      expect(useEntityAccess('incidenceRate', 23).canWrite.value).toBe(true)
+    })
+  })
+
   it('drops the grants when the subject changes', async () => {
-    await registerCreatedEntity('cohortDefinition', 42)
+    await syncAccessAfterCreate('cohortDefinition', 42)
     expect(useEntityAccess('cohortDefinition', 42).canWrite.value).toBe(true)
 
     signInWithoutGlobalWrite()


### PR DESCRIPTION
## Problem

An entity you create during a session cannot be edited or deleted until you refresh the page. Save and Delete are disabled on the thing you just made (#274), and the cohort definition Delete button behaves the same way (#268). After a refresh, both work.

## Cause

WebAPI reports per-entity permissions only through `/user/me`, which the client requests once at startup. An entity created later in the session is not in that snapshot, so the client finds no permission for it and disables writing. Refreshing re-requests `/user/me`, the permission appears, and the buttons come back to life.

## What changes

When a create succeeds, the client now records you as the owner of the new entity straight away — the server accepting the request already establishes that — so Save and Delete work immediately, without a refresh.

This covers cohort definitions, concept sets, characterizations, feature analyses, pathways and incidence rates, including copying an incidence rate.

Fixes #274
Fixes #268