### PR TITLE
Fixes for generation polling on Characterization, Pathway, Incidence Rates

### DIFF
--- a/src/components/characterization-results/ResultsHeader.vue
+++ b/src/components/characterization-results/ResultsHeader.vue
@@ -116,7 +116,7 @@ const emit = defineEmits<{
 
 const { tv } = useI18n()
 
-function formatTime(value: number | undefined): string {
+function formatTime(value: number | null | undefined): string {
   if (typeof value !== 'number' || value <= 0) {
     return '—'
   }

--- a/src/components/characterization/CharacterizationRunMeta.vue
+++ b/src/components/characterization/CharacterizationRunMeta.vue
@@ -71,12 +71,12 @@ const props = defineProps<{
 
 const { tv } = useI18n()
 
-function formatTime(value: number | undefined): string {
+function formatTime(value: number | null | undefined): string {
   if (typeof value !== 'number' || value <= 0) return '—'
   return formatDateTime(value)
 }
 
-function effectiveDuration(startTime: number | undefined, endTime: number | undefined, duration: number | undefined): number | undefined {
+function effectiveDuration(startTime: number | null | undefined, endTime: number | null | undefined, duration: number | null | undefined): number | undefined {
   if (typeof duration === 'number' && duration > 0) return duration
   if (typeof startTime === 'number' && typeof endTime === 'number') {
     return Math.max(0, endTime - startTime)

--- a/src/components/characterization/CharacterizationWorkbench.vue
+++ b/src/components/characterization/CharacterizationWorkbench.vue
@@ -30,12 +30,14 @@
       <DataSourceRunTable
         :sources="runTableSources"
         :executions="runTableExecutions"
+        :selected-execution-id="selectedExecutionId"
         :loading="store.executionsLoading"
         :run-disabled="runDisabled"
         :run-disabled-reason="runDisabledReason"
         data-testid="char-workbench-run-table"
         @run="handleRun"
         @cancel="handleCancel"
+        @select-result="onSelectHistoryExecution"
         @show-history="handleShowHistory"
       />
 
@@ -134,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import CharacterizationDesignRail from './CharacterizationDesignRail.vue'
@@ -171,8 +173,18 @@ import {
 } from '@/models/characterization.types'
 import type { CohortDefinitionSummary } from '@/models/webapi.types'
 import type { FeatureAnalysisListItem } from '@/models/feature-analysis.types'
-import { arrayToCsv, downloadCsv } from '@/utils/csv'
-import { buildTable1 } from '@/utils/characterization-table1'
+import { exportCharacterizationResults } from './characterization-export'
+import {
+  resolveActiveRunSummary,
+  resolveAvailableCohortsForFilter,
+  resolveAvailableDomains,
+  resolveCohorts,
+  resolveEmptyVariant,
+  resolveHasStrata,
+  resolveHistorySourceName,
+  resolveRunDisabledReason,
+  resolveSelectedExecutionId,
+} from './characterization-workbench-state'
 
 import type { ViewMode } from './CharacterizationCanvasToolbar.vue'
 
@@ -207,18 +219,44 @@ const errorMessage = ref<string>('')
 const historyOpen = ref<boolean>(false)
 const historySourceKey = ref<string | null>(null)
 
-const cohorts = computed<LinkedCohort[]>(() => {
-  const map = new Map<number, LinkedCohort>()
-  for (const r of prevalence.value) for (const c of r.cohorts) if (!map.has(c.id)) map.set(c.id, c)
-  for (const r of distribution.value) for (const c of r.cohorts) if (!map.has(c.id)) map.set(c.id, c)
-  if (map.size > 0) return Array.from(map.values())
-  return props.modelValue.cohorts
-})
+async function refreshExecutions(characterizationId: number): Promise<void> {
+  await store.loadExecutions(characterizationId)
+  seedRunningExecutions()
+  await selectDefaultExecution()
+}
 
-const hasStrata = computed<boolean>(() =>
-  props.modelValue.stratas.length > 0
-  || (props.modelValue.stratifiedBy ?? '').trim().length > 0
-)
+async function selectDefaultExecution(): Promise<void> {
+  if (selectedExecutionId.value !== null) return
+  const selectable =
+    store.executions.find(e => e.status === 'COMPLETED') ??
+    store.executions.find(e => e.status === 'FAILED')
+  if (selectable) {
+    await router.replace({ query: { ...route.query, run: String(selectable.id) } })
+  }
+}
+
+function seedRunningExecutions(): void {
+  for (const execution of store.executions) {
+    if (!isTerminalStatus(execution.status)) {
+      store.pollExecution(execution.id, () => {
+        if (props.characterizationId != null) {
+          void refreshExecutions(props.characterizationId)
+        }
+      })
+    }
+  }
+}
+
+const cohorts = computed<LinkedCohort[]>(() => resolveCohorts({
+  prevalence: prevalence.value,
+  distribution: distribution.value,
+  fallbackCohorts: props.modelValue.cohorts,
+}))
+
+const hasStrata = computed<boolean>(() => resolveHasStrata({
+  stratasLength: props.modelValue.stratas.length,
+  stratifiedBy: props.modelValue.stratifiedBy,
+}))
 
 const availableAnalyses = computed<{ id: number; name: string }[]>(() => {
   const map = new Map<number, string>()
@@ -227,46 +265,29 @@ const availableAnalyses = computed<{ id: number; name: string }[]>(() => {
   return Array.from(map.entries()).map(([id, name]) => ({ id, name }))
 })
 
-const availableDomains = computed<string[]>(() => {
-  const set = new Set<string>()
-  for (const r of prevalence.value) if (r.domainId) set.add(r.domainId)
-  for (const r of distribution.value) if (r.domainId) set.add(r.domainId)
-  return Array.from(set).sort()
-})
+const availableDomains = computed<string[]>(() => resolveAvailableDomains({
+  prevalence: prevalence.value,
+  distribution: distribution.value,
+}))
 
-const availableCohortsForFilter = computed<LinkedCohort[]>(() => {
-  const map = new Map<number, LinkedCohort>()
-  for (const r of prevalence.value) for (const c of r.cohorts) if (!map.has(c.id)) map.set(c.id, c)
-  for (const r of distribution.value) for (const c of r.cohorts) if (!map.has(c.id)) map.set(c.id, c)
-  return Array.from(map.values())
-})
+const availableCohortsForFilter = computed<LinkedCohort[]>(() => resolveAvailableCohortsForFilter({
+  prevalence: prevalence.value,
+  distribution: distribution.value,
+}))
 
-const selectedExecutionId = computed<number | null>(() => {
-  const q = route.query?.run
-  if (typeof q === 'string') {
-    const n = Number(q)
-    return Number.isFinite(n) ? n : null
-  }
-  return null
-})
+const selectedExecutionId = computed<number | null>(() => resolveSelectedExecutionId(route.query?.run))
 
-const activeRunSummary = computed(() => {
-  if (!execution.value) return null
-  return {
-    id: execution.value.id,
-    sourceKey: execution.value.sourceKey,
-    personCount: resultCount.value || undefined,
-  }
-})
+const activeRunSummary = computed(() => resolveActiveRunSummary({
+  execution: execution.value,
+  resultCount: resultCount.value,
+}))
 
-const emptyVariant = computed<'no-runs' | 'run-pending' | 'run-failed' | null>(() => {
-  if (!props.characterizationId) return null
-  if (store.executions.length === 0) return 'no-runs'
-  if (selectedExecutionId.value === null) return null
-  if (execution.value && !isTerminalStatus(execution.value.status)) return 'run-pending'
-  if (execution.value?.status === 'FAILED') return 'run-failed'
-  return null
-})
+const emptyVariant = computed(() => resolveEmptyVariant({
+  characterizationId: props.characterizationId,
+  executionCount: store.executions.length,
+  selectedExecutionId: selectedExecutionId.value,
+  executionStatus: execution.value?.status,
+}))
 
 const runTableSources = computed<RunTableSource[]>(() =>
   sourcesStore.sources.map((s) => ({
@@ -281,53 +302,37 @@ const runTableExecutions = computed<RunTableExecution[]>(() =>
     sourceKey: e.sourceKey,
     status: e.status,
     startTime: e.startTime,
-    endTime: e.endTime,
+    endTime: e.endTime ?? undefined,
     duration: e.duration,
   }))
 )
 
 const runDisabled = computed<boolean>(() => props.characterizationId == null || store.isDirty)
 
-const runDisabledReason = computed<string>(() => {
-  if (props.characterizationId == null) {
-    return tv(
-      'characterizations.editor.executions.runDisabledNoId',
-      'Save the characterization before running.'
-    )
-  }
-  if (store.isDirty) {
-    return tv('const.disabledReason.dirty', 'Save your changes before running.')
-  }
-  return ''
-})
+const runDisabledReason = computed<string>(() => resolveRunDisabledReason({
+  characterizationId: props.characterizationId,
+  isDirty: store.isDirty,
+  translate: tv,
+}))
 
-const historySourceName = computed<string>(() => {
-  if (!historySourceKey.value) return ''
-  const found = sourcesStore.sources.find(s => s.sourceKey === historySourceKey.value)
-  return found?.sourceName ?? historySourceKey.value
-})
+const historySourceName = computed<string>(() => resolveHistorySourceName({
+  historySourceKey: historySourceKey.value,
+  sources: sourcesStore.sources,
+}))
 
 watch(
   () => props.characterizationId,
   async (id, prev) => {
+    if (prev !== undefined && prev !== id) {
+      store.dispose()
+    }
     if (id == null) return
     if (prev !== undefined && prev !== id && route.query.run !== undefined) {
       const { run: _run, ...rest } = route.query
       void _run
       await router.replace({ query: rest })
     }
-    await store.loadExecutions(id)
-    if (selectedExecutionId.value === null) {
-      // Prefer a run with results, but fall back to a failed one rather than
-      // selecting nothing: with only failed runs the workbench would sit on
-      // its empty state and never report that the generation failed.
-      const selectable =
-        store.executions.find(e => e.status === 'COMPLETED') ??
-        store.executions.find(e => e.status === 'FAILED')
-      if (selectable) {
-        await router.replace({ query: { ...route.query, run: String(selectable.id) } })
-      }
-    }
+    await refreshExecutions(id)
   },
   { immediate: true },
 )
@@ -379,6 +384,10 @@ onMounted(async () => {
   }
 })
 
+onBeforeUnmount(() => {
+  store.dispose()
+})
+
 async function handleRun(sourceKey: string): Promise<void> {
   if (props.characterizationId == null) return
   try {
@@ -410,7 +419,8 @@ function handleShowHistory(sourceKey: string): void {
   historyOpen.value = true
 }
 
-function onSelectHistoryExecution(id: number | string): void {
+function onSelectHistoryExecution(id: number | string | undefined): void {
+  if (id == null) return
   const numericId = typeof id === 'number' ? id : Number(id)
   if (!Number.isFinite(numericId)) return
   historyOpen.value = false
@@ -429,69 +439,15 @@ function onRunStarted(exec: CharacterizationExecution): void {
 function onExplore(row: PrevalenceStat): void { emit('explore', row) }
 
 function onExport(): void {
-  const built = buildTable1({
+  exportCharacterizationResults({
     prevalence: prevalence.value,
     distribution: distribution.value,
     cohorts: cohorts.value,
     config: config.value,
     filters: filters.value,
     cohortSizes: cohortSizes.value,
+    selectedExecutionId: selectedExecutionId.value,
   })
-  if (built.rows.length === 0) return
-
-  const headers: { key: string; label: string }[] = [
-    { key: 'kind', label: 'Type' },
-    { key: 'analysisId', label: 'Analysis ID' },
-    { key: 'analysisName', label: 'Analysis' },
-    { key: 'covariateId', label: 'Covariate ID' },
-    { key: 'covariateName', label: 'Covariate' },
-    { key: 'conceptId', label: 'Concept ID' },
-  ]
-  for (const col of built.columns) {
-    const colLabel = col.strataLabel
-      ? `${col.cohortName} · ${col.strataLabel}`
-      : col.cohortName
-    headers.push({ key: `${col.cohortKey}__primary`, label: `${colLabel} · primary` })
-    headers.push({ key: `${col.cohortKey}__secondary`, label: `${colLabel} · secondary` })
-  }
-  if (built.includeStdDiff) {
-    headers.push({ key: 'stdDiff', label: 'Std Diff' })
-  }
-
-  const rows: Array<Record<string, string | number | null>> = []
-  for (const row of built.rows) {
-    if (row.kind === 'group') continue
-    const out: Record<string, string | number | null> = {
-      kind: row.kind,
-      analysisId: row.analysisId,
-      analysisName: row.analysisName,
-      covariateId: row.covariateId,
-      covariateName: row.label,
-      conceptId: row.conceptId,
-    }
-    for (const col of built.columns) {
-      const cell = row.cells[col.cohortKey]
-      if (cell === null || cell === undefined) {
-        out[`${col.cohortKey}__primary`] = null
-        out[`${col.cohortKey}__secondary`] = null
-      } else if (row.kind === 'binary') {
-        out[`${col.cohortKey}__primary`] = (cell as { count: number }).count
-        out[`${col.cohortKey}__secondary`] = (cell as { pct: number }).pct
-      } else {
-        out[`${col.cohortKey}__primary`] = (cell as { primary: number }).primary
-        out[`${col.cohortKey}__secondary`] = (cell as { secondary: number }).secondary
-      }
-    }
-    if (built.includeStdDiff && row.kind === 'binary' && typeof row.stdDiff === 'number') {
-      out.stdDiff = row.stdDiff
-    } else {
-      out.stdDiff = null
-    }
-    rows.push(out)
-  }
-
-  const csv = arrayToCsv(rows, headers)
-  downloadCsv(`characterization-${selectedExecutionId.value ?? 'results'}.csv`, csv)
 }
 </script>
 

--- a/src/components/characterization/characterization-export.ts
+++ b/src/components/characterization/characterization-export.ts
@@ -1,13 +1,17 @@
 import { arrayToCsv, downloadCsv } from '@/utils/csv'
 import { buildTable1 } from '@/utils/characterization-table1'
-import type { CharacterizationDefinition } from '@/models/characterization.types'
-import type { PrevalenceStat } from '@/models/characterization-results.types'
+import type {
+  CharacterizationDefinition,
+  DistributionStat,
+  PrevalenceStat,
+  Table1Config,
+} from '@/models/characterization.types'
 
 export function exportCharacterizationResults(input: {
   prevalence: PrevalenceStat[]
-  distribution: PrevalenceStat[]
+  distribution: DistributionStat[]
   cohorts: CharacterizationDefinition['cohorts']
-  config: { showStdDiffCI: boolean }
+  config: Table1Config
   filters: {
     threshold: number
     selectedAnalysisIds: number[]

--- a/src/components/characterization/characterization-export.ts
+++ b/src/components/characterization/characterization-export.ts
@@ -1,0 +1,83 @@
+import { arrayToCsv, downloadCsv } from '@/utils/csv'
+import { buildTable1 } from '@/utils/characterization-table1'
+import type { CharacterizationDefinition } from '@/models/characterization.types'
+import type { PrevalenceStat } from '@/models/characterization-results.types'
+
+export function exportCharacterizationResults(input: {
+  prevalence: PrevalenceStat[]
+  distribution: PrevalenceStat[]
+  cohorts: CharacterizationDefinition['cohorts']
+  config: { showStdDiffCI: boolean }
+  filters: {
+    threshold: number
+    selectedAnalysisIds: number[]
+    selectedDomains: string[]
+    selectedCohortId: number | null
+  }
+  cohortSizes: Record<string, number>
+  selectedExecutionId: number | null
+}): void {
+  const built = buildTable1({
+    prevalence: input.prevalence,
+    distribution: input.distribution,
+    cohorts: input.cohorts,
+    config: input.config,
+    filters: input.filters,
+    cohortSizes: input.cohortSizes,
+  })
+  if (built.rows.length === 0) return
+
+  const headers: { key: string; label: string }[] = [
+    { key: 'kind', label: 'Type' },
+    { key: 'analysisId', label: 'Analysis ID' },
+    { key: 'analysisName', label: 'Analysis' },
+    { key: 'covariateId', label: 'Covariate ID' },
+    { key: 'covariateName', label: 'Covariate' },
+    { key: 'conceptId', label: 'Concept ID' },
+  ]
+  for (const col of built.columns) {
+    const colLabel = col.strataLabel
+      ? `${col.cohortName} · ${col.strataLabel}`
+      : col.cohortName
+    headers.push({ key: `${col.cohortKey}__primary`, label: `${colLabel} · primary` })
+    headers.push({ key: `${col.cohortKey}__secondary`, label: `${colLabel} · secondary` })
+  }
+  if (built.includeStdDiff) {
+    headers.push({ key: 'stdDiff', label: 'Std Diff' })
+  }
+
+  const rows: Array<Record<string, string | number | null>> = []
+  for (const row of built.rows) {
+    if (row.kind === 'group') continue
+    const out: Record<string, string | number | null> = {
+      kind: row.kind,
+      analysisId: row.analysisId,
+      analysisName: row.analysisName,
+      covariateId: row.covariateId,
+      covariateName: row.label,
+      conceptId: row.conceptId,
+    }
+    for (const col of built.columns) {
+      const cell = row.cells[col.cohortKey]
+      if (cell === null || cell === undefined) {
+        out[`${col.cohortKey}__primary`] = null
+        out[`${col.cohortKey}__secondary`] = null
+      } else if (row.kind === 'binary') {
+        out[`${col.cohortKey}__primary`] = (cell as { count: number }).count
+        out[`${col.cohortKey}__secondary`] = (cell as { pct: number }).pct
+      } else {
+        out[`${col.cohortKey}__primary`] = (cell as { primary: number }).primary
+        out[`${col.cohortKey}__secondary`] = (cell as { secondary: number }).secondary
+      }
+    }
+    if (built.includeStdDiff && row.kind === 'binary' && typeof row.stdDiff === 'number') {
+      out.stdDiff = row.stdDiff
+    } else {
+      out.stdDiff = null
+    }
+    rows.push(out)
+  }
+
+  const csv = arrayToCsv(rows, headers)
+  downloadCsv(`characterization-${input.selectedExecutionId ?? 'results'}.csv`, csv)
+}

--- a/src/components/characterization/characterization-workbench-state.ts
+++ b/src/components/characterization/characterization-workbench-state.ts
@@ -1,11 +1,10 @@
-import type { LinkedCohort } from '@/models/characterization.types'
-import type { PrevalenceStat } from '@/models/characterization-results.types'
+import type { DistributionStat, LinkedCohort, PrevalenceStat } from '@/models/characterization.types'
 
 export type EmptyVariant = 'no-runs' | 'run-pending' | 'run-failed' | null
 
 export function resolveCohorts(input: {
   prevalence: PrevalenceStat[]
-  distribution: PrevalenceStat[]
+  distribution: DistributionStat[]
   fallbackCohorts: LinkedCohort[]
 }): LinkedCohort[] {
   const map = new Map<number, LinkedCohort>()
@@ -20,7 +19,7 @@ export function resolveHasStrata(input: { stratasLength: number; stratifiedBy: s
 
 export function resolveAvailableDomains(input: {
   prevalence: PrevalenceStat[]
-  distribution: PrevalenceStat[]
+  distribution: DistributionStat[]
 }): string[] {
   const set = new Set<string>()
   for (const row of input.prevalence) if (row.domainId) set.add(row.domainId)
@@ -30,7 +29,7 @@ export function resolveAvailableDomains(input: {
 
 export function resolveAvailableCohortsForFilter(input: {
   prevalence: PrevalenceStat[]
-  distribution: PrevalenceStat[]
+  distribution: DistributionStat[]
 }): LinkedCohort[] {
   const map = new Map<number, LinkedCohort>()
   for (const row of input.prevalence) for (const cohort of row.cohorts) if (!map.has(cohort.id)) map.set(cohort.id, cohort)

--- a/src/components/characterization/characterization-workbench-state.ts
+++ b/src/components/characterization/characterization-workbench-state.ts
@@ -1,0 +1,98 @@
+import type { LinkedCohort } from '@/models/characterization.types'
+import type { PrevalenceStat } from '@/models/characterization-results.types'
+
+export type EmptyVariant = 'no-runs' | 'run-pending' | 'run-failed' | null
+
+export function resolveCohorts(input: {
+  prevalence: PrevalenceStat[]
+  distribution: PrevalenceStat[]
+  fallbackCohorts: LinkedCohort[]
+}): LinkedCohort[] {
+  const map = new Map<number, LinkedCohort>()
+  for (const row of input.prevalence) for (const cohort of row.cohorts) if (!map.has(cohort.id)) map.set(cohort.id, cohort)
+  for (const row of input.distribution) for (const cohort of row.cohorts) if (!map.has(cohort.id)) map.set(cohort.id, cohort)
+  return map.size > 0 ? Array.from(map.values()) : input.fallbackCohorts
+}
+
+export function resolveHasStrata(input: { stratasLength: number; stratifiedBy: string | null | undefined }): boolean {
+  return input.stratasLength > 0 || (input.stratifiedBy ?? '').trim().length > 0
+}
+
+export function resolveAvailableDomains(input: {
+  prevalence: PrevalenceStat[]
+  distribution: PrevalenceStat[]
+}): string[] {
+  const set = new Set<string>()
+  for (const row of input.prevalence) if (row.domainId) set.add(row.domainId)
+  for (const row of input.distribution) if (row.domainId) set.add(row.domainId)
+  return Array.from(set).sort()
+}
+
+export function resolveAvailableCohortsForFilter(input: {
+  prevalence: PrevalenceStat[]
+  distribution: PrevalenceStat[]
+}): LinkedCohort[] {
+  const map = new Map<number, LinkedCohort>()
+  for (const row of input.prevalence) for (const cohort of row.cohorts) if (!map.has(cohort.id)) map.set(cohort.id, cohort)
+  for (const row of input.distribution) for (const cohort of row.cohorts) if (!map.has(cohort.id)) map.set(cohort.id, cohort)
+  return Array.from(map.values())
+}
+
+export function resolveSelectedExecutionId(runQuery: unknown): number | null {
+  if (typeof runQuery === 'string') {
+    const parsed = Number(runQuery)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+export function resolveActiveRunSummary(input: {
+  execution: { id: number; sourceKey: string } | null
+  resultCount: number
+}): { id: number; sourceKey: string; personCount?: number } | null {
+  if (!input.execution) return null
+  return {
+    id: input.execution.id,
+    sourceKey: input.execution.sourceKey,
+    personCount: input.resultCount || undefined,
+  }
+}
+
+export function resolveEmptyVariant(input: {
+  characterizationId: number | null
+  executionCount: number
+  selectedExecutionId: number | null
+  executionStatus: string | null | undefined
+}): EmptyVariant {
+  if (!input.characterizationId) return null
+  if (input.executionCount === 0) return 'no-runs'
+  if (input.selectedExecutionId === null) return null
+  if (input.executionStatus && input.executionStatus !== 'COMPLETED' && input.executionStatus !== 'FAILED') {
+    return 'run-pending'
+  }
+  if (input.executionStatus === 'FAILED') return 'run-failed'
+  return null
+}
+
+export function resolveHistorySourceName(input: {
+  historySourceKey: string | null
+  sources: Array<{ sourceKey: string; sourceName?: string | null }>
+}): string {
+  if (!input.historySourceKey) return ''
+  const found = input.sources.find(source => source.sourceKey === input.historySourceKey)
+  return found?.sourceName ?? input.historySourceKey
+}
+
+export function resolveRunDisabledReason(input: {
+  characterizationId: number | null
+  isDirty: boolean
+  translate: (key: string, fallback: string) => string
+}): string {
+  if (input.characterizationId == null) {
+    return input.translate('characterizations.editor.executions.runDisabledNoId', 'Save the characterization before running.')
+  }
+  if (input.isDirty) {
+    return input.translate('const.disabledReason.dirty', 'Save your changes before running.')
+  }
+  return ''
+}

--- a/src/components/generation/DataSourceRunRow.vue
+++ b/src/components/generation/DataSourceRunRow.vue
@@ -32,7 +32,28 @@
       {{ primaryLabel }}
     </AtlasButton>
 
+    <AtlasTooltip
+      v-if="canViewLatestResult"
+      location="top"
+    >
+      <template #activator="{ props: tipProps }">
+        <span v-bind="tipProps">
+          <AtlasIconButton
+            :icon="latestResultIcon"
+            v-bind="{ ariaLabel: viewLatestLabel }"
+            variant="text"
+            size="sm"
+            :tone="isActiveLatestResult ? 'primary' : 'neutral'"
+            :data-testid="`view-latest-btn-${sourceKey}`"
+            @click="$emit('select-result')"
+          />
+        </span>
+      </template>
+      <span>{{ viewLatestLabel }}</span>
+    </AtlasTooltip>
+
     <AtlasIconButton
+      v-if="!hideHistoryButton"
       icon="mdi-history"
       v-bind="{ ariaLabel: historyLabel }"
       variant="text"
@@ -43,7 +64,7 @@
       @click="$emit('show-history')"
     />
     <span
-      v-if="historyCount > 1"
+      v-if="!hideHistoryButton && historyCount > 1"
       class="dsrr-count"
       :data-testid="`history-count-${sourceKey}`"
     >{{ historyCount }}</span>
@@ -60,22 +81,29 @@ import type { GenerationStatus } from '@/models/characterization.types'
 interface Props {
   sourceKey: string
   latestStatus?: GenerationStatus
+  latestExecutionId?: number | string | null
+  selectedExecutionId?: number | string | null
   historyCount: number
   runDisabled?: boolean
   runDisabledReason?: string
   hideCancel?: boolean
+  hideHistoryButton?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   latestStatus: undefined,
+  latestExecutionId: null,
+  selectedExecutionId: null,
   runDisabled: false,
   runDisabledReason: '',
   hideCancel: false,
+  hideHistoryButton: false,
 })
 
 const emit = defineEmits<{
   run: []
   cancel: []
+  'select-result': []
   'show-history': []
 }>()
 
@@ -89,6 +117,13 @@ const isActive = computed(() =>
   props.latestStatus === 'RUNNING'
 )
 const isStopping = computed(() => props.latestStatus === 'STOPPING')
+const isActiveLatestResult = computed(() =>
+  props.selectedExecutionId != null &&
+  props.latestExecutionId != null &&
+  String(props.selectedExecutionId) === String(props.latestExecutionId)
+)
+const canViewLatestResult = computed(() => props.latestStatus === 'COMPLETED' && props.latestExecutionId != null)
+const latestResultIcon = computed(() => (isActiveLatestResult.value ? 'mdi-eye' : 'mdi-eye-outline'))
 
 const primaryLabel = computed(() => {
   if (isStopping.value) {
@@ -129,6 +164,7 @@ const disabledReason = computed(() => {
 
 const historyDisabled = computed(() => props.historyCount === 0)
 const historyLabel = tv('components.analysisExecution.previousRuns', 'Previous runs')
+const viewLatestLabel = tv('components.analysisExecution.viewResults', 'View results')
 
 function onPrimaryClick() {
   if (effectiveDisabled.value) return

--- a/src/components/generation/DataSourceRunTable.vue
+++ b/src/components/generation/DataSourceRunTable.vue
@@ -68,12 +68,16 @@
         <DataSourceRunRow
           :source-key="(item as Row).sourceKey"
           :latest-status="(item as Row).latestStatus"
+          :latest-execution-id="(item as Row).latestExecutionId"
+          :selected-execution-id="selectedExecutionId"
           :history-count="(item as Row).count"
           :run-disabled="runDisabled"
           :run-disabled-reason="runDisabledReason"
           :hide-cancel="hideCancel"
+          :hide-history-button="hideHistoryButton"
           @run="$emit('run', (item as Row).sourceKey)"
           @cancel="$emit('cancel', (item as Row).sourceKey)"
+          @select-result="$emit('select-result', (item as Row).latestExecutionId)"
           @show-history="$emit('show-history', (item as Row).sourceKey)"
         />
         <AtlasButton
@@ -133,6 +137,8 @@ interface Props {
   showPatientCount?: boolean
   extraActions?: ExtraAction[]
   hideCancel?: boolean
+  hideHistoryButton?: boolean
+  selectedExecutionId?: number | string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -143,11 +149,14 @@ const props = withDefaults(defineProps<Props>(), {
   showPatientCount: false,
   extraActions: () => [],
   hideCancel: false,
+  hideHistoryButton: false,
+  selectedExecutionId: null,
 })
 
 const emit = defineEmits<{
   run: [sourceKey: string]
   cancel: [sourceKey: string]
+  'select-result': [executionId: number | string | undefined]
   'show-history': [sourceKey: string]
   'extra-action': [actionKey: string, sourceKey: string]
 }>()
@@ -245,6 +254,7 @@ interface Row {
   sourceKey: string
   sourceName: string
   showKey: boolean
+  latestExecutionId?: number | string
   latestStatus?: GenerationStatus
   statusLabel: string
   statusTone: AtlasChipTone
@@ -302,6 +312,7 @@ const rows = computed<Row[]>(() =>
       sourceKey: s.sourceKey,
       sourceName: s.sourceName || s.sourceKey,
       showKey: !!(s.sourceName && s.sourceName !== s.sourceKey),
+      latestExecutionId: latest?.id,
       latestStatus: status,
       statusLabel: status ?? '',
       statusTone: status ? STATUS_TONE[status] : 'neutral',

--- a/src/components/incidence-rate/IncidenceRateWorkbench.vue
+++ b/src/components/incidence-rate/IncidenceRateWorkbench.vue
@@ -272,8 +272,11 @@ watch(
   { immediate: true },
 )
 
-function onSelectRun(id: number) {
-  void router.replace({ query: { ...route.query, run: String(id) } })
+function onSelectRun(id: number | string | undefined) {
+  if (id == null) return
+  const numericId = typeof id === 'number' ? id : Number(id)
+  if (!Number.isFinite(numericId)) return
+  void router.replace({ query: { ...route.query, run: String(numericId) } })
 }
 
 onMounted(async () => {

--- a/src/components/incidence-rate/IncidenceRateWorkbench.vue
+++ b/src/components/incidence-rate/IncidenceRateWorkbench.vue
@@ -31,11 +31,14 @@
         <DataSourceRunTable
           :sources="runTableSources"
           :executions="runTableExecutions"
+          :selected-execution-id="selectedExecutionId"
           :loading="ds.isLoading"
           :run-disabled="!store.canGenerate"
           :run-disabled-reason="runDisabledReason"
+          :hide-history-button="true"
           @run="onRunSource"
           @cancel="onCancelSource"
+          @select-result="onSelectRun"
           @show-history="onShowHistory"
         />
 
@@ -151,10 +154,25 @@ import DataSourceRunTable, {
 } from '@/components/generation/DataSourceRunTable.vue'
 import PreviousRunsDialog from '@/components/generation/PreviousRunsDialog.vue'
 import { IR_TERMINAL_STATUSES } from '@/models/incidence-rate.types'
-import { arrayToCsv, downloadCsv } from '@/utils/csv'
 import type { ConceptSet } from '@/models/circe-types'
 import type { StratifyRule } from '@/models/incidence-rate.types'
-import type { GenerationStatus } from '@/models/characterization.types'
+import {
+  buildCsvExport,
+  buildRunTableExecutions,
+  resolveActiveRun,
+  resolveEmptyVariant,
+  resolveHistorySourceName,
+  resolveRunDisabledReason,
+  resolveRunTableSources,
+  resolveSelectedExecutionId,
+} from './incidence-rate-workbench-state'
+import {
+  cancelIncidenceRateSource,
+  maybeFetchIncidenceRateSources,
+  selectIncidenceRateFromHistory,
+  syncIncidenceRateSelection,
+  runIncidenceRateSource,
+} from './incidence-rate-workbench-actions'
 
 const { t, tv } = useI18n()
 const route = useRoute()
@@ -186,18 +204,12 @@ function onAddStratifyConceptSet(cs: ConceptSet) {
   }
 }
 
-const selectedExecutionId = computed<number | null>(() => {
-  const q = route.query?.run
-  if (typeof q === 'string') {
-    const n = Number(q)
-    return Number.isFinite(n) ? n : null
-  }
-  return null
-})
+const selectedExecutionId = computed<number | null>(() => resolveSelectedExecutionId(route.query?.run))
 
-const activeRun = computed(() =>
-  selectedExecutionId.value === null ? null : store.executionById(selectedExecutionId.value)
-)
+const activeRun = computed(() => resolveActiveRun({
+  selectedExecutionId: selectedExecutionId.value,
+  executionById: id => store.executionById(id),
+}))
 
 const irIdRef = computed<number | null>(() => store.currentIR?.id ?? null)
 const sourceKeyRef = computed<string | null>(() => activeRun.value?.sourceKey ?? null)
@@ -221,33 +233,41 @@ const availableOutcomes = computed(() =>
   }))
 )
 
-const emptyVariant = computed<'run-pending' | 'run-failed' | 'select-to' | null>(() => {
-  if (!store.currentIR?.id) return null
-  if (selectedExecutionId.value === null) return null
-  if (activeRun.value && !IR_TERMINAL_STATUSES.has(activeRun.value.status)) return 'run-pending'
-  if (activeRun.value?.status === 'FAILED') return 'run-failed'
-  if (!store.selectedTargetId || !store.selectedOutcomeId) return 'select-to'
-  return null
-})
+const emptyVariant = computed(() => resolveEmptyVariant({
+  currentIRId: store.currentIR?.id,
+  selectedExecutionId: selectedExecutionId.value,
+  activeRun: activeRun.value,
+  selectedTargetId: store.selectedTargetId,
+  selectedOutcomeId: store.selectedOutcomeId,
+  terminalStatuses: IR_TERMINAL_STATUSES,
+}))
+
+async function clearRunQuery() {
+  if (!('run' in route.query)) return
+  const nextQuery = { ...route.query }
+  delete (nextQuery as { run?: unknown }).run
+  await router.replace({ query: nextQuery })
+}
 
 watch(
   [() => store.currentIR?.id, () => store.executions],
-  async ([id, executions], [prevId]) => {
-    if (id == null) return
-    if (id !== prevId) {
-      await useIncidenceRateGeneration(id).pollOnce()
-    }
-    if (selectedExecutionId.value === null) {
-      const list = id !== prevId ? store.executions : executions
-      const completed = list.find(e => e.status === 'COMPLETED' || e.status === 'COMPLETE')
-      if (completed) await router.replace({ query: { ...route.query, run: String(completed.id) } })
-    }
-    if (store.selectedTargetId === null && store.currentIR?.expression.targetIds.length) {
-      store.setSelectedTargetOutcome(
-        store.currentIR.expression.targetIds[0]!,
-        store.currentIR.expression.outcomeIds[0] ?? null
-      )
-    }
+  async ([id], [prevId]) => {
+    await syncIncidenceRateSelection({
+      currentIRId: id,
+      previousIRId: prevId,
+      executions: store.executions,
+      selectedExecutionId: selectedExecutionId.value,
+      executionById: executionId => store.executionById(executionId),
+      currentTargetIds: store.currentIR?.expression.targetIds ?? [],
+      currentOutcomeIds: store.currentIR?.expression.outcomeIds ?? [],
+      selectedTargetId: store.selectedTargetId,
+      setSelectedTargetOutcome: (targetId, outcomeId) => store.setSelectedTargetOutcome(targetId, outcomeId),
+      clearRunQuery,
+      replaceRunQuery: async (runId: number) => {
+        await router.replace({ query: { ...route.query, run: String(runId) } })
+      },
+      pollOnceForNewDesign: async (irId: number) => { await useIncidenceRateGeneration(irId).pollOnce() },
+    })
   },
   { immediate: true },
 )
@@ -257,52 +277,50 @@ function onSelectRun(id: number) {
 }
 
 onMounted(async () => {
-  if (ds.sources.length === 0 && !ds.isLoading) await ds.fetchDataSources()
+  await maybeFetchIncidenceRateSources({
+    sourceCount: ds.sources.length,
+    isLoading: ds.isLoading,
+    fetchDataSources: () => ds.fetchDataSources(),
+  })
 })
 
 const runTableSources = computed<RunTableSource[]>(() =>
-  ds.sources.map(s => ({ sourceKey: s.sourceKey, sourceName: s.sourceName }))
+  resolveRunTableSources(ds.sources)
 )
-
-function mapStatus(raw: string): GenerationStatus {
-  return raw === 'COMPLETE' ? 'COMPLETED' : (raw as GenerationStatus)
-}
 
 const runTableExecutions = computed<RunTableExecution[]>(() =>
-  store.executions.map(e => ({
-    id: e.id,
-    sourceKey: e.sourceKey,
-    status: mapStatus(e.status),
-    startTime: e.startTime ?? undefined,
-    duration: e.duration ?? undefined,
-  }))
+  buildRunTableExecutions(store.executions)
 )
 
-const runDisabledReason = computed(() => {
-  if (store.isPreviewMode) return tv('common.previewMode', 'Preview mode')
-  if (store.isDirty) return tv('components.generation.unsavedChanges', 'Save changes before running')
-  if (store.hasErrors) return tv('components.generation.fixErrors', 'Resolve validation errors before running')
-  return ''
-})
+const runDisabledReason = computed(() => resolveRunDisabledReason({
+  isPreviewMode: store.isPreviewMode,
+  isDirty: store.isDirty,
+  hasErrors: store.hasErrors,
+  translate: tv,
+}))
 
 async function onRunSource(sourceKey: string) {
-  const id = store.currentIR?.id
-  if (id == null) return
-  await useIncidenceRateGeneration(id).start(sourceKey)
+  await runIncidenceRateSource({
+    currentIRId: store.currentIR?.id,
+    sourceKey,
+    start: async (irId, key) => { await useIncidenceRateGeneration(irId).start(key) },
+  })
 }
 
 async function onCancelSource(sourceKey: string) {
-  const id = store.currentIR?.id
-  if (id == null) return
-  await useIncidenceRateGeneration(id).cancel(sourceKey)
+  await cancelIncidenceRateSource({
+    currentIRId: store.currentIR?.id,
+    sourceKey,
+    cancel: async (irId, key) => { await useIncidenceRateGeneration(irId).cancel(key) },
+  })
 }
 
 const historyOpen = ref(false)
 const historySourceKey = ref<string | null>(null)
-const historySourceName = computed(() => {
-  if (!historySourceKey.value) return ''
-  return ds.sources.find(s => s.sourceKey === historySourceKey.value)?.sourceName ?? historySourceKey.value
-})
+const historySourceName = computed(() => resolveHistorySourceName({
+  historySourceKey: historySourceKey.value,
+  sources: ds.sources,
+}))
 
 function onShowHistory(sourceKey: string) {
   historySourceKey.value = sourceKey
@@ -310,12 +328,10 @@ function onShowHistory(sourceKey: string) {
 }
 
 function onSelectFromHistory(id: number | string) {
-  historyOpen.value = false
-  if (typeof id === 'number') onSelectRun(id)
-  else {
-    const n = Number(id)
-    if (Number.isFinite(n)) onSelectRun(n)
-  }
+  selectIncidenceRateFromHistory({
+    onSelectRun,
+    setHistoryOpen: open => { historyOpen.value = open },
+  })(id)
 }
 
 function onStrataAdd() {
@@ -335,29 +351,11 @@ function onStrataEdit(index: number) {
 }
 
 function onExport(format: 'csv' | 'svg' | 'png') {
-  if (format === 'csv' && report.value) {
-    type CsvRow = { name: string; totalPersons: number; cases: number; timeAtRisk: number }
-    const rows: CsvRow[] = [
-      {
-        name: 'Summary',
-        totalPersons: report.value.summary.totalPersons,
-        cases: report.value.summary.cases,
-        timeAtRisk: report.value.summary.timeAtRisk,
-      },
-      ...report.value.stratifyStats.map(s => ({
-        name: s.name,
-        totalPersons: s.totalPersons,
-        cases: s.cases,
-        timeAtRisk: s.timeAtRisk,
-      })),
-    ]
-    const headers: { key: keyof CsvRow; label: string }[] = [
-      { key: 'name',         label: 'Stratum' },
-      { key: 'totalPersons', label: 'Persons' },
-      { key: 'cases',        label: 'Cases' },
-      { key: 'timeAtRisk',   label: 'TAR (days)' },
-    ]
-    downloadCsv(`incidence-rate-${selectedExecutionId.value ?? 'results'}.csv`, arrayToCsv(rows, headers))
+  if (format === 'csv') {
+    buildCsvExport({
+      selectedExecutionId: selectedExecutionId.value,
+      report: report.value,
+    })
   }
 }
 </script>

--- a/src/components/incidence-rate/incidence-rate-workbench-actions.ts
+++ b/src/components/incidence-rate/incidence-rate-workbench-actions.ts
@@ -1,0 +1,83 @@
+export async function syncIncidenceRateSelection(input: {
+  currentIRId: number | null | undefined
+  previousIRId: number | null | undefined
+  executions: Array<{ id: number; status: string }>
+  selectedExecutionId: number | null
+  executionById: (id: number) => { status: string } | null
+  currentTargetIds: number[]
+  currentOutcomeIds: number[]
+  selectedTargetId: number | null
+  setSelectedTargetOutcome: (targetId: number, outcomeId: number | null) => void
+  clearRunQuery: () => Promise<void>
+  replaceRunQuery: (runId: number) => Promise<void>
+  pollOnceForNewDesign: (id: number) => Promise<void>
+}): Promise<void> {
+  const { currentIRId, executions, selectedExecutionId } = input
+  if (currentIRId == null) return
+
+  if (input.previousIRId !== currentIRId) {
+    await input.pollOnceForNewDesign(currentIRId)
+    const defaultExecution = executions[0] ?? null
+    if (defaultExecution) {
+      await input.replaceRunQuery(defaultExecution.id)
+    } else {
+      await input.clearRunQuery()
+    }
+    return
+  }
+
+  if (selectedExecutionId === null || !input.executionById(selectedExecutionId)) {
+    const defaultExecution = executions[0] ?? null
+    if (defaultExecution) {
+      await input.replaceRunQuery(defaultExecution.id)
+    } else {
+      await input.clearRunQuery()
+    }
+  }
+
+  if (input.selectedTargetId === null && input.currentTargetIds.length) {
+    input.setSelectedTargetOutcome(input.currentTargetIds[0]!, input.currentOutcomeIds[0] ?? null)
+  }
+}
+
+export async function runIncidenceRateSource(input: {
+  currentIRId: number | null | undefined
+  sourceKey: string
+  start: (irId: number, sourceKey: string) => Promise<void>
+}): Promise<void> {
+  if (input.currentIRId == null) return
+  await input.start(input.currentIRId, input.sourceKey)
+}
+
+export async function cancelIncidenceRateSource(input: {
+  currentIRId: number | null | undefined
+  sourceKey: string
+  cancel: (irId: number, sourceKey: string) => Promise<void>
+}): Promise<void> {
+  if (input.currentIRId == null) return
+  await input.cancel(input.currentIRId, input.sourceKey)
+}
+
+export function selectIncidenceRateFromHistory(input: {
+  onSelectRun: (id: number) => void
+  setHistoryOpen: (open: boolean) => void
+}): (id: number | string) => void {
+  return (id: number | string) => {
+    input.setHistoryOpen(false)
+    if (typeof id === 'number') input.onSelectRun(id)
+    else {
+      const parsed = Number(id)
+      if (Number.isFinite(parsed)) input.onSelectRun(parsed)
+    }
+  }
+}
+
+export async function maybeFetchIncidenceRateSources(input: {
+  sourceCount: number
+  isLoading: boolean
+  fetchDataSources: () => Promise<void>
+}): Promise<void> {
+  if (input.sourceCount === 0 && !input.isLoading) {
+    await input.fetchDataSources()
+  }
+}

--- a/src/components/incidence-rate/incidence-rate-workbench-state.ts
+++ b/src/components/incidence-rate/incidence-rate-workbench-state.ts
@@ -1,6 +1,14 @@
 import { arrayToCsv, downloadCsv } from '@/utils/csv'
 import type { GenerationStatus } from '@/models/characterization.types'
 import type { RunTableExecution, RunTableSource } from '@/components/generation/DataSourceRunTable.vue'
+import type { IncidenceRateExecutionSummary } from '@/stores/incidence-rate'
+
+function toMs(value: string | number | null | undefined): number | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'number') return value
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
 
 export function resolveSelectedExecutionId(runQuery: unknown): number | null {
   if (typeof runQuery === 'string') {
@@ -23,13 +31,15 @@ export function buildRunTableExecutions(input: Array<{
   sourceKey: string
   status: string
   startTime?: string | number | null
+  endTime?: string | number | null
   duration?: number | null
 }>): RunTableExecution[] {
   return input.map(execution => ({
     id: execution.id,
     sourceKey: execution.sourceKey,
     status: mapStatus(execution.status),
-    startTime: execution.startTime ?? undefined,
+    startTime: toMs(execution.startTime),
+    endTime: toMs(execution.endTime),
     duration: execution.duration ?? undefined,
   }))
 }
@@ -56,15 +66,15 @@ export function resolveHistorySourceName(input: {
 
 export function resolveActiveRun(input: {
   selectedExecutionId: number | null
-  executionById: (id: number) => { sourceKey: string; status: string; message?: string } | null
-}): { sourceKey: string; status: string; message?: string } | null {
+  executionById: (id: number) => IncidenceRateExecutionSummary | null
+}): IncidenceRateExecutionSummary | null {
   return input.selectedExecutionId === null ? null : input.executionById(input.selectedExecutionId)
 }
 
 export function resolveEmptyVariant(input: {
   currentIRId: number | null | undefined
   selectedExecutionId: number | null
-  activeRun: { status: string } | null
+  activeRun: IncidenceRateExecutionSummary | null
   selectedTargetId: number | null
   selectedOutcomeId: number | null
   terminalStatuses: Set<string>

--- a/src/components/incidence-rate/incidence-rate-workbench-state.ts
+++ b/src/components/incidence-rate/incidence-rate-workbench-state.ts
@@ -1,0 +1,110 @@
+import { arrayToCsv, downloadCsv } from '@/utils/csv'
+import type { GenerationStatus } from '@/models/characterization.types'
+import type { RunTableExecution, RunTableSource } from '@/components/generation/DataSourceRunTable.vue'
+
+export function resolveSelectedExecutionId(runQuery: unknown): number | null {
+  if (typeof runQuery === 'string') {
+    const parsed = Number(runQuery)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+export function resolveRunTableSources(input: Array<{ sourceKey: string; sourceName: string }>): RunTableSource[] {
+  return input.map(source => ({ sourceKey: source.sourceKey, sourceName: source.sourceName }))
+}
+
+export function mapStatus(raw: string): GenerationStatus {
+  return raw === 'COMPLETE' ? 'COMPLETED' : (raw as GenerationStatus)
+}
+
+export function buildRunTableExecutions(input: Array<{
+  id: number
+  sourceKey: string
+  status: string
+  startTime?: string | number | null
+  duration?: number | null
+}>): RunTableExecution[] {
+  return input.map(execution => ({
+    id: execution.id,
+    sourceKey: execution.sourceKey,
+    status: mapStatus(execution.status),
+    startTime: execution.startTime ?? undefined,
+    duration: execution.duration ?? undefined,
+  }))
+}
+
+export function resolveRunDisabledReason(input: {
+  isPreviewMode: boolean
+  isDirty: boolean
+  hasErrors: boolean
+  translate: (key: string, fallback: string) => string
+}): string {
+  if (input.isPreviewMode) return input.translate('common.previewMode', 'Preview mode')
+  if (input.isDirty) return input.translate('components.generation.unsavedChanges', 'Save changes before running')
+  if (input.hasErrors) return input.translate('components.generation.fixErrors', 'Resolve validation errors before running')
+  return ''
+}
+
+export function resolveHistorySourceName(input: {
+  historySourceKey: string | null
+  sources: Array<{ sourceKey: string; sourceName: string }>
+}): string {
+  if (!input.historySourceKey) return ''
+  return input.sources.find(source => source.sourceKey === input.historySourceKey)?.sourceName ?? input.historySourceKey
+}
+
+export function resolveActiveRun(input: {
+  selectedExecutionId: number | null
+  executionById: (id: number) => { sourceKey: string; status: string; message?: string } | null
+}): { sourceKey: string; status: string; message?: string } | null {
+  return input.selectedExecutionId === null ? null : input.executionById(input.selectedExecutionId)
+}
+
+export function resolveEmptyVariant(input: {
+  currentIRId: number | null | undefined
+  selectedExecutionId: number | null
+  activeRun: { status: string } | null
+  selectedTargetId: number | null
+  selectedOutcomeId: number | null
+  terminalStatuses: Set<string>
+}): 'run-pending' | 'run-failed' | 'select-to' | null {
+  if (!input.currentIRId) return null
+  if (input.selectedExecutionId === null) return null
+  if (input.activeRun && !input.terminalStatuses.has(input.activeRun.status)) return 'run-pending'
+  if (input.activeRun?.status === 'FAILED') return 'run-failed'
+  if (!input.selectedTargetId || !input.selectedOutcomeId) return 'select-to'
+  return null
+}
+
+export function buildCsvExport(input: {
+  selectedExecutionId: number | null
+  report: {
+    summary: { totalPersons: number; cases: number; timeAtRisk: number }
+    stratifyStats: Array<{ name: string; totalPersons: number; cases: number; timeAtRisk: number }>
+  } | null
+}): void {
+  if (!input.report) return
+  type CsvRow = { name: string; totalPersons: number; cases: number; timeAtRisk: number }
+  const rows: CsvRow[] = [
+    {
+      name: 'Summary',
+      totalPersons: input.report.summary.totalPersons,
+      cases: input.report.summary.cases,
+      timeAtRisk: input.report.summary.timeAtRisk,
+    },
+    ...input.report.stratifyStats.map(stratum => ({
+      name: stratum.name,
+      totalPersons: stratum.totalPersons,
+      cases: stratum.cases,
+      timeAtRisk: stratum.timeAtRisk,
+    })),
+  ]
+  const headers: { key: keyof CsvRow; label: string }[] = [
+    { key: 'name', label: 'Stratum' },
+    { key: 'totalPersons', label: 'Persons' },
+    { key: 'cases', label: 'Cases' },
+    { key: 'timeAtRisk', label: 'TAR (days)' },
+  ]
+  downloadCsv(`incidence-rate-${input.selectedExecutionId ?? 'results'}.csv`, arrayToCsv(rows, headers))
+}

--- a/src/components/pathway/PathwayWorkbench.vue
+++ b/src/components/pathway/PathwayWorkbench.vue
@@ -324,8 +324,10 @@ function onShowHistory(sourceKey: string) {
   historyOpen.value = true
 }
 
-function onHistorySelect(id: number | string) {
-  if (typeof id === 'number') emit('execution:select', id)
+function onHistorySelect(id: number | string | undefined) {
+  if (id == null) return
+  const numericId = typeof id === 'number' ? id : Number(id)
+  if (Number.isFinite(numericId)) emit('execution:select', numericId)
   historyOpen.value = false
 }
 

--- a/src/components/pathway/PathwayWorkbench.vue
+++ b/src/components/pathway/PathwayWorkbench.vue
@@ -41,11 +41,13 @@
         v-if="pathwayId"
         :sources="runTableSources"
         :executions="runTableExecutions"
+        :selected-execution-id="selectedExecutionId ?? null"
         :loading="executionsLoading"
         :run-disabled="!canGenerate"
         :run-disabled-reason="runDisabledReason"
         @run="onRun"
         @cancel="onCancel"
+        @select-result="onHistorySelect"
         @show-history="onShowHistory"
       />
 
@@ -190,31 +192,21 @@ import type {
   RunTableExecution,
 } from '@/components/generation/DataSourceRunTable.vue'
 import type { PathwayExecution } from '@/models/pathway.types'
-
-const PALETTE_20 = [
-  '#1f77b4',
-  '#ff7f0e',
-  '#2ca02c',
-  '#d62728',
-  '#9467bd',
-  '#8c564b',
-  '#e377c2',
-  '#7f7f7f',
-  '#bcbd22',
-  '#17becf',
-  '#aec7e8',
-  '#ffbb78',
-  '#98df8a',
-  '#ff9896',
-  '#c5b0d5',
-  '#c49c94',
-  '#f7b6d2',
-  '#c7c7c7',
-  '#dbdb8d',
-  '#9edae5',
-]
-
-const TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'CANCELED'])
+import {
+  buildColorMap,
+  buildCoverageProps,
+  buildRunTableExecutions,
+  resolveActiveRunSummary,
+  resolveHistorySourceName,
+  resolveTargetCohortName,
+  resolveTargetGroup,
+} from './pathway-workbench-state'
+import {
+  cancelPathwayGeneration,
+  maybeFetchPathwaySources,
+  refreshPathwayExecutions,
+  runPathwayGeneration,
+} from './pathway-workbench-actions'
 
 const props = defineProps<{
   pathwayId: number | null
@@ -256,43 +248,22 @@ const runDisabledReason = tv(
   'Save the design before generating'
 )
 
-const targetGroup = computed(() => results.value?.pathwayGroups[0] ?? null)
+const targetGroup = computed(() => resolveTargetGroup(results.value))
 
-const targetCohortName = computed(() => {
-  if (!design.value || !targetGroup.value) return ''
-  return (
-    design.value.targetCohorts.find(c => c.id === targetGroup.value!.targetCohortId)?.name ?? ''
-  )
-})
+const targetCohortName = computed(() => resolveTargetCohortName({
+  design: design.value,
+  targetGroup: targetGroup.value,
+}))
 
-const colorMap = computed(() => {
-  const map = new Map<string, string>()
-  const singleCodes = (results.value?.eventCodes ?? [])
-    .filter(ec => !ec.isCombo)
-    .sort((a, b) => a.code - b.code)
-  if (singleCodes.length > 0) {
-    singleCodes.forEach((ec, i) => {
-      map.set(String(ec.code), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
-    })
-  } else if (design.value) {
-    design.value.eventCohorts.forEach((cohort, i) => {
-      const bit = cohort.code != null ? (1 << cohort.code) : (1 << i)
-      map.set(String(bit), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
-    })
-  }
-  return map
-})
+const colorMap = computed(() => buildColorMap({
+  results: results.value,
+  design: design.value,
+}))
 const colors = (key: string): string => colorMap.value.get(key) ?? '#ccc'
 
-const activeRunSummary = computed(() => {
-  if (!props.selectedExecutionId) return null
-  return { id: props.selectedExecutionId, sourceKey: '—', age: undefined }
-})
+const activeRunSummary = computed(() => resolveActiveRunSummary(props.selectedExecutionId))
 
-const coverageProps = computed(() => ({
-  totalPathwaysCount: targetGroup.value?.totalPathwaysCount ?? 0,
-  targetCohortCount: targetGroup.value?.targetCohortCount ?? 0,
-}))
+const coverageProps = computed(() => buildCoverageProps(targetGroup.value))
 
 const pathStats = computed(() => {
   if (!design.value || !results.value || !targetGroup.value) return null
@@ -308,84 +279,44 @@ const runTableSources = computed<RunTableSource[]>(() =>
   dsStore.sources.map(s => ({ sourceKey: s.sourceKey, sourceName: s.sourceName }))
 )
 
-function toMs(v: string | number | undefined): number | undefined {
-  if (v === undefined) return undefined
-  if (typeof v === 'number') return v
-  const n = Date.parse(v)
-  return Number.isNaN(n) ? undefined : n
-}
+const runTableExecutions = computed<RunTableExecution[]>(() => buildRunTableExecutions({
+  executions: executions.value,
+  liveExecution: generation.value?.execution.value ?? null,
+}))
 
-const runTableExecutions = computed<RunTableExecution[]>(() => {
-  const rows: RunTableExecution[] = executions.value.map(e => {
-    const start = toMs(e.startTime) ?? toMs(e.executionDate)
-    const end = toMs(e.endTime)
-    return {
-      id: e.id,
-      sourceKey: e.sourceKey,
-      status: e.status,
-      startTime: start,
-      endTime: end,
-      duration: e.duration,
-    }
-  })
-
-  const live = generation.value?.execution.value
-  if (live && !TERMINAL_STATUSES.has(live.status)) {
-    const idx = rows.findIndex(r => r.sourceKey === live.sourceKey)
-    const liveRow: RunTableExecution = {
-      id: live.id,
-      sourceKey: live.sourceKey,
-      status: live.status,
-      startTime: toMs(live.startTime) ?? toMs(live.executionDate),
-    }
-    if (idx >= 0) rows[idx] = liveRow
-    else rows.unshift(liveRow)
-  }
-
-  return rows
-})
-
-const historySourceName = computed(() => {
-  const match = dsStore.sources.find(s => s.sourceKey === historySourceKey.value)
-  return match?.sourceName ?? historySourceKey.value
-})
+const historySourceName = computed(() => resolveHistorySourceName({
+  sourceKey: historySourceKey.value,
+  sources: dsStore.sources,
+}))
 
 async function refreshExecutions() {
-  if (!props.pathwayId) {
-    executions.value = []
-    return
-  }
-  executionsLoading.value = true
-  try {
-    const r = await listPathwayExecutions(props.pathwayId)
-    if (r.success) {
-      executions.value = r.data
-      if (!props.selectedExecutionId) {
-        const latestCompleted = r.data.find(e => e.status === 'COMPLETED')
-        if (latestCompleted) emit('execution:select', latestCompleted.id)
-      }
-    } else {
-      logger.error('PathwayWorkbench', 'listPathwayExecutions failed', r.error)
-    }
-  } finally {
-    executionsLoading.value = false
-  }
+  await refreshPathwayExecutions({
+    pathwayId: props.pathwayId,
+    selectedExecutionId: props.selectedExecutionId,
+    listExecutions: listPathwayExecutions,
+    onExecutions: value => { executions.value = value },
+    onLoading: value => { executionsLoading.value = value },
+    onSelectExecution: id => emit('execution:select', id),
+    logError: (message, error) => logger.error('PathwayWorkbench', message, error),
+  })
 }
 
 async function onRun(sourceKey: string) {
-  const gen = generation.value
-  if (!gen) return
-  const ok = await gen.start(sourceKey)
-  if (!ok) logger.error('PathwayWorkbench', 'start failed', gen.error.value)
-  await refreshExecutions()
+  await runPathwayGeneration({
+    generation: generation.value,
+    sourceKey,
+    refreshExecutions,
+    logError: (message, error) => logger.error('PathwayWorkbench', message, error),
+  })
 }
 
 async function onCancel(sourceKey: string) {
-  const gen = generation.value
-  if (!gen) return
-  const ok = await gen.cancel(sourceKey)
-  if (!ok) logger.error('PathwayWorkbench', 'cancel failed', gen.error.value)
-  await refreshExecutions()
+  await cancelPathwayGeneration({
+    generation: generation.value,
+    sourceKey,
+    refreshExecutions,
+    logError: (message, error) => logger.error('PathwayWorkbench', message, error),
+  })
 }
 
 function onShowHistory(sourceKey: string) {
@@ -450,9 +381,11 @@ watch(
 onBeforeUnmount(stopAgentPolling)
 
 onMounted(async () => {
-  if (dsStore.sources.length === 0 && !dsStore.isLoading) {
-    await dsStore.fetchDataSources()
-  }
+  await maybeFetchPathwaySources({
+    sourceCount: dsStore.sources.length,
+    isLoading: dsStore.isLoading,
+    fetchDataSources: () => dsStore.fetchDataSources(),
+  })
 })
 
 onBeforeUnmount(() => {

--- a/src/components/pathway/pathway-workbench-actions.ts
+++ b/src/components/pathway/pathway-workbench-actions.ts
@@ -3,7 +3,7 @@ import type { PathwayExecution } from '@/models/pathway.types'
 export async function refreshPathwayExecutions(input: {
   pathwayId: number | null | undefined
   selectedExecutionId: number | null | undefined
-  listExecutions: (pathwayId: number) => Promise<{ success: boolean; data: PathwayExecution[]; error?: unknown }>
+  listExecutions: (pathwayId: number) => Promise<{ success: boolean; data?: PathwayExecution[]; error?: unknown }>
   onExecutions: (executions: PathwayExecution[]) => void
   onLoading: (loading: boolean) => void
   onSelectExecution: (id: number) => void
@@ -16,7 +16,7 @@ export async function refreshPathwayExecutions(input: {
   input.onLoading(true)
   try {
     const result = await input.listExecutions(input.pathwayId)
-    if (result.success) {
+    if (result.success && Array.isArray(result.data)) {
       input.onExecutions(result.data)
       if (!input.selectedExecutionId) {
         const latestCompleted = result.data.find(execution => execution.status === 'COMPLETED')

--- a/src/components/pathway/pathway-workbench-actions.ts
+++ b/src/components/pathway/pathway-workbench-actions.ts
@@ -1,0 +1,65 @@
+import type { PathwayExecution } from '@/models/pathway.types'
+
+export async function refreshPathwayExecutions(input: {
+  pathwayId: number | null | undefined
+  selectedExecutionId: number | null | undefined
+  listExecutions: (pathwayId: number) => Promise<{ success: boolean; data: PathwayExecution[]; error?: unknown }>
+  onExecutions: (executions: PathwayExecution[]) => void
+  onLoading: (loading: boolean) => void
+  onSelectExecution: (id: number) => void
+  logError: (message: string, error?: unknown) => void
+}): Promise<void> {
+  if (!input.pathwayId) {
+    input.onExecutions([])
+    return
+  }
+  input.onLoading(true)
+  try {
+    const result = await input.listExecutions(input.pathwayId)
+    if (result.success) {
+      input.onExecutions(result.data)
+      if (!input.selectedExecutionId) {
+        const latestCompleted = result.data.find(execution => execution.status === 'COMPLETED')
+        if (latestCompleted) input.onSelectExecution(latestCompleted.id)
+      }
+    } else {
+      input.logError('PathwayWorkbench listPathwayExecutions failed', result.error)
+    }
+  } finally {
+    input.onLoading(false)
+  }
+}
+
+export async function runPathwayGeneration(input: {
+  generation: { start: (sourceKey: string) => Promise<boolean>; error: { value: string | null } } | null
+  sourceKey: string
+  refreshExecutions: () => Promise<void>
+  logError: (message: string, error?: unknown) => void
+}): Promise<void> {
+  if (!input.generation) return
+  const ok = await input.generation.start(input.sourceKey)
+  if (!ok) input.logError('PathwayWorkbench start failed', input.generation.error.value)
+  await input.refreshExecutions()
+}
+
+export async function cancelPathwayGeneration(input: {
+  generation: { cancel: (sourceKey: string) => Promise<boolean>; error: { value: string | null } } | null
+  sourceKey: string
+  refreshExecutions: () => Promise<void>
+  logError: (message: string, error?: unknown) => void
+}): Promise<void> {
+  if (!input.generation) return
+  const ok = await input.generation.cancel(input.sourceKey)
+  if (!ok) input.logError('PathwayWorkbench cancel failed', input.generation.error.value)
+  await input.refreshExecutions()
+}
+
+export async function maybeFetchPathwaySources(input: {
+  sourceCount: number
+  isLoading: boolean
+  fetchDataSources: () => Promise<void>
+}): Promise<void> {
+  if (input.sourceCount === 0 && !input.isLoading) {
+    await input.fetchDataSources()
+  }
+}

--- a/src/components/pathway/pathway-workbench-state.ts
+++ b/src/components/pathway/pathway-workbench-state.ts
@@ -1,0 +1,103 @@
+import type { PathwayExecution } from '@/models/pathway.types'
+import type { RunTableExecution } from '@/components/generation/DataSourceRunTable.vue'
+import type { PathwayDesign, PathwayResults } from '@/models/pathway-results.types'
+
+const PALETTE_20 = [
+  '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
+  '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+  '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5',
+  '#c49c94', '#f7b6d2', '#c7c7c7', '#dbdb8d', '#9edae5',
+]
+
+export function resolveTargetGroup(results: PathwayResults | null | undefined) {
+  return results?.pathwayGroups[0] ?? null
+}
+
+export function resolveTargetCohortName(input: {
+  design: PathwayDesign | null | undefined
+  targetGroup: { targetCohortId: number } | null
+}): string {
+  if (!input.design || !input.targetGroup) return ''
+  return input.design.targetCohorts.find(c => c.id === input.targetGroup.targetCohortId)?.name ?? ''
+}
+
+export function buildColorMap(input: {
+  results: PathwayResults | null | undefined
+  design: PathwayDesign | null | undefined
+}): Map<string, string> {
+  const map = new Map<string, string>()
+  const singleCodes = (input.results?.eventCodes ?? [])
+    .filter(ec => !ec.isCombo)
+    .sort((a, b) => a.code - b.code)
+  if (singleCodes.length > 0) {
+    singleCodes.forEach((ec, i) => {
+      map.set(String(ec.code), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
+    })
+  } else if (input.design) {
+    input.design.eventCohorts.forEach((cohort, i) => {
+      const bit = cohort.code != null ? (1 << cohort.code) : (1 << i)
+      map.set(String(bit), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
+    })
+  }
+  return map
+}
+
+export function resolveActiveRunSummary(selectedExecutionId: number | null | undefined) {
+  if (!selectedExecutionId) return null
+  return { id: selectedExecutionId, sourceKey: '—', age: undefined }
+}
+
+export function buildCoverageProps(targetGroup: { totalPathwaysCount: number; targetCohortCount: number } | null) {
+  return {
+    totalPathwaysCount: targetGroup?.totalPathwaysCount ?? 0,
+    targetCohortCount: targetGroup?.targetCohortCount ?? 0,
+  }
+}
+
+function toMs(v: string | number | undefined): number | undefined {
+  if (v === undefined) return undefined
+  if (typeof v === 'number') return v
+  const parsed = Date.parse(v)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+export function buildRunTableExecutions(input: {
+  executions: PathwayExecution[]
+  liveExecution: PathwayExecution | null | undefined
+}): RunTableExecution[] {
+  const rows: RunTableExecution[] = input.executions.map(e => {
+    const start = toMs(e.startTime) ?? toMs(e.executionDate)
+    const end = toMs(e.endTime)
+    return {
+      id: e.id,
+      sourceKey: e.sourceKey,
+      status: e.status,
+      startTime: start,
+      endTime: end,
+      duration: e.duration,
+    }
+  })
+
+  const live = input.liveExecution
+  if (live && !['COMPLETED', 'FAILED', 'CANCELED'].includes(live.status)) {
+    const idx = rows.findIndex(r => r.sourceKey === live.sourceKey)
+    const liveRow: RunTableExecution = {
+      id: live.id,
+      sourceKey: live.sourceKey,
+      status: live.status,
+      startTime: toMs(live.startTime) ?? toMs(live.executionDate),
+    }
+    if (idx >= 0) rows[idx] = liveRow
+    else rows.unshift(liveRow)
+  }
+
+  return rows
+}
+
+export function resolveHistorySourceName(input: {
+  sourceKey: string
+  sources: Array<{ sourceKey: string; sourceName: string }>
+}): string {
+  const match = input.sources.find(s => s.sourceKey === input.sourceKey)
+  return match?.sourceName ?? input.sourceKey
+}

--- a/src/components/pathway/pathway-workbench-state.ts
+++ b/src/components/pathway/pathway-workbench-state.ts
@@ -1,6 +1,5 @@
-import type { PathwayExecution } from '@/models/pathway.types'
+import type { Pathway, PathwayExecution, PathwayResults } from '@/models/pathway.types'
 import type { RunTableExecution } from '@/components/generation/DataSourceRunTable.vue'
-import type { PathwayDesign, PathwayResults } from '@/models/pathway-results.types'
 
 const PALETTE_20 = [
   '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd',
@@ -9,40 +8,41 @@ const PALETTE_20 = [
   '#c49c94', '#f7b6d2', '#c7c7c7', '#dbdb8d', '#9edae5',
 ]
 
-export function resolveTargetGroup(results: PathwayResults | null | undefined) {
+export function resolveTargetGroup(results: PathwayResults | null | undefined): PathwayResults['pathwayGroups'][number] | null {
   return results?.pathwayGroups[0] ?? null
 }
 
 export function resolveTargetCohortName(input: {
-  design: PathwayDesign | null | undefined
+  design: Pathway | null | undefined
   targetGroup: { targetCohortId: number } | null
 }): string {
-  if (!input.design || !input.targetGroup) return ''
-  return input.design.targetCohorts.find(c => c.id === input.targetGroup.targetCohortId)?.name ?? ''
+  const targetGroup = input.targetGroup
+  if (!input.design || !targetGroup) return ''
+  return input.design.targetCohorts.find(cohort => cohort.id === targetGroup.targetCohortId)?.name ?? ''
 }
 
 export function buildColorMap(input: {
   results: PathwayResults | null | undefined
-  design: PathwayDesign | null | undefined
+  design: Pathway | null | undefined
 }): Map<string, string> {
   const map = new Map<string, string>()
   const singleCodes = (input.results?.eventCodes ?? [])
-    .filter(ec => !ec.isCombo)
+    .filter(eventCode => !eventCode.isCombo)
     .sort((a, b) => a.code - b.code)
   if (singleCodes.length > 0) {
-    singleCodes.forEach((ec, i) => {
-      map.set(String(ec.code), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
+    singleCodes.forEach((eventCode, index) => {
+      map.set(String(eventCode.code), PALETTE_20[index % PALETTE_20.length] ?? '#cccccc')
     })
   } else if (input.design) {
-    input.design.eventCohorts.forEach((cohort, i) => {
-      const bit = cohort.code != null ? (1 << cohort.code) : (1 << i)
-      map.set(String(bit), PALETTE_20[i % PALETTE_20.length] ?? '#cccccc')
+    input.design.eventCohorts.forEach((cohort, index) => {
+      const bit = cohort.code != null ? (1 << cohort.code) : (1 << index)
+      map.set(String(bit), PALETTE_20[index % PALETTE_20.length] ?? '#cccccc')
     })
   }
   return map
 }
 
-export function resolveActiveRunSummary(selectedExecutionId: number | null | undefined) {
+export function resolveActiveRunSummary(selectedExecutionId: number | null | undefined): { id: number; sourceKey: string; age?: string } | null {
   if (!selectedExecutionId) return null
   return { id: selectedExecutionId, sourceKey: '—', age: undefined }
 }
@@ -54,8 +54,8 @@ export function buildCoverageProps(targetGroup: { totalPathwaysCount: number; ta
   }
 }
 
-function toMs(v: string | number | undefined): number | undefined {
-  if (v === undefined) return undefined
+function toMs(v: string | number | null | undefined): number | undefined {
+  if (v == null) return undefined
   if (typeof v === 'number') return v
   const parsed = Date.parse(v)
   return Number.isNaN(parsed) ? undefined : parsed

--- a/src/composables/usePathwayGeneration.ts
+++ b/src/composables/usePathwayGeneration.ts
@@ -10,7 +10,6 @@ const TERMINAL = new Set(['COMPLETED', 'FAILED', 'CANCELED'])
 export function usePathwayGeneration(pathwayId: number) {
   const execution = ref<PathwayExecution | null>(null)
   const error = ref<string | null>(null)
-
   const poller = useExecutionPolling<PathwayExecution>({
     intervalMs: PATHWAY_GENERATION_POLL_MS,
     fetcher: async () => {

--- a/src/models/characterization.types.ts
+++ b/src/models/characterization.types.ts
@@ -221,7 +221,7 @@ export interface CharacterizationExecution {
   hashCode?: string | number | null
   status: GenerationStatus
   startTime?: number
-  endTime?: number
+  endTime?: number | null
   duration?: number
   executionStatus?: GenerationStatus
   sourceKey: string
@@ -237,7 +237,7 @@ export const CharacterizationExecutionSchema = z
     hashCode: z.union([z.string(), z.number()]).nullable().optional(),
     status: GenerationStatusSchema,
     startTime: z.number().optional(),
-    endTime: z.number().optional(),
+    endTime: z.number().nullable().optional(),
     duration: z.number().optional(),
     executionStatus: GenerationStatusSchema.optional(),
     sourceKey: z.string(),

--- a/src/models/pathway.types.ts
+++ b/src/models/pathway.types.ts
@@ -120,10 +120,10 @@ export const PathwayExecutionSchema = z.object({
   id: z.number(),
   status: PathwayExecutionStatusSchema,
   sourceKey: z.string(),
-  hashCode: z.union([z.string(), z.number()]).optional(),
+  hashCode: z.union([z.string(), z.number()]).nullable().optional(),
   executionDate: z.union([z.string(), z.number()]).optional(),
   startTime: z.union([z.string(), z.number()]).optional(),
-  endTime: z.union([z.string(), z.number()]).optional(),
+  endTime: z.union([z.string(), z.number()]).nullable().optional(),
   duration: z.number().optional(),
   exitMessage: z.string().optional(),
 })

--- a/tests/component/characterization/CharacterizationWorkbench.spec.ts
+++ b/tests/component/characterization/CharacterizationWorkbench.spec.ts
@@ -7,6 +7,19 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import CharacterizationWorkbench from '@/components/characterization/CharacterizationWorkbench.vue'
 import { useCharacterizationStore } from '@/stores/characterization'
+import {
+  getCharacterizationExecution,
+  getCharacterizationResultCount,
+  getCharacterizationResults,
+} from '@/services/characterization.service'
+
+const mockResultCount = vi.mocked(getCharacterizationResultCount)
+const mockResults = vi.mocked(getCharacterizationResults)
+const mockDataSources = {
+  sources: [{ sourceId: 12, sourceKey: 'CCAE', sourceName: 'CCAE' }],
+  isLoading: false,
+  fetchDataSources: vi.fn().mockResolvedValue(undefined),
+}
 
 // vi.mock factories are hoisted above imports, so the ApiResult shape is
 // inlined here rather than built via the `success()` helper.
@@ -32,6 +45,19 @@ vi.mock('@/services/characterization.service', () => ({
   copyCharacterization: vi.fn(),
 }))
 
+vi.mock('@/stores/datasources', () => ({
+  useDataSourcesStore: () => mockDataSources,
+}))
+
+vi.mock('@/services/cohort-definition.service', () => ({
+  getCohortGenerationInfo: vi.fn().mockResolvedValue({
+    success: true,
+    data: [
+      { id: { sourceId: 12 }, personCount: 123 },
+    ],
+  }),
+}))
+
 const vuetify = createVuetify({ components, directives })
 const stubs = [
   'CharacterizationDesignRail', 'CharacterizationCanvasToolbar',
@@ -54,7 +80,19 @@ const baseDraft = () => ({
 })
 
 describe('CharacterizationWorkbench', () => {
-  beforeEach(() => setActivePinia(createPinia()))
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockDataSources.sources = [{ sourceId: 12, sourceKey: 'CCAE', sourceName: 'CCAE' }]
+    mockDataSources.fetchDataSources.mockClear()
+    mockResultCount.mockReset()
+    mockResultCount.mockResolvedValue({ success: true, data: 0 })
+    mockResults.mockReset()
+    mockResults.mockResolvedValue({ success: true, data: [] })
+    vi.mocked(getCharacterizationExecution).mockResolvedValue({
+      success: true,
+      data: { id: 7, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 0, executionDuration: 0 },
+    })
+  })
 
   it('shows no-id empty state when characterizationId is null', () => {
     const router = makeRouter()
@@ -82,6 +120,105 @@ describe('CharacterizationWorkbench', () => {
     expect(w.findComponent({ name: 'CharacterizationPerAnalysisView' }).exists()).toBe(true)
   })
 
+  it('parses invalid run ids as null when no executions are loaded', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5?run=abc')
+    const store = useCharacterizationStore()
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [] as never
+    })
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5, availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+
+    expect(w.findComponent({ name: 'CharacterizationEmptyState' }).props('variant')).toBe('no-runs')
+    expect(w.findComponent({ name: 'DataSourceRunTable' }).props('selectedExecutionId')).toBeNull()
+  })
+
+  it('shows pending and failed empty variants from the selected execution status', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5?run=7')
+    vi.mocked(getCharacterizationExecution).mockResolvedValueOnce({
+      success: true,
+      data: { id: 7, sourceKey: 'CCAE', status: 'PENDING', startTime: 0, executionDuration: 0 },
+    })
+    const pending = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5, availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+    expect(pending.findComponent({ name: 'CharacterizationEmptyState' }).props('variant')).toBe('run-pending')
+
+    vi.mocked(getCharacterizationExecution).mockResolvedValueOnce({
+      success: true,
+      data: { id: 7, sourceKey: 'CCAE', status: 'FAILED', startTime: 0, executionDuration: 0 },
+    })
+    const failed = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5, availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+    expect(failed.findComponent({ name: 'CharacterizationEmptyState' }).props('variant')).toBe('run-failed')
+  })
+
+  it('clears a stale run query when the characterization id changes', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5?run=7')
+    const store = useCharacterizationStore()
+    const disposeSpy = vi.spyOn(store, 'dispose')
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [
+        { id: 7, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 0, executionDuration: 0 },
+      ] as never
+    })
+    const replaceSpy = vi.spyOn(router, 'replace')
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5, availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+    await w.setProps({ characterizationId: 6 })
+    await flushPromises()
+
+    expect(disposeSpy).toHaveBeenCalled()
+    expect(replaceSpy).toHaveBeenCalledWith({ query: {} })
+  })
+
+  it('fetches cohort sizes when std diff is enabled and sources start empty', async () => {
+    mockDataSources.sources = []
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    mockResults.mockResolvedValue({ success: true, data: [
+      {
+        analysisId: 1,
+        analysisName: 'Analysis A',
+        covariateId: 11,
+        covariateName: 'Cov A',
+        conceptId: 0,
+        cohortId: 1,
+        cohortName: 'Cohort A',
+        count: 10,
+        pct: 5,
+        resultType: 'PREVALENCE',
+      },
+    ] })
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5, availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+    await w.findComponent({ name: 'CharacterizationCanvasToolbar' }).vm.$emit('open-configure')
+    await w.findComponent({ name: 'ConfigureInspector' }).vm.$emit('update:config', {
+      ...w.findComponent({ name: 'ConfigureInspector' }).props('config'),
+      showStdDiffCI: true,
+    })
+    await flushPromises()
+
+    expect(mockDataSources.fetchDataSources).toHaveBeenCalled()
+  })
+
   it('opens and closes the configure inspector', async () => {
     const router = makeRouter()
     await router.push('/characterizations/5')
@@ -96,6 +233,83 @@ describe('CharacterizationWorkbench', () => {
     expect(w.findComponent({ name: 'ConfigureInspector' }).props('open')).toBe(true)
     await w.findComponent({ name: 'ConfigureInspector' }).vm.$emit('close')
     expect(w.findComponent({ name: 'ConfigureInspector' }).props('open')).toBe(false)
+  })
+
+  it('wires the toolbar, filters, design rail, history, and cohort-size watcher branches', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+
+    mockResultCount.mockResolvedValue({ success: true, data: 1 })
+    mockResults.mockResolvedValue({ success: true, data: [
+      {
+        analysisId: 1,
+        analysisName: 'Analysis A',
+        covariateId: 11,
+        covariateName: 'Cov A',
+        conceptId: 0,
+        cohortId: 1,
+        cohortName: 'Cohort A',
+        count: 10,
+        pct: 5,
+        resultType: 'PREVALENCE',
+      },
+      {
+        analysisId: 2,
+        analysisName: 'Analysis B',
+        covariateId: 22,
+        covariateName: 'Cov B',
+        conceptId: 0,
+        cohortId: 1,
+        cohortName: 'Cohort A',
+        count: 3,
+        pct: 2,
+        resultType: 'DISTRIBUTION',
+      },
+    ] })
+
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: {
+        modelValue: baseDraft(),
+        characterizationId: 5,
+        availableCohorts: [],
+        availableFeatureAnalyses: []
+      },
+    })
+    await flushPromises()
+
+    const toolbar = w.findComponent({ name: 'CharacterizationCanvasToolbar' })
+    await toolbar.vm.$emit('update:mode', 'table1')
+    await toolbar.vm.$emit('update:threshold', 0.2)
+    await toolbar.vm.$emit('open-configure')
+    await toolbar.vm.$emit('export')
+    await w.findComponent({ name: 'CharacterizationDesignRail' }).vm.$emit('update:modelValue', baseDraft())
+
+    const filtersPanel = w.findComponent({ name: 'ResultsFilterPanel' })
+    await filtersPanel.vm.$emit('update:selected-analysis-ids', [1])
+    await filtersPanel.vm.$emit('update:selected-domains', ['D1'])
+    await filtersPanel.vm.$emit('update:selected-cohort-id', 1)
+
+    const inspector = w.findComponent({ name: 'ConfigureInspector' })
+    await inspector.vm.$emit('update:config', { ...inspector.props('config'), showStdDiffCI: true })
+    await inspector.vm.$emit('close')
+    await flushPromises()
+
+    await w.findComponent({ name: 'CharacterizationTable1View' }).vm.$emit('explore', {
+      analysisId: 1,
+      analysisName: 'Analysis A',
+      covariateId: 11,
+      covariateName: 'Cov A',
+      cohortId: 1,
+      cohortName: 'Cohort A',
+      count: 10,
+      pct: 5,
+      resultType: 'PREVALENCE',
+    })
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('show-history', 'CCAE')
+    expect(w.findComponent({ name: 'PreviousRunsDialog' }).props('modelValue')).toBe(true)
+    expect(w.findComponent({ name: 'CharacterizationTable1View' }).exists()).toBe(true)
   })
 
   it('run with a returned execution pins the run query and starts polling', async () => {
@@ -145,15 +359,124 @@ describe('CharacterizationWorkbench', () => {
     expect(pollSpy).not.toHaveBeenCalled()
   })
 
+  it('selects a completed execution by default when executions load', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [
+        { id: 21, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 0, executionDuration: 0 },
+      ] as never
+    })
+    vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+    const replaceSpy = vi.spyOn(router, 'replace')
+
+    mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: {
+        modelValue: baseDraft(),
+        characterizationId: 5,
+        availableCohorts: [],
+        availableFeatureAnalyses: []
+      },
+    })
+
+    await flushPromises()
+
+    expect(replaceSpy).toHaveBeenCalledWith({ query: expect.objectContaining({ run: '21' }) })
+  })
+
+  it('falls back to a failed execution when no completed run exists', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [
+        { id: 33, sourceKey: 'CCAE', status: 'FAILED', startTime: 0, executionDuration: 0 },
+      ] as never
+    })
+    vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+    const replaceSpy = vi.spyOn(router, 'replace')
+
+    mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: {
+        modelValue: baseDraft(),
+        characterizationId: 5,
+        availableCohorts: [],
+        availableFeatureAnalyses: []
+      },
+    })
+
+    await flushPromises()
+
+    expect(replaceSpy).toHaveBeenCalledWith({ query: expect.objectContaining({ run: '33' }) })
+  })
+
+  it('shows the no-runs state when there are no executions to select', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [] as never
+    })
+    vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: {
+        modelValue: baseDraft(),
+        characterizationId: 5,
+        availableCohorts: [],
+        availableFeatureAnalyses: []
+      },
+    })
+
+    await flushPromises()
+
+    const empty = w.findComponent({ name: 'CharacterizationEmptyState' })
+    expect(empty.exists()).toBe(true)
+    expect(empty.props('variant')).toBe('no-runs')
+  })
+
+  it('seeds polling for running executions loaded on mount and disposes on teardown', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const store = useCharacterizationStore()
+    const pollSpy = vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
+    const disposeSpy = vi.spyOn(store, 'dispose').mockImplementation(() => {})
+    vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [
+        { id: 7, sourceKey: 'CCAE', status: 'RUNNING', startTime: 0, executionDuration: 0 },
+        { id: 8, sourceKey: 'CCAE', status: 'COMPLETED', startTime: 0, executionDuration: 0 },
+      ] as never
+    })
+
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5,
+               availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+
+    expect(pollSpy).toHaveBeenCalledWith(7, expect.any(Function))
+    expect(pollSpy).not.toHaveBeenCalledWith(8, expect.any(Function))
+
+    w.unmount()
+    expect(disposeSpy).toHaveBeenCalled()
+  })
+
   it('cancels the latest execution for a source and refreshes the list', async () => {
     const router = makeRouter()
     await router.push('/characterizations/5')
     const store = useCharacterizationStore()
-    store.executions = [
-      { id: 7, sourceKey: 'CCAE', status: 'RUNNING', startTime: 0, executionDuration: 0 },
-    ] as never
+    const loadSpy = vi.spyOn(store, 'loadExecutions').mockImplementation(async () => {
+      store.executions = [
+        { id: 7, sourceKey: 'CCAE', status: 'RUNNING', startTime: 0, executionDuration: 0 },
+      ] as never
+    })
+    vi.spyOn(store, 'pollExecution').mockImplementation(() => {})
     const cancelSpy = vi.spyOn(store, 'cancelExecution').mockResolvedValue(undefined)
-    const loadSpy = vi.spyOn(store, 'loadExecutions').mockResolvedValue(undefined)
     const w = mount(CharacterizationWorkbench, {
       global: { plugins: [router, vuetify], stubs },
       props: { modelValue: baseDraft(), characterizationId: 5,
@@ -165,6 +488,22 @@ describe('CharacterizationWorkbench', () => {
 
     expect(cancelSpy).toHaveBeenCalledWith(5, 'CCAE', 7)
     expect(loadSpy).toHaveBeenCalled()
+  })
+
+  it('select-result from the main table changes the selected execution', async () => {
+    const router = makeRouter()
+    await router.push('/characterizations/5')
+    const pushSpy = vi.spyOn(router, 'push')
+    const w = mount(CharacterizationWorkbench, {
+      global: { plugins: [router, vuetify], stubs },
+      props: { modelValue: baseDraft(), characterizationId: 5,
+               availableCohorts: [], availableFeatureAnalyses: [] },
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('select-result', 7)
+
+    expect(pushSpy).toHaveBeenCalledWith({ query: expect.objectContaining({ run: '7' }) })
   })
 
   it('ignores invalid history selections', async () => {

--- a/tests/component/generation/DataSourceRunRow.spec.ts
+++ b/tests/component/generation/DataSourceRunRow.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { createPinia, setActivePinia } from 'pinia'
+
+import DataSourceRunRow from '@/components/generation/DataSourceRunRow.vue'
+import { useAuthStore } from '@/stores/auth'
+import { emptyEntityAccess } from '@/models/auth.types'
+
+const vuetify = createVuetify({ components, directives })
+
+function mountRow(props: Record<string, unknown> = {}) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const authStore = useAuthStore()
+  authStore.setUser({
+    login: 'tester',
+    displayName: 'tester',
+    permissionIdx: { admin: ['admin:source'] },
+    entityAccess: emptyEntityAccess(),
+  })
+
+  return mount(DataSourceRunRow, {
+    global: {
+      plugins: [vuetify, pinia],
+      stubs: {
+        AtlasButton: {
+          name: 'AtlasButton',
+          props: ['variant', 'size', 'disabled'],
+          template: '<button class="run-stub" :disabled="disabled"><slot /></button>',
+        },
+        AtlasIconButton: {
+          name: 'AtlasIconButton',
+          props: ['icon', 'ariaLabel', 'variant', 'size', 'tone', 'disabled'],
+          emits: ['click'],
+          template:
+            '<button class="eye-stub" :data-icon="icon" :data-tone="tone" :aria-label="ariaLabel" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+        },
+        AtlasTooltip: {
+          name: 'AtlasTooltip',
+          template: '<div><slot name="activator" :props="{}" /><slot /></div>',
+        },
+      },
+    },
+    props: {
+      sourceKey: 'CCAE',
+      historyCount: 2,
+      latestStatus: 'COMPLETED',
+      latestExecutionId: 7,
+      selectedExecutionId: null,
+      ...props,
+    },
+  })
+}
+
+describe('DataSourceRunRow', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('shows an unhighlighted view-results eye for an inactive completed result', () => {
+    const w = mountRow()
+    const eye = w.find('[data-testid="view-latest-btn-CCAE"]')
+    expect(eye.exists()).toBe(true)
+    expect(eye.attributes('data-icon')).toBe('mdi-eye-outline')
+    expect(eye.attributes('data-tone')).toBe('neutral')
+  })
+
+  it('highlights the eye when the completed result is active', () => {
+    const w = mountRow({ selectedExecutionId: 7 })
+    const eye = w.find('[data-testid="view-latest-btn-CCAE"]')
+    expect(eye.attributes('data-icon')).toBe('mdi-eye')
+    expect(eye.attributes('data-tone')).toBe('primary')
+  })
+
+  it('emits select-result when the eye is clicked', async () => {
+    const w = mountRow()
+    await w.find('[data-testid="view-latest-btn-CCAE"]').trigger('click')
+    expect(w.emitted('select-result')).toEqual([[]])
+  })
+
+  it('hides the eye when the latest execution is not completed', () => {
+    const w = mountRow({ latestStatus: 'RUNNING' })
+    expect(w.find('[data-testid="view-latest-btn-CCAE"]').exists()).toBe(false)
+  })
+})

--- a/tests/component/generation/DataSourceRunTable.spec.ts
+++ b/tests/component/generation/DataSourceRunTable.spec.ts
@@ -45,6 +45,7 @@ function mountTable(props: Partial<{
   runDisabled: boolean
   runDisabledReason: string
   noSourcesText: string
+  selectedExecutionId: number | string | null
 }> = {}) {
   const pinia = createPinia()
   setActivePinia(pinia)
@@ -60,6 +61,7 @@ function mountTable(props: Partial<{
     props: {
       sources: SOURCES,
       executions: [],
+      selectedExecutionId: null,
       ...props,
     },
   })
@@ -98,6 +100,14 @@ describe('DataSourceRunTable', () => {
     const w = mountTable()
     await w.find('[data-testid="run-btn-MDCD"]').trigger('click')
     expect(w.emitted('run')?.[0]).toEqual(['MDCD'])
+  })
+
+  it('emits select-result when the main-view eye is clicked', async () => {
+    const w = mountTable({
+      executions: [exec({ id: 11, sourceKey: 'CCAE', status: 'COMPLETED' })],
+    })
+    await w.find('[data-testid="view-latest-btn-CCAE"]').trigger('click')
+    expect(w.emitted('select-result')?.[0]).toEqual([11])
   })
 
   it('disables history icon when no executions for a source and emits show-history when clicked', async () => {

--- a/tests/component/incidence-rate/IncidenceRateWorkbench.spec.ts
+++ b/tests/component/incidence-rate/IncidenceRateWorkbench.spec.ts
@@ -5,12 +5,19 @@ import { setActivePinia, createPinia } from 'pinia'
 import { vuetify, pristinePinia } from './_test-helpers'
 import IncidenceRateWorkbench from '@/components/incidence-rate/IncidenceRateWorkbench.vue'
 import { useIncidenceRateStore } from '@/stores/incidence-rate'
+import { generateIncidenceRate, cancelIncidenceRateGeneration } from '@/services/incidence-rate.service'
+
+const mockGenerate = vi.mocked(generateIncidenceRate)
+const mockCancel = vi.mocked(cancelIncidenceRateGeneration)
 
 vi.mock('@/services/incidence-rate.service', () => ({
   getIncidenceRateReport: vi.fn().mockResolvedValue({ success: true, data: null }),
   listIncidenceRateInfo: vi.fn().mockResolvedValue({ success: true, data: [] }),
-  generateIncidenceRate: vi.fn(),
-  cancelIncidenceRateGeneration: vi.fn(),
+  generateIncidenceRate: vi.fn().mockResolvedValue({
+    success: true,
+    data: { id: { analysisId: 42, sourceId: 7 }, status: 'PENDING' },
+  }),
+  cancelIncidenceRateGeneration: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 
@@ -38,7 +45,10 @@ const stubs = [
 const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/', component: { template: '<div/>' } }] })
 
 describe('IncidenceRateWorkbench', () => {
-  beforeEach(() => pristinePinia())
+  beforeEach(() => {
+    pristinePinia()
+    vi.clearAllMocks()
+  })
 
   function loadedStore() {
     const store = useIncidenceRateStore()
@@ -88,6 +98,142 @@ describe('IncidenceRateWorkbench', () => {
     })
     await flushPromises()
     expect(pushed).toMatchObject({ query: { run: '7' } })
+  })
+
+  it('routes the eye icon selection back to the run query', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const store = loadedStore()
+
+    store.setExecutionInfo('CCAE', {
+      executionInfo: { id: { analysisId: 42, sourceId: 7 }, status: 'COMPLETED', startTime: 100 },
+      summaryList: [],
+    })
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+    const replaceSpy = vi.spyOn(r, 'replace')
+
+    const w = mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('select-result', 7)
+
+    expect(replaceSpy).toHaveBeenCalledWith({ query: expect.objectContaining({ run: '7' }) })
+  })
+
+  it('runs the selected source when the table emits run', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    loadedStore()
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+
+    const w = mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('run', 'CCAE')
+    await flushPromises()
+
+    expect(mockGenerate).toHaveBeenCalledWith(42, 'CCAE')
+  })
+
+  it('cancels the selected source when the table emits cancel', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    loadedStore()
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+
+    const w = mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('cancel', 'CCAE')
+    await flushPromises()
+
+    expect(mockCancel).toHaveBeenCalledWith(42, 'CCAE')
+  })
+
+  it('opens the history dialog when the table emits show-history', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    loadedStore()
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+
+    const w = mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    await w.findComponent({ name: 'DataSourceRunTable' }).vm.$emit('show-history', 'CCAE')
+
+    expect(w.findComponent({ name: 'PreviousRunsDialog' }).props('modelValue')).toBe(true)
+  })
+
+  it('selects the new default run when a different IR design loads', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const store = loadedStore()
+
+    store.setExecutionInfo('CCAE', {
+      executionInfo: { id: { analysisId: 42, sourceId: 11 }, status: 'COMPLETED', startTime: 100 },
+      summaryList: [],
+    })
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+    await r.push({ path: '/', query: { run: '999' } })
+    await r.isReady()
+    const replaceSpy = vi.spyOn(r, 'replace')
+
+    mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    expect(replaceSpy).toHaveBeenCalledWith({ query: { run: '11' } })
+  })
+
+  it('leaves no run selected when the design has no generations', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    loadedStore()
+
+    const r = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+    await r.push({ path: '/', query: { run: '999' } })
+    await r.isReady()
+    const replaceSpy = vi.spyOn(r, 'replace')
+
+    mount(IncidenceRateWorkbench, {
+      global: { plugins: [vuetify, r, pinia], stubs },
+    })
+    await flushPromises()
+
+    expect(replaceSpy).toHaveBeenCalledWith({ query: {} })
+    expect(replaceSpy).not.toHaveBeenCalledWith({ query: expect.objectContaining({ run: expect.any(String) }) })
   })
 
   it('toggles the design rail and fires the strata add/edit handlers', async () => {

--- a/tests/component/pathway/PathwayWorkbench.spec.ts
+++ b/tests/component/pathway/PathwayWorkbench.spec.ts
@@ -245,4 +245,31 @@ describe('PathwayWorkbench', () => {
     await w.findComponent({ name: 'PreviousRunsDialog' }).vm.$emit('select', 11)
     expect(w.emitted('execution:select')?.at(-1)).toEqual([11])
   })
+
+  it('selects a pathway result from the main run table eye', async () => {
+    const store = usePathwayStore()
+    store.createNewPathway()
+    if (store.currentPathway) store.currentPathway.id = 1
+    composableMocks.design.value = store.currentPathway
+    composableMocks.results.value = {
+      pathwayGroups: [{ targetCohortId: 5, totalPathwaysCount: 10, targetCohortCount: 4 }],
+      eventCodes: [],
+    }
+    vi.mocked(listPathwayExecutions).mockResolvedValue({
+      success: true,
+      data: [{ id: 11, sourceKey: 's1', status: 'COMPLETED', executionDate: Date.now() }],
+    } as never)
+
+    const w = mount(PathwayWorkbench, {
+      props: { pathwayId: 1, selectedExecutionId: 11 },
+      global: { plugins: [vuetify], stubs: stubChildren },
+    })
+    await flushPromises()
+
+    const runTable = w.findComponent({ name: 'DataSourceRunTable' })
+    await runTable.vm.$emit('select-result', 11)
+    await flushPromises()
+
+    expect(w.emitted('execution:select')?.at(-1)).toEqual([11])
+  })
 })

--- a/tests/unit/composables/useIncidenceRateGeneration.spec.ts
+++ b/tests/unit/composables/useIncidenceRateGeneration.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { useDataSourcesStore } from '@/stores/datasources'
 
 beforeAll(() => { vi.useFakeTimers() })
 afterAll(() => { vi.useRealTimers() })
@@ -20,6 +21,15 @@ vi.mock('@/services/incidence-rate.service', () => ({
 
 import { useIncidenceRateGeneration } from '@/composables/useIncidenceRateGeneration'
 import { useIncidenceRateStore } from '@/stores/incidence-rate'
+import {
+  generateIncidenceRate,
+  cancelIncidenceRateGeneration,
+  listIncidenceRateInfo,
+} from '@/services/incidence-rate.service'
+
+const mockGenerate = vi.mocked(generateIncidenceRate)
+const mockCancel = vi.mocked(cancelIncidenceRateGeneration)
+const mockListInfo = vi.mocked(listIncidenceRateInfo)
 
 beforeEach(() => {
   setActivePinia(createPinia())
@@ -27,14 +37,92 @@ beforeEach(() => {
 })
 
 describe('useIncidenceRateGeneration', () => {
-  it('start triggers polling and stops on terminal status', async () => {
+  it('start triggers polling and keeps polling until terminal status arrives', async () => {
+    const store = useIncidenceRateStore()
+    const ds = useDataSourcesStore()
+    ds.sources = [{ sourceId: 2, sourceKey: 'CCAE' }] as never
+    mockListInfo
+      .mockResolvedValueOnce({
+        success: true,
+        data: [
+          { executionInfo: { id: { analysisId: 1, sourceId: 2 }, status: 'RUNNING' }, summaryList: [] },
+        ],
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [
+          { executionInfo: { id: { analysisId: 1, sourceId: 2 }, status: 'COMPLETE' }, summaryList: [] },
+        ],
+      })
+
     const gen = useIncidenceRateGeneration(1)
-    await gen.start('2')
+    await gen.start('CCAE')
+
+    expect(mockGenerate).toHaveBeenCalledWith(1, 'CCAE')
     expect(gen.polling.value).toBe(true)
     await vi.advanceTimersByTimeAsync(5000)
-    // After polling fetches COMPLETE, polling stops
     expect(gen.polling.value).toBe(false)
+    expect(store.executionInfoBySourceKey.CCAE.executionInfo.status).toBe('COMPLETE')
+  })
+
+  it('pollOnce retries data-source loading and maps source ids to keys', async () => {
     const store = useIncidenceRateStore()
-    expect(store.executionInfoBySourceKey['2'].executionInfo.status).toBe('COMPLETE')
+    const ds = useDataSourcesStore()
+    ds.sources = [] as never
+    const fetchSpy = vi.spyOn(ds, 'fetchDataSources').mockImplementationOnce(async () => {
+      ds.sources = [] as never
+    }).mockImplementationOnce(async () => {
+      ds.sources = [{ sourceId: 9, sourceKey: 'SRC9' }] as never
+    })
+    mockListInfo.mockResolvedValue({
+      success: true,
+      data: [
+        { executionInfo: { id: { analysisId: 1, sourceId: 9 }, status: 'COMPLETE' }, summaryList: [] },
+      ],
+    })
+
+    const gen = useIncidenceRateGeneration(1)
+    await gen.pollOnce()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(store.executionInfoBySourceKey.SRC9.executionInfo.id.sourceId).toBe(9)
+  })
+
+  it('surfaces a poll failure and stops the active poller', async () => {
+    mockListInfo.mockResolvedValue({
+      success: false,
+      error: { message: 'boom' },
+    } as never)
+
+    const gen = useIncidenceRateGeneration(1)
+    await gen.pollOnce()
+
+    expect(gen.error.value).toBe('boom')
+  })
+
+  it('returns false when generation start fails', async () => {
+    mockGenerate.mockResolvedValueOnce({
+      success: false,
+      error: { message: 'cannot start' },
+    } as never)
+
+    const gen = useIncidenceRateGeneration(1)
+    const ok = await gen.start('CCAE')
+
+    expect(ok).toBe(false)
+    expect(gen.error.value).toBe('cannot start')
+  })
+
+  it('returns false when cancel fails', async () => {
+    mockCancel.mockResolvedValueOnce({
+      success: false,
+      error: { message: 'cannot cancel' },
+    } as never)
+
+    const gen = useIncidenceRateGeneration(1)
+    const ok = await gen.cancel('CCAE')
+
+    expect(ok).toBe(false)
+    expect(gen.error.value).toBe('cannot cancel')
   })
 })

--- a/tests/unit/services/characterization.service.spec.ts
+++ b/tests/unit/services/characterization.service.spec.ts
@@ -126,6 +126,28 @@ describe('services/characterization.service', () => {
       }
     })
 
+      it('accepts a running execution with null endTime and hashCode', async () => {
+        ok({
+          id: 290,
+          status: 'STARTED',
+          sourceKey: 'sample',
+          hashCode: null,
+          startTime: 1787763349585,
+          endTime: null,
+          exitMessage: '',
+        })
+
+        const result = await getCharacterizationExecution(290)
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.id).toBe(290)
+          expect(result.data.endTime).toBeNull()
+        } else {
+          expect.fail(`expected success, got ${result.error.message}`)
+        }
+      })
+
     it('does not import the webapi barrel', async () => {
       const source = await import('node:fs').then(fs =>
         fs.readFileSync('src/services/characterization.service.ts', 'utf8')

--- a/tests/unit/services/pathway.service.spec.ts
+++ b/tests/unit/services/pathway.service.spec.ts
@@ -341,20 +341,51 @@ describe('services/pathway.service', () => {
 
   describe('pathway executions', () => {
     it('listPathwayExecutions GETs /pathway-analysis/:id/generation', async () => {
-      ok([])
+      ok([
+        {
+          id: 290,
+          status: 'STARTED',
+          sourceKey: 'sample',
+          hashCode: null,
+          startTime: 1787763349585,
+          endTime: null,
+          exitMessage: '',
+        },
+      ])
 
-      await listPathwayExecutions(1)
+      const result = await listPathwayExecutions(1)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].endTime).toBeNull()
+      } else {
+        expect.fail(`expected success, got ${result.error.message}`)
+      }
 
       const [url] = mockFetch.mock.calls[0]
       expect(url).toContain('/pathway-analysis/1/generation')
     })
 
     it('getPathwayExecution GETs /pathway-analysis/generation/:gid', async () => {
-      ok({ id: 99, status: 'COMPLETED', sourceKey: 'cdm' })
+      ok({
+        id: 99,
+        status: 'STARTED',
+        sourceKey: 'cdm',
+        hashCode: null,
+        startTime: 1787763349585,
+        endTime: null,
+        exitMessage: '',
+      })
 
       const result = await getPathwayExecution(99)
 
       expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.endTime).toBeNull()
+      } else {
+        expect.fail(`expected success, got ${result.error.message}`)
+      }
       const [url] = mockFetch.mock.calls[0]
       expect(url).toContain('/pathway-analysis/generation/99')
     })

--- a/tests/unit/stores/characterization.spec.ts
+++ b/tests/unit/stores/characterization.spec.ts
@@ -527,6 +527,24 @@ describe('Characterization Store', () => {
         await vi.advanceTimersByTimeAsync(10000)
         expect(vi.mocked(getCharacterizationExecution).mock.calls.length).toBe(callsBefore)
       })
+
+      it('dispose clears all pollers and stops future ticks', async () => {
+        const store = useCharacterizationStore()
+        vi.mocked(getCharacterizationExecution).mockResolvedValue(
+          success({ ...baseExec, id: 500, status: 'RUNNING' })
+        )
+
+        store.pollExecution(500)
+        await vi.advanceTimersByTimeAsync(0)
+        expect(store.pollingHandles.has(500)).toBe(true)
+
+        store.dispose()
+        expect(store.pollingHandles.has(500)).toBe(false)
+
+        const callsBefore = vi.mocked(getCharacterizationExecution).mock.calls.length
+        await vi.advanceTimersByTimeAsync(10000)
+        expect(vi.mocked(getCharacterizationExecution).mock.calls.length).toBe(callsBefore)
+      })
     })
   })
 })


### PR DESCRIPTION
This was going to be a hotfix for #287, however, in investigating the complete fix there, I uncovered some polling logic issues that I wanted to fix, so this PR is going to complete the fix for #287 as well as address polling issues discovered.

In summary: Polling should start from the list of generations and then the individual executions should be polled for.   The list poll can be a slower interval, while the individual executions can check more frequently.

The issue was that if you just opened a existing characterization (or other analysis types) and there was an active generation, you would not poll for it.   Also, if a generation starts up by another user while you have the view open, the list wasn't polling and showing activity.

We also didn't have a way to select source results on the overview/workbench component, so an icon was added to select the latest result of a source.   The icon highlights indicating which is active.   

Incidence Rates don't have the notion of 'generation history' so the source result view now has a flag to disable the generation results.
