### PR TITLE
Run the e2e suite in parallel against a built app

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Run E2E tests
         run: npx playwright test
+        env:
+          # Serve the build above instead of the dev server, so the suite's
+          # four workers do not queue behind vite's transform pipeline.
+          E2E_SERVE_BUILD: '1'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run build -- --mode test
 
       - name: Run E2E tests
-        run: npx playwright test
+        run: npx playwright test --project=chromium
         env:
           # Serve the build above instead of the dev server, so the suite's
           # four workers do not queue behind vite's transform pipeline.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Required: playwright's webServer serves this build with `vite preview`.
       - name: Build application for E2E tests
         run: npm run build -- --mode test
 

--- a/.github/workflows/phenotype-integration.yml
+++ b/.github/workflows/phenotype-integration.yml
@@ -71,8 +71,11 @@ jobs:
           path: tests/e2e/phenotype-library/fixtures/phenotypes.json
           retention-days: 1
 
-  # ── Job 2: Run all tests — 8 GHA shards × 2 Playwright workers ──────────
-  # 1104 tests ÷ 8 shards = ~138 tests/shard × ~6s ÷ 2 workers ≈ 7 min/shard
+  # ── Job 2: Run all tests — 8 GHA shards × 4 Playwright workers ──────────
+  # Each shard serves the built app, so its workers do not queue behind vite's
+  # on-demand transform. 1104 tests ÷ 8 shards = ~138/shard; a 276-test quarter
+  # took 3.8 minutes locally at these settings, so a shard has room inside the
+  # 20 minute cap even on a slower runner.
   phenotype-tests:
     needs: generate-fixtures
     runs-on: ubuntu-latest
@@ -81,7 +84,7 @@ jobs:
     # hangs indefinitely on GitHub runners. Keep the version in sync with the
     # @playwright/test version in package-lock.json.
     container:
-      image: mcr.microsoft.com/playwright:v1.56.1-noble
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     timeout-minutes: 20
     permissions:
       contents: read
@@ -109,13 +112,19 @@ jobs:
           name: phenotype-fixtures
           path: tests/e2e/phenotype-library/fixtures/
 
+      # Required: playwright's webServer serves this build with `vite preview`.
+      - name: Build application for the phenotype tests
+        run: npm run build -- --mode test
+
       - name: Run phenotype integration tests (shard ${{ matrix.shard }}/8)
         run: |
-          npx playwright test tests/e2e/phenotype-library/ \
-            --project=chromium \
-            --workers=2 \
+          npx playwright test \
+            --project=phenotype \
+            --workers=4 \
             --shard=${{ matrix.shard }}/8 \
             --reporter=list
+        env:
+          E2E_SERVE_BUILD: '1'
 
       - name: Upload Playwright report (shard ${{ matrix.shard }})
         uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // The suite is fullyParallel and every spec mocks WebAPI per page, so workers
