### PR TITLE
Filter, search and page the vocabulary concept tables (#266)

### DIFF
--- a/src/components/concepts/IncludedConceptsTable.vue
+++ b/src/components/concepts/IncludedConceptsTable.vue
@@ -19,16 +19,31 @@
       </div>
     </AtlasAlert>
 
+    <ConceptFacetFilters
+      v-if="items.length > 0"
+      :facets="facets"
+      :facet-options="facetOptions"
+      :selected="selectedFacets"
+      :active-filter-count="activeFilterCount"
+      :result-filter="textFilter"
+      text-field-test-id="included-result-filter"
+      class="included-concepts-table__filters"
+      @update:facet="({ key, values }) => setFacet(key, values)"
+      @update:result-filter="setTextFilter"
+      @clear="clearFilters()"
+    />
+
     <AtlasCard
       v-if="loading || items.length > 0"
       padding="none"
     >
       <AtlasDataTable
         v-model:sort-by="sortBy"
+        v-model:items-per-page="pageSize"
         :headers="headers"
-        :items="items"
+        :items="visibleConcepts"
         :loading="loading"
-        :items-per-page="50"
+        multi-sort
         hover
         class="included-concepts-table__table"
       >
@@ -95,6 +110,22 @@
           </AtlasChip>
         </template>
 
+        <template #no-data>
+          <div class="included-concepts-table__no-match">
+            <p class="included-concepts-table__no-match-text">
+              {{ t('cs.manager.emptyFilteredMessage', 'No concepts match the active filters.').value }}
+            </p>
+            <AtlasButton
+              size="sm"
+              variant="ghost"
+              data-testid="included-clear-filters-btn"
+              @click="clearFilters()"
+            >
+              {{ t('versions.filterClear', 'Clear filters').value }}
+            </AtlasButton>
+          </div>
+        </template>
+
         <template #loading>
           <AtlasSkeleton
             v-for="i in 5"
@@ -123,7 +154,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, toRef } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import type { Concept } from '@/models/concept-set.types'
 import {
@@ -135,6 +166,8 @@ import {
   AtlasIcon,
   AtlasSkeleton,
 } from '@/components/ui'
+import ConceptFacetFilters from './ConceptFacetFilters.vue'
+import { CONCEPT_FACETS, useConceptFacets } from '@/composables/useConceptFacets'
 import { getDomainColor } from '@/utils/domain-colors'
 import { useThemeStore } from '@/stores/theme'
 
@@ -156,6 +189,32 @@ const emit = defineEmits<{
 }>()
 
 const sortBy = ref([{ key: 'conceptId', order: 'asc' as const }])
+
+/**
+ * The footer's rows-per-page control only works when the caller round-trips the
+ * value: binding a bare number makes v-data-table's model controlled, so the
+ * user's choice is emitted and then overwritten by the unchanged prop. Owning it
+ * here is what makes the dropdown live (issue #266).
+ */
+const pageSize = ref(50)
+
+/**
+ * Facets mirror this table's own categorical columns, so every filter the bar
+ * offers corresponds to something on screen. Concept class is left out because
+ * this table does not show it.
+ */
+const facets = CONCEPT_FACETS.filter(f => f.key !== 'conceptClassId')
+
+const {
+  facetOptions,
+  selected: selectedFacets,
+  textFilter,
+  filteredConcepts: visibleConcepts,
+  activeFilterCount,
+  setFacet,
+  setTextFilter,
+  clearFilters,
+} = useConceptFacets(toRef(props, 'items'), facets)
 
 const headers = [
   { title: t('columns.conceptId', 'ID').value, key: 'conceptId', sortable: true, width: '90px' },
@@ -200,6 +259,24 @@ function onView(c: Concept) {
 <style scoped>
 .included-concepts-table {
   width: 100%;
+}
+
+.included-concepts-table__filters {
+  margin-bottom: 12px;
+}
+
+.included-concepts-table__no-match {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 24px;
+}
+
+.included-concepts-table__no-match-text {
+  margin: 0;
+  font-size: 14px;
+  color: rgb(var(--v-theme-on-surface-variant));
 }
 
 .included-concepts-table__error {

--- a/src/components/concepts/IncludedSourceCodesTable.vue
+++ b/src/components/concepts/IncludedSourceCodesTable.vue
@@ -19,16 +19,31 @@
       </div>
     </AtlasAlert>
 
+    <ConceptFacetFilters
+      v-if="store.sourceCodeItems.length > 0"
+      :facets="facets"
+      :facet-options="facetOptions"
+      :selected="selectedFacets"
+      :active-filter-count="activeFilterCount"
+      :result-filter="textFilter"
+      text-field-test-id="source-codes-result-filter"
+      class="included-source-codes-table__filters"
+      @update:facet="({ key, values }) => setFacet(key, values)"
+      @update:result-filter="setTextFilter"
+      @clear="clearFilters()"
+    />
+
     <AtlasCard
       v-if="store.sourceCodeLoading || store.sourceCodeItems.length > 0"
       padding="none"
     >
       <AtlasDataTable
         v-model:sort-by="sortBy"
+        v-model:items-per-page="pageSize"
         :headers="headers"
-        :items="store.sourceCodeItems"
+        :items="visibleSourceCodes"
         :loading="store.sourceCodeLoading"
-        :items-per-page="50"
+        multi-sort
         hover
         class="included-source-codes-table__table"
       >
@@ -74,6 +89,22 @@
           </AtlasChip>
         </template>
 
+        <template #no-data>
+          <div class="included-source-codes-table__no-match">
+            <p class="included-source-codes-table__no-match-text">
+              {{ t('cs.manager.emptyFilteredMessage', 'No concepts match the active filters.').value }}
+            </p>
+            <AtlasButton
+              size="sm"
+              variant="ghost"
+              data-testid="source-codes-clear-filters-btn"
+              @click="clearFilters()"
+            >
+              {{ t('versions.filterClear', 'Clear filters').value }}
+            </AtlasButton>
+          </div>
+        </template>
+
         <template #loading>
           <AtlasSkeleton
             v-for="i in 5"
@@ -115,6 +146,8 @@ import {
   AtlasIcon,
   AtlasSkeleton,
 } from '@/components/ui'
+import ConceptFacetFilters from './ConceptFacetFilters.vue'
+import { CONCEPT_FACETS, useConceptFacets } from '@/composables/useConceptFacets'
 import { getDomainColor } from '@/utils/domain-colors'
 import { useThemeStore } from '@/stores/theme'
 
@@ -133,6 +166,31 @@ const emit = defineEmits<{
 }>()
 
 const sortBy = ref([{ key: 'conceptId', order: 'asc' as const }])
+
+/**
+ * See IncludedConceptsTable: a bare `:items-per-page` makes v-data-table's model
+ * controlled, so the footer's dropdown emits and is then overwritten. Owning the
+ * value here is what makes it live (issue #266).
+ */
+const pageSize = ref(50)
+
+/** Facets mirror this table's categorical columns: class, domain and vocabulary. */
+const facets = CONCEPT_FACETS.filter(f =>
+  ['conceptClassId', 'domainId', 'vocabularyId'].includes(f.key)
+)
+
+const sourceCodeItems = computed(() => store.sourceCodeItems)
+
+const {
+  facetOptions,
+  selected: selectedFacets,
+  textFilter,
+  filteredConcepts: visibleSourceCodes,
+  activeFilterCount,
+  setFacet,
+  setTextFilter,
+  clearFilters,
+} = useConceptFacets(sourceCodeItems, facets)
 
 const headers = [
   { title: t('columns.conceptId', 'ID').value, key: 'conceptId', sortable: true, width: '90px' },
@@ -167,6 +225,9 @@ watch(
     if (!active) return
     const [prevActive, prevSig, prevKey] = prev ?? [false, '', undefined]
     if (active !== prevActive || sig !== prevSig || key !== prevKey) {
+      // A different included set resolves to a different value space, so a
+      // stale selection would silently hide rows the user just produced.
+      if (sig !== prevSig || key !== prevKey) clearFilters()
       void store.resolveSourceCodes(key)
     }
   },
@@ -181,6 +242,24 @@ function onView(c: Concept) {
 <style scoped>
 .included-source-codes-table {
   width: 100%;
+}
+
+.included-source-codes-table__filters {
+  margin-bottom: 12px;
+}
+
+.included-source-codes-table__no-match {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 24px;
+}
+
+.included-source-codes-table__no-match-text {
+  margin: 0;
+  font-size: 14px;
+  color: rgb(var(--v-theme-on-surface-variant));
 }
 
 .included-source-codes-table__error {

--- a/tests/component/concepts/IncludedConceptsTable.spec.ts
+++ b/tests/component/concepts/IncludedConceptsTable.spec.ts
@@ -123,3 +123,146 @@ describe('IncludedConceptsTable', () => {
     expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
   })
 })
+
+describe('IncludedConceptsTable — filtering, sorting and pagination (issue #266)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  const mixedItems = [
+    makeConcept(1, { conceptName: 'Type 2 diabetes mellitus', vocabularyId: 'SNOMED' }),
+    makeConcept(2, { conceptName: 'Essential hypertension', vocabularyId: 'SNOMED' }),
+    makeConcept(3, {
+      conceptName: 'Metformin 500 MG',
+      vocabularyId: 'RxNorm',
+      domainId: 'Drug',
+    }),
+  ]
+
+  function mountWith(items = mixedItems) {
+    return mount(IncludedConceptsTable, {
+      global: { plugins: [vuetify] },
+      props: { items, loading: false, error: null, manualCount: items.length, sourceKey: 'SYNPUF1K' },
+    })
+  }
+
+  function facetBar(wrapper: ReturnType<typeof mountWith>) {
+    return wrapper.findComponent({ name: 'ConceptFacetFilters' })
+  }
+
+  it('offers a facet per categorical column the table shows, and no others', () => {
+    const keys = (facetBar(mountWith()).props('facets') as { key: string }[]).map(f => f.key)
+
+    // Vocabulary, Domain, Standard and Validity are all rendered as columns.
+    expect(keys).toEqual(
+      expect.arrayContaining(['vocabularyId', 'domainId', 'standardConcept', 'invalidReason'])
+    )
+    // Concept class is not a column here, so filtering by it would be a filter
+    // over something the user cannot see.
+    expect(keys).not.toContain('conceptClassId')
+  })
+
+  it('counts each facet option against the rows actually present', () => {
+    const options = facetBar(mountWith()).props('facetOptions') as Record<
+      string,
+      { value: string; count: number }[]
+    >
+    const vocab = Object.fromEntries(options.vocabularyId.map(o => [o.value, o.count]))
+    expect(vocab).toEqual({ SNOMED: 2, RxNorm: 1 })
+  })
+
+  it('narrows the rows to a selected facet value', async () => {
+    const wrapper = mountWith()
+    expect(wrapper.text()).toContain('Metformin 500 MG')
+
+    facetBar(wrapper).vm.$emit('update:facet', { key: 'vocabularyId', values: ['RxNorm'] })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Metformin 500 MG')
+    expect(wrapper.text()).not.toContain('Type 2 diabetes mellitus')
+    expect(wrapper.text()).not.toContain('Essential hypertension')
+  })
+
+  it('matches the free-text filter on a substring, not just a prefix', async () => {
+    const wrapper = mountWith()
+
+    facetBar(wrapper).vm.$emit('update:resultFilter', 'diabetes')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Type 2 diabetes mellitus')
+    expect(wrapper.text()).not.toContain('Metformin 500 MG')
+  })
+
+  it('offers a way back when the filters match nothing', async () => {
+    const wrapper = mountWith()
+
+    facetBar(wrapper).vm.$emit('update:resultFilter', 'no-such-concept')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toMatch(/No concepts match the active filters/i)
+
+    await wrapper.find('[data-testid="included-clear-filters-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Clearing restores every row rather than leaving the user stuck.
+    expect(wrapper.text()).toContain('Type 2 diabetes mellitus')
+    expect(wrapper.text()).toContain('Metformin 500 MG')
+  })
+
+  it('keeps the filter bar visible while nothing matches, so filters can be undone', async () => {
+    const wrapper = mountWith()
+    facetBar(wrapper).vm.$emit('update:resultFilter', 'no-such-concept')
+    await wrapper.vm.$nextTick()
+    expect(facetBar(wrapper).exists()).toBe(true)
+  })
+
+  it('hides the filter bar when there is nothing to filter', () => {
+    const wrapper = mount(IncludedConceptsTable, {
+      global: { plugins: [vuetify] },
+      props: { items: [], loading: false, error: null, manualCount: 2 },
+    })
+    expect(facetBar(wrapper).exists()).toBe(false)
+  })
+
+  it('lets the table own the page size so the rows-per-page control is live', async () => {
+    const wrapper = mountWith()
+    const table = wrapper.findComponent({ name: 'AtlasDataTable' })
+
+    // The default the table opens on.
+    expect(table.props('itemsPerPage')).toBe(50)
+
+    // A choice made in the footer is written back rather than discarded, which
+    // is what the bare `:items-per-page="50"` binding failed to do.
+    table.vm.$emit('update:itemsPerPage', 10)
+    await wrapper.vm.$nextTick()
+    expect(table.props('itemsPerPage')).toBe(10)
+  })
+
+  it('enables multi-column sort on the underlying data table', () => {
+    // AtlasDataTable forwards unknown attributes to v-data-table, so the
+    // contract worth pinning is what the data table itself ends up with.
+    const dataTable = mountWith().findComponent({ name: 'VDataTable' })
+    expect(dataTable.props('multiSort')).toBe(true)
+  })
+
+  it('keeps a multi-column sort order applied to the rows', async () => {
+    const wrapper = mountWith([
+      makeConcept(3, { conceptName: 'B second', vocabularyId: 'RxNorm' }),
+      makeConcept(1, { conceptName: 'A first', vocabularyId: 'SNOMED' }),
+      makeConcept(2, { conceptName: 'A first', vocabularyId: 'RxNorm' }),
+    ])
+    const dataTable = wrapper.findComponent({ name: 'VDataTable' })
+
+    dataTable.vm.$emit('update:sortBy', [
+      { key: 'conceptName', order: 'asc' },
+      { key: 'conceptId', order: 'desc' },
+    ])
+    await wrapper.vm.$nextTick()
+
+    // Both columns survive: name ascending, then id descending within a tie.
+    expect(dataTable.props('sortBy')).toEqual([
+      { key: 'conceptName', order: 'asc' },
+      { key: 'conceptId', order: 'desc' },
+    ])
+  })
+})

--- a/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
+++ b/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
@@ -14,8 +14,23 @@ const stubs = {
   AtlasCard: { template: '<div class="stub-card"><slot /></div>' },
   AtlasChip: { template: '<span class="stub-chip"><slot /></span>' },
   AtlasDataTable: {
-    props: ['items', 'loading'],
-    template: '<table class="stub-table"><tbody><tr v-for="i in items" :key="i.conceptId"><td>{{ i.conceptName }}</td></tr></tbody></table>',
+    name: 'AtlasDataTable',
+    // multiSort is typed so the bare `multi-sort` attribute coerces to true,
+    // the way v-data-table's own Boolean prop does.
+    props: {
+      items: { type: Array, default: () => [] },
+      loading: Boolean,
+      itemsPerPage: Number,
+      multiSort: Boolean,
+      sortBy: { type: Array, default: () => [] },
+    },
+    template: '<table class="stub-table"><tbody><tr v-for="i in items" :key="i.conceptId"><td>{{ i.conceptName }}</td></tr></tbody><tfoot v-if="items.length === 0"><slot name="no-data" /></tfoot></table>',
+  },
+  ConceptFacetFilters: {
+    name: 'ConceptFacetFilters',
+    props: ['facets', 'facetOptions', 'selected', 'activeFilterCount', 'resultFilter'],
+    emits: ['update:facet', 'update:resultFilter', 'clear'],
+    template: '<div class="stub-facets" />',
   },
   AtlasIcon: { template: '<i />' },
   AtlasSkeleton: { template: '<div class="stub-skeleton" />' },
@@ -77,5 +92,114 @@ describe('IncludedSourceCodesTable', () => {
     store.sourceCodeError = 'Network error'
     const wrapper = makeWrapper()
     expect(wrapper.find('.stub-alert').exists()).toBe(true)
+  })
+})
+
+describe('IncludedSourceCodesTable — filtering and pagination (issue #266)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(useConceptSetsStore(), 'resolveSourceCodes').mockResolvedValue()
+  })
+
+  const code = (id: number, over: Record<string, unknown> = {}) => ({
+    conceptId: id,
+    conceptName: `Code ${id}`,
+    conceptCode: `C${id}`,
+    domainId: 'Condition',
+    vocabularyId: 'ICD10CM',
+    conceptClassId: 'ICD10 code',
+    standardConcept: null,
+    invalidReason: null,
+    ...over,
+  })
+
+  function seed(items: ReturnType<typeof code>[]) {
+    const store = useConceptSetsStore()
+    store.sourceCodeItems = items as never
+    return store
+  }
+
+  const facetBar = (wrapper: ReturnType<typeof makeWrapper>) =>
+    wrapper.findComponent({ name: 'ConceptFacetFilters' })
+
+  it('offers facets for the categorical columns this table shows', () => {
+    seed([code(1)])
+    const keys = (facetBar(makeWrapper()).props('facets') as { key: string }[]).map(f => f.key)
+
+    expect(keys).toEqual(expect.arrayContaining(['conceptClassId', 'domainId', 'vocabularyId']))
+    // Standard and validity are not columns on the source-codes table.
+    expect(keys).not.toContain('standardConcept')
+    expect(keys).not.toContain('invalidReason')
+  })
+
+  it('narrows the rows to a selected facet value', async () => {
+    seed([code(1, { vocabularyId: 'ICD10CM' }), code(2, { vocabularyId: 'READ' })])
+    const wrapper = makeWrapper()
+    expect(wrapper.text()).toContain('Code 2')
+
+    facetBar(wrapper).vm.$emit('update:facet', { key: 'vocabularyId', values: ['ICD10CM'] })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Code 1')
+    expect(wrapper.text()).not.toContain('Code 2')
+  })
+
+  it('matches the free-text filter on a substring', async () => {
+    seed([code(1, { conceptName: 'Diabetes mellitus' }), code(2, { conceptName: 'Hypertension' })])
+    const wrapper = makeWrapper()
+
+    facetBar(wrapper).vm.$emit('update:resultFilter', 'betes')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('Diabetes mellitus')
+    expect(wrapper.text()).not.toContain('Hypertension')
+  })
+
+  it('drops stale filters when the included set changes', async () => {
+    const store = seed([code(1, { vocabularyId: 'ICD10CM' })])
+    const wrapper = makeWrapper()
+
+    facetBar(wrapper).vm.$emit('update:facet', { key: 'vocabularyId', values: ['ICD10CM'] })
+    await wrapper.vm.$nextTick()
+    expect(facetBar(wrapper).props('activeFilterCount')).toBe(1)
+
+    // A different included set resolves to a different value space; keeping the
+    // old selection would hide every row the new resolve produced.
+    store.includedItems = [{ conceptId: 99 }] as never
+    await wrapper.vm.$nextTick()
+
+    expect(facetBar(wrapper).props('activeFilterCount')).toBe(0)
+  })
+
+  it('lets the table own the page size so the rows-per-page control is live', async () => {
+    seed([code(1)])
+    const wrapper = makeWrapper()
+    const table = wrapper.findComponent({ name: 'AtlasDataTable' })
+
+    expect(table.props('itemsPerPage')).toBe(50)
+
+    table.vm.$emit('update:itemsPerPage', 25)
+    await wrapper.vm.$nextTick()
+    expect(table.props('itemsPerPage')).toBe(25)
+  })
+
+  it('enables multi-column sort', () => {
+    seed([code(1)])
+    expect(
+      makeWrapper().findComponent({ name: 'AtlasDataTable' }).props('multiSort')
+    ).toBe(true)
+  })
+
+  it('offers a way back when the filters match nothing', async () => {
+    seed([code(1)])
+    const wrapper = makeWrapper()
+
+    facetBar(wrapper).vm.$emit('update:resultFilter', 'no-such-code')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toMatch(/No concepts match the active filters/i)
+
+    await wrapper.find('[data-testid="source-codes-clear-filters-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('Code 1')
   })
 })


### PR DESCRIPTION
## Problem

The Included concepts and Source codes tables in the concept set editor list everything a set resolves to — routinely thousands of rows — with no way to narrow them down. Reviewing what a concept set actually contains means scrolling.

The rows-per-page dropdown at the foot of both tables is visible and clickable but does nothing: picking a different value leaves the page showing the same number of rows.

## What changes

Both tables now carry the same filter bar used by concept search results and the Compare tab:

- **Filter by category** — select and deselect values for the columns each table shows, with a live count next to every option. Included concepts filters on Vocabulary, Domain, Standard and Validity; Source codes on Class, Domain and Vocabulary. Each table only offers filters for columns it actually displays.
- **Free-text search** — matches a substring anywhere in the visible fields, not just the start.
- **Rows per page** — the dropdown now takes effect.
- **Multi-column sort** — sort by more than one column at a time. Note the modifier is **shift**-click rather than ctrl-click; that is what the underlying table library uses.

Filtering everything out shows a message saying so, with a Clear filters button, rather than the "add concepts to see them here" text that would wrongly suggest the set is empty. On the Source codes tab, filters reset when the included concepts change, since the newly resolved rows have different values to filter on.

## Not included

Two requests from the comments are not covered here: showing and hiding columns, and resizing column widths. Those need new shared behaviour in the table component used across the whole application, and are better handled separately.

Fixes #266