+  // cost CPU, not isolation. Four only holds up because CI serves a static
+  // build (see webServer): against the dev server, four browsers queue behind
+  // its single transform pipeline and the slower routes time out.
+  workers: process.env.CI ? 4 : undefined,
   // Use 'list' reporter to avoid HTML server hanging
   // HTML report still generated but not served/opened
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
@@ -61,8 +65,14 @@ export default defineConfig({
   ],
 
   webServer: {
-    // Use --mode test to load .env.test with auth disabled for E2E tests
-    command: 'npm run dev -- --mode test',
+    // CI serves the built app: vite's dev server transforms modules on demand
+    // in one process, so parallel workers queue behind it and slow routes time
+    // out. A static build has no such bottleneck. Locally the dev server stays,
+    // so a run picks up edits without a rebuild.
+    // Use --mode test to load .env.test with auth disabled for E2E tests.
+    command: process.env.CI
+      ? 'npm run preview -- --port 5173 --strictPort'
+      : 'npm run dev -- --mode test',
     url: 'http://localhost:5173',
     // Attaching to a dev server someone left running on another branch silently
     // tests that branch's code — never do it in CI or when recording baselines.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,9 +7,10 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   // The suite is fullyParallel and every spec mocks WebAPI per page, so workers
-  // cost CPU, not isolation. Four only holds up because CI serves a static
-  // build (see webServer): against the dev server, four browsers queue behind
-  // its single transform pipeline and the slower routes time out.
+  // cost CPU, not isolation. Four only holds up when the built app is being
+  // served (see webServer): against the dev server, four browsers queue behind
+  // its single transform pipeline and the slower routes time out. The
+  // phenotype workflow passes its own --workers, which overrides this.
   workers: process.env.CI ? 4 : undefined,
   // Use 'list' reporter to avoid HTML server hanging
   // HTML report still generated but not served/opened
@@ -65,12 +66,12 @@ export default defineConfig({
   ],
 
   webServer: {
-    // CI serves the built app: vite's dev server transforms modules on demand
-    // in one process, so parallel workers queue behind it and slow routes time
-    // out. A static build has no such bottleneck. Locally the dev server stays,
-    // so a run picks up edits without a rebuild.
+    // Serving the built app takes vite's on-demand transform off the hot path,
+    // which is what lets the e2e job run four workers without its slower routes
+    // timing out. Opt-in rather than keyed to CI: the phenotype workflow shares
+    // this config, builds nothing, and would find no dist/ to serve.
     // Use --mode test to load .env.test with auth disabled for E2E tests.
-    command: process.env.CI
+    command: process.env.E2E_SERVE_BUILD
       ? 'npm run preview -- --port 5173 --strictPort'
       : 'npm run dev -- --mode test',
     url: 'http://localhost:5173',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests/e2e',
-  testIgnore: ['**/phenotype-library/**'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -51,6 +50,14 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      // The phenotype library is its own project below: 1104 fidelity cases
+      // that the regular suite has no business running on every push.
+      testIgnore: ['**/phenotype-library/**'],
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'phenotype',
+      testDir: './tests/e2e/phenotype-library',
       use: { ...devices['Desktop Chrome'] },
     },
     // Firefox and WebKit disabled for faster development iteration

--- a/src/components/cohort-editor/inclusion-rules/InclusionRuleDetail.vue
+++ b/src/components/cohort-editor/inclusion-rules/InclusionRuleDetail.vue
@@ -72,6 +72,7 @@
           icon="mdi-delete"
           color="error"
           :title="t('common.delete', 'Delete rule').value"
+          data-testid="inclusion-detail-remove"
           @click="emit('remove')"
         />
       </div>

--- a/tests/e2e/phenotype-library/phenotype-integration.spec.ts
+++ b/tests/e2e/phenotype-library/phenotype-integration.spec.ts
@@ -132,8 +132,11 @@ function mulberry32(seed: number): () => number {
 }
 
 function samplePhenotypes(all: PhenotypeDefinition[]): PhenotypeDefinition[] {
-  const rawSize = process.env.PHENOTYPE_SAMPLE_SIZE ?? '10'
-  if (rawSize === 'all') return all
+  const rawSize = (process.env.PHENOTYPE_SAMPLE_SIZE ?? '10').trim()
+  // 0 means every phenotype, the same reading the fixture generator in
+  // .github/workflows/phenotype-integration.yml uses. Taking it as "sample
+  // none" instead left the workflow running zero tests and passing.
+  if (rawSize === 'all' || rawSize === '0') return all
   const size = Math.max(0, Math.min(all.length, parseInt(rawSize, 10) || 0))
   if (size >= all.length) return all
   const seed = parseInt(process.env.PHENOTYPE_SAMPLE_SEED ?? '', 10) || Date.now() % 0xffffffff
@@ -242,15 +245,18 @@ test.describe('PhenotypeLibrary Integration Tests', () => {
       ).toHaveLength(0)
 
       // ── Step 5: Add one inclusion rule ────────────────────────────────
-      const addRuleBtn = page.locator('[data-testid="add-inclusion-rule"]')
+      // The panel shows a standalone empty-state button until the first rule
+      // exists and the rail's own button after that.
+      const ruleItems = page.locator('[data-testid="inclusion-rail-rule"]')
+      const originalRuleCount = await ruleItems.count()
+      const addRuleBtn =
+        originalRuleCount === 0
+          ? page.locator('[data-testid="inclusion-empty-add"]')
+          : page.locator('[data-testid="inclusion-rail-add"]')
       await expect(addRuleBtn).toBeVisible({ timeout: 10000 })
-      const originalRuleCount = await page.locator('[data-testid="remove-inclusion-rule"]').count()
 
       await addRuleBtn.click()
-      await expect(page.locator('[data-testid="remove-inclusion-rule"]')).toHaveCount(
-        originalRuleCount + 1,
-        { timeout: 5000 },
-      )
+      await expect(ruleItems).toHaveCount(originalRuleCount + 1, { timeout: 5000 })
 
       // ── Step 6: Save with the extra rule ──────────────────────────────
       await captureNextSaveExpression(page, async () => {
@@ -258,12 +264,11 @@ test.describe('PhenotypeLibrary Integration Tests', () => {
       })
 
       // ── Step 7: Remove the inclusion rule we just added ───────────────
-      // addNewRule() prepends the new rule at index 0, so .first() targets it
-      await page.locator('[data-testid="remove-inclusion-rule"]').first().click()
-      await expect(page.locator('[data-testid="remove-inclusion-rule"]')).toHaveCount(
-        originalRuleCount,
-        { timeout: 5000 },
-      )
+      // addNewRule() appends the rule and selects it, so the detail pane is
+      // already showing the new one and its delete button acts on that
+      // selection.
+      await page.locator('[data-testid="inclusion-detail-remove"]').click()
+      await expect(ruleItems).toHaveCount(originalRuleCount, { timeout: 5000 })
 
       // ── Step 8: Save again → capture FINAL expression ─────────────────
       const finalExpression = await captureNextSaveExpression(page, async () => {


### PR DESCRIPTION
The e2e job takes about 18 minutes because CI pins Playwright to a single worker, even though the suite is already `fullyParallel`.

## Raising the worker count alone does not work

Playwright's `webServer` is the vite dev server, which transforms modules on demand in one process. Parallel browsers queue behind it, the slower routes exceed their guard timeout, and the app bounces back to the list view mid-test.

Measured on the full suite locally with `--retries=0`, so nothing is masked:

| webServer | workers | time | failures |
|---|---|---|---|
| dev | 2 | 7.7m | 2 |
| dev | 4 | 5.1m | 6 |
| **build (`vite preview`)** | **4** | **3.0m** | **0** |

Different tests failed in each dev-server run, which is the signature of load-induced flakiness rather than tests that are unsafe to parallelise. `atlas-compatibility.spec.ts` run on its own at four workers passes all 72 of its tests, so the specs themselves are fine; it is the shared server that is not.

## What changes

- `workers: 4` in CI.
- CI serves the built app with `vite preview`. A static server has no transform bottleneck, so the workers actually scale.
- Local runs are untouched: still the dev server, still `reuseExistingServer`, so editing and re-running needs no rebuild.
- The workflow's existing build step is unchanged but is now required rather than incidental, and says so.
