### PR TITLE
Added refresh permission wrapper around entity create, route change, and poll interval.

### DIFF
--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -34,6 +34,10 @@ export function useAuth() {
       return authService.refreshToken()
     },
 
+    async refreshUser(): Promise<void> {
+      await authStore.refreshUser()
+    },
+
     async runAs(targetUsername: string): Promise<void> {
       return authService.runAs(targetUsername)
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -72,6 +72,17 @@ router.beforeEach(
   }
 )
 
+
+router.afterEach(to => {
+  if (to.meta.isOAuthCallback || to.meta.isSAMLCallback || to.meta.isOpenIDCallback) {
+    return
+  }
+
+  const authStore = useAuthStore()
+  void authStore.refreshUser().catch(error => {
+    logger.warn('Router', 'Permission refresh after navigation failed', error)
+  })
+})
 // Home redirect guard - must run before auth guard
 router.beforeEach(
   (to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) => {
@@ -108,9 +119,7 @@ router.beforeEach(async (to, _from, next) => {
         const { authService } = await import('@/services/auth/authService')
         const jwt = await authService.redeemOTC(otcCode)
         authStore.setToken(jwt)
-
-        const userInfo = await authService.fetchUserInfo()
-        authStore.setUser(userInfo)
+        await authStore.refreshUser()
         authStore.setAuthClient('OIDC')
 
         const oidcDestination = sessionStorage.getItem('oauth_redirect_destination')
@@ -125,10 +134,7 @@ router.beforeEach(async (to, _from, next) => {
       if (localStorageToken && localStorageToken !== 'null' && localStorageToken !== 'undefined') {
         authStore.setToken(localStorageToken)
 
-        // Fetch user info
-        const { authService } = await import('@/services/auth/authService')
-        const userInfo = await authService.fetchUserInfo()
-        authStore.setUser(userInfo)
+        await authStore.refreshUser()
         authStore.setAuthClient('OpenID')
 
         // Restore destination URL or redirect to home
@@ -145,10 +151,7 @@ router.beforeEach(async (to, _from, next) => {
         logger.info('Router', 'Token found in cookie')
         authStore.setToken(cookieToken)
 
-        // Fetch user info
-        const { authService } = await import('@/services/auth/authService')
-        const userInfo = await authService.fetchUserInfo()
-        authStore.setUser(userInfo)
+        await authStore.refreshUser()
 
         // Clear the cookie token
         document.cookie = 'bearerToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'

--- a/src/services/access.service.ts
+++ b/src/services/access.service.ts
@@ -11,6 +11,7 @@ import { unwrap, parseOrThrow, unwrapList } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import { RoleListSchema, type Role } from '@/models/role.types'
 import { AccessEntityTypeSchema, AccessTypeSchema, type AccessEntityType, type AccessType } from '@/models/access.types'
+import { useAuthStore } from '@/stores/auth'
 
 const CONTEXT = 'AccessService'
 
@@ -60,11 +61,14 @@ export async function grantEntityAccess(
   accessType: AccessType = 'WRITE'
 ): Promise<ApiResult<void>> {
   return unwrap(async () => {
+    const authStore = useAuthStore()
     const normalizedEntityType = AccessEntityTypeSchema.parse(entityType)
     const normalizedAccessType = AccessTypeSchema.parse(accessType)
-    await httpPost(accessRolePath(normalizedEntityType, entityId, roleId), {
-      accessType: normalizedAccessType,
-    })
+    await authStore.executeWithUserRefresh(() =>
+      httpPost(accessRolePath(normalizedEntityType, entityId, roleId), {
+        accessType: normalizedAccessType,
+      })
+    )
   }, CONTEXT)
 }
 
@@ -78,10 +82,13 @@ export async function revokeEntityAccess(
   accessType: AccessType = 'WRITE'
 ): Promise<ApiResult<void>> {
   return unwrap(async () => {
+    const authStore = useAuthStore()
     const normalizedEntityType = AccessEntityTypeSchema.parse(entityType)
     const normalizedAccessType = AccessTypeSchema.parse(accessType)
-    await httpDelete(accessRolePath(normalizedEntityType, entityId, roleId), {
-      body: { accessType: normalizedAccessType },
-    })
+    await authStore.executeWithUserRefresh(() =>
+      httpDelete(accessRolePath(normalizedEntityType, entityId, roleId), {
+        body: { accessType: normalizedAccessType },
+      })
+    )
   }, CONTEXT)
 }

--- a/src/services/characterization.service.ts
+++ b/src/services/characterization.service.ts
@@ -18,6 +18,7 @@ import {
 } from '@/models/characterization.types'
 import { z } from 'zod'
 import { normalizeCriteriaGroupForCirce } from '@/components/cohort-editor/normalize'
+import { useAuthStore } from '@/stores/auth'
 
 const CONTEXT = 'CharacterizationService'
 
@@ -75,7 +76,10 @@ export async function createCharacterization(
   def: CharacterizationDefinition
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
-    const data = await httpPost<unknown>('/cohort-characterization', serializeCharacterization(def))
+    const authStore = useAuthStore()
+    const data = await authStore.executeWithUserRefresh(() =>
+      httpPost<unknown>('/cohort-characterization', serializeCharacterization(def))
+    )
     return parseOrThrow(
       CharacterizationDefinitionSchema,
       data,
@@ -95,9 +99,9 @@ export async function updateCharacterization(
     if (typeof def.id !== 'number') {
       throw new Error('updateCharacterization requires def.id')
     }
-    const data = await httpPut<unknown>(
-      `/cohort-characterization/${def.id}`,
-      serializeCharacterization(def)
+    const authStore = useAuthStore()
+    const data = await authStore.executeWithUserRefresh(() =>
+      httpPut<unknown>(`/cohort-characterization/${def.id}`, serializeCharacterization(def))
     )
     return parseOrThrow(
       CharacterizationDefinitionSchema,
@@ -126,7 +130,10 @@ export async function copyCharacterization(
   id: number
 ): Promise<ApiResult<CharacterizationDefinition>> {
   return unwrap(async () => {
-    const data = await httpPost<unknown>(`/cohort-characterization/${id}`)
+    const authStore = useAuthStore()
+    const data = await authStore.executeWithUserRefresh(() =>
+      httpPost<unknown>(`/cohort-characterization/${id}`)
+    )
     return parseOrThrow(
       CharacterizationDefinitionSchema,
       data,

--- a/src/services/cohort-definition.service.ts
+++ b/src/services/cohort-definition.service.ts
@@ -9,6 +9,7 @@ import { unwrap, ApiError, parseOrThrow, zodIssues } from '@/services/api-error'
 import { type ApiResult } from '@/types/api'
 import type { RawCohortDefinition } from '@/models/atlas.types'
 import type { CohortDefinition } from '@/models/cohort.types'
+import { useAuthStore } from '@/stores/auth'
 import {
   CohortGenerationInfoListSchema,
   CohortDefinitionListSchema,
@@ -68,9 +69,12 @@ export async function saveCohortDefinition(
 ): Promise<ApiResult<CohortDefinition>> {
   return unwrap(async () => {
     logger.debug(CONTEXT, 'Saving cohort definition', { id: cohort.id, name: cohort.name })
-    const saved = cohort.id
-      ? await httpPut<CohortDefinition>(`/cohortdefinition/${cohort.id}`, cohort)
-      : await httpPost<CohortDefinition>('/cohortdefinition', cohort)
+    const authStore = useAuthStore()
+    const saved = await authStore.executeWithUserRefresh(() =>
+      cohort.id
+        ? httpPut<CohortDefinition>(`/cohortdefinition/${cohort.id}`, cohort)
+        : httpPost<CohortDefinition>('/cohortdefinition', cohort)
+    )
     return saved
   }, CONTEXT)
 }

--- a/src/services/concept-set.service.ts
+++ b/src/services/concept-set.service.ts
@@ -16,6 +16,7 @@ import {
 import { logger } from '@/utils/logger'
 import { httpGet, httpPost, httpPut, httpDelete } from '@/services/http-client'
 import { getSourceKey } from '@/config/webapi'
+import { useAuthStore } from '@/stores/auth'
 
 /**
  * Prefer the source key validated against the sources the server actually
@@ -98,23 +99,30 @@ export async function createConceptSet(
   conceptSet: Omit<ConceptSet, 'id' | 'createdDate' | 'createdBy' | 'modifiedDate' | 'modifiedBy'>
 ): Promise<ConceptSet> {
   try {
+    const authStore = useAuthStore()
     const metadataPayload = {
       name: conceptSet.name,
       description: conceptSet.description,
     }
 
-    const data = await httpPost<ConceptSetAPIResponse>('/conceptset', metadataPayload)
+    const data = await authStore.executeWithUserRefresh(async () => {
+      const created = await httpPost<ConceptSetAPIResponse>('/conceptset', metadataPayload)
 
-    if ((conceptSet.items?.length || 0) > 0 && data.id) {
-      const itemsPayload = (conceptSet.items || []).map(item => ({
-        conceptId: item.conceptId,
-        isExcluded: item.isExcluded ? 1 : 0,
-        includeDescendants: item.includeDescendants ? 1 : 0,
-        includeMapped: item.includeMapped ? 1 : 0,
-      }))
+      if ((conceptSet.items?.length || 0) > 0 && created.id) {
+        const itemsPayload = (conceptSet.items || []).map(item => ({
+          conceptId: item.conceptId,
+          isExcluded: item.isExcluded ? 1 : 0,
+          includeDescendants: item.includeDescendants ? 1 : 0,
+          includeMapped: item.includeMapped ? 1 : 0,
+        }))
 
-      await httpPut(`/conceptset/${data.id}/items`, itemsPayload)
+        await httpPut(`/conceptset/${created.id}/items`, itemsPayload)
+      }
 
+      return created
+    })
+
+    if (data.id) {
       const sourceKey = await resolveSourceKey()
       const [updatedMetadata, updatedExpression] = await Promise.all([
         httpGet<ConceptSetAPIMetadata>(`/conceptset/${data.id}`),
@@ -129,8 +137,6 @@ export async function createConceptSet(
 
     return mapConceptSetFromAPI(data)
   } catch (error) {
-    // Propagate: the server's error detail (the shared client surfaces the body)
-    // is what the user needs; a bare null reduced every failure to a generic toast.
     logger.error('ConceptSet', 'Failed to create concept set', error)
     throw error
   }
@@ -147,22 +153,25 @@ export async function updateConceptSet(conceptSet: ConceptSet): Promise<ConceptS
   }
 
   try {
+    const authStore = useAuthStore()
     const metadataPayload = {
       id: conceptSet.id,
       name: conceptSet.name,
       description: conceptSet.description,
     }
 
-    await httpPut<ConceptSetAPIResponse>(`/conceptset/${conceptSet.id}`, metadataPayload)
+    await authStore.executeWithUserRefresh(async () => {
+      await httpPut<ConceptSetAPIResponse>(`/conceptset/${conceptSet.id}`, metadataPayload)
 
-    const itemsPayload = (conceptSet.items || []).map(item => ({
-      conceptId: item.conceptId,
-      isExcluded: item.isExcluded ? 1 : 0,
-      includeDescendants: item.includeDescendants ? 1 : 0,
-      includeMapped: item.includeMapped ? 1 : 0,
-    }))
+      const itemsPayload = (conceptSet.items || []).map(item => ({
+        conceptId: item.conceptId,
+        isExcluded: item.isExcluded ? 1 : 0,
+        includeDescendants: item.includeDescendants ? 1 : 0,
+        includeMapped: item.includeMapped ? 1 : 0,
+      }))
 
-    await httpPut(`/conceptset/${conceptSet.id}/items`, itemsPayload)
+      await httpPut(`/conceptset/${conceptSet.id}/items`, itemsPayload)
+    })
 
     const sourceKey = await resolveSourceKey()
     const [updatedMetadata, updatedExpression] = await Promise.all([

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -14,6 +14,10 @@ let storageHandler: ((e: StorageEvent) => void) | null = null
 // Debounce timeout for cross-tab sync
 let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null
 const SYNC_DEBOUNCE_MS = 100
+const PERMISSION_REFRESH_INTERVAL_MS = 60_000
+
+let refreshUserPromise: Promise<UserInfo> | null = null
+let permissionRefreshIntervalId: ReturnType<typeof setInterval> | null = null
 
 let lastModalOpenTime = 0
 const MODAL_DEBOUNCE_MS = 500
@@ -21,6 +25,7 @@ const MODAL_DEBOUNCE_MS = 500
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState & {
     refreshTimeoutId: number | null
+    isRefreshingUser: boolean
     isRunningAs: boolean
     originalUser: UserInfo | null
     sessionExpiryModalOpen: boolean
@@ -41,6 +46,7 @@ export const useAuthStore = defineStore('auth', {
     errorMessage: null,
     isAuthenticating: false,
     refreshTimeoutId: null,
+    isRefreshingUser: false,
     isRunningAs: false,
     originalUser: null,
     sessionExpiryModalOpen: false,
@@ -81,6 +87,52 @@ export const useAuthStore = defineStore('auth', {
       storageManager.saveToken(token)
 
       this.scheduleTokenRefresh()
+    },
+
+    async refreshUser(): Promise<UserInfo> {
+      if (refreshUserPromise) {
+        return refreshUserPromise
+      }
+
+      this.isRefreshingUser = true
+      refreshUserPromise = (async () => {
+        try {
+          const { authService } = await import('@/services/auth/authService')
+          const userInfo = await authService.fetchUserInfo()
+          this.setUser(userInfo)
+          return userInfo
+        } finally {
+          this.isRefreshingUser = false
+          refreshUserPromise = null
+        }
+      })()
+
+      return refreshUserPromise
+    },
+
+    async executeWithUserRefresh<T>(operation: () => Promise<T>): Promise<T> {
+      const result = await operation()
+      await this.refreshUser()
+      return result
+    },
+
+    startPermissionRefreshPolling() {
+      if (permissionRefreshIntervalId !== null) {
+        return
+      }
+
+      permissionRefreshIntervalId = setInterval(() => {
+        void this.refreshUser().catch(error => {
+          logger.warn('Auth', 'Periodic permission refresh failed', error)
+        })
+      }, PERMISSION_REFRESH_INTERVAL_MS)
+    },
+
+    stopPermissionRefreshPolling() {
+      if (permissionRefreshIntervalId !== null) {
+        clearInterval(permissionRefreshIntervalId)
+        permissionRefreshIntervalId = null
+      }
     },
 
     /**
@@ -131,6 +183,7 @@ export const useAuthStore = defineStore('auth', {
       this.errorMessage = null
       this.isRunningAs = false
       this.originalUser = null
+      this.isRefreshingUser = false
       // The expiry warning is tied to the active session — once auth is
       // cleared (logout, cross-tab sync, refresh failure) the modal must
       // not linger above whatever comes next.
@@ -283,9 +336,7 @@ export const useAuthStore = defineStore('auth', {
       // anonymous permission set and no login prompt is shown; per-endpoint
       // permissions still gate actions server-side.
       try {
-        const { authService } = await import('@/services/auth/authService')
-        const userInfo = await authService.fetchUserInfo()
-        this.setUser(userInfo)
+        await this.refreshUser()
       } catch (error) {
         this.setUser(null)
         if (hadToken) {
@@ -304,6 +355,7 @@ export const useAuthStore = defineStore('auth', {
         this.userResolved = true
       }
 
+      this.startPermissionRefreshPolling()
       this.setupCrossTabSync()
     },
 
@@ -324,9 +376,7 @@ export const useAuthStore = defineStore('auth', {
                 this.setToken(newValue)
                 if (!this.tokenExpired && this.isTokenValid) {
                   try {
-                    const { authService } = await import('@/services/auth/authService')
-                    const userInfo = await authService.fetchUserInfo()
-                    this.setUser(userInfo)
+                    await this.refreshUser()
                   } catch (error) {
                     logger.error('Auth', 'Failed to fetch user info on tab sync', error)
                   }
@@ -371,6 +421,7 @@ export const useAuthStore = defineStore('auth', {
         window.removeEventListener('storage', storageHandler)
         storageHandler = null
       }
+      this.stopPermissionRefreshPolling()
     },
   },
 })

--- a/src/stores/roles.ts
+++ b/src/stores/roles.ts
@@ -14,6 +14,7 @@ import * as permissionService from '@/services/permission.service'
 import * as userService from '@/services/user.service'
 import type { Role, RoleCreate, RoleUpdate, Permission, User } from '@/models/role.types'
 import { logger } from '@/utils/logger'
+import { useAuthStore } from '@/stores/auth'
 
 export const useRolesStore = defineStore('roles', () => {
   // ============================================================================
@@ -298,7 +299,10 @@ export const useRolesStore = defineStore('roles', () => {
     isSaving.value = true
 
     try {
-      const result = await roleService.assignPermissionToRole(roleId, permissionId)
+      const authStore = useAuthStore()
+      const result = await authStore.executeWithUserRefresh(() =>
+        roleService.assignPermissionToRole(roleId, permissionId)
+      )
 
       if (result.success) {
         // Add to local state if not already present
@@ -336,7 +340,10 @@ export const useRolesStore = defineStore('roles', () => {
     isSaving.value = true
 
     try {
-      const result = await roleService.removePermissionFromRole(roleId, permissionId)
+      const authStore = useAuthStore()
+      const result = await authStore.executeWithUserRefresh(() =>
+        roleService.removePermissionFromRole(roleId, permissionId)
+      )
 
       if (result.success) {
         // Remove from local state
@@ -436,7 +443,10 @@ export const useRolesStore = defineStore('roles', () => {
     isSaving.value = true
 
     try {
-      const result = await roleService.assignUserToRole(roleId, userId)
+      const authStore = useAuthStore()
+      const result = await authStore.executeWithUserRefresh(() =>
+        roleService.assignUserToRole(roleId, userId)
+      )
 
       if (result.success) {
         // Add to local state if not already present
@@ -470,7 +480,10 @@ export const useRolesStore = defineStore('roles', () => {
     isSaving.value = true
 
     try {
-      const result = await roleService.removeUserFromRole(roleId, userId)
+      const authStore = useAuthStore()
+      const result = await authStore.executeWithUserRefresh(() =>
+        roleService.removeUserFromRole(roleId, userId)
+      )
 
       if (result.success) {
         // Remove from local state

--- a/tests/unit/router/index.spec.ts
+++ b/tests/unit/router/index.spec.ts
@@ -89,6 +89,10 @@ describe('Vue Router', () => {
       setAuthClient: vi.fn(),
       setError: vi.fn(),
       openLoginModal: vi.fn(),
+      refreshUser: vi.fn(async () => {
+        const userInfo = await authService.fetchUserInfo()
+        mockAuthStore.setUser(userInfo)
+      }),
     }
     vi.mocked(useAuthStore).mockReturnValue(mockAuthStore)
 
@@ -122,6 +126,7 @@ describe('Vue Router', () => {
     // Reset router to initial state
     await router.push('/')
     await router.isReady()
+    vi.mocked(mockAuthStore.refreshUser).mockClear()
   })
 
   afterEach(() => {
@@ -145,6 +150,14 @@ describe('Vue Router', () => {
       const conceptsRoute = router.getRoutes().find((r) => r.name === 'concepts')
       expect((cohortsRoute?.meta as { titleKey?: string })?.titleKey).toBe('route.cohorts.title')
       expect((conceptsRoute?.meta as { titleKey?: string })?.titleKey).toBe('route.conceptSets.title')
+    })
+  })
+
+  describe('permission refresh', () => {
+    it('should refresh user after navigation', async () => {
+      await router.push('/cohorts')
+
+      expect(mockAuthStore.refreshUser).toHaveBeenCalled()
     })
   })
 
@@ -229,6 +242,7 @@ describe('Vue Router', () => {
         name: 'Test User',
         email: 'test@example.com',
       })
+      vi.mocked(mockAuthStore.refreshUser).mockClear()
     })
 
     describe('Token in localStorage', () => {
@@ -705,6 +719,7 @@ describe('Deeplink guard (?route= handling)', () => {
       setAuthClient: vi.fn(),
       setError: vi.fn(),
       openLoginModal: vi.fn(),
+      refreshUser: vi.fn().mockResolvedValue(undefined),
     }
     mockUIStore = {
       configPanelState: { isOpen: false },

--- a/tests/unit/services/access.service.test.ts
+++ b/tests/unit/services/access.service.test.ts
@@ -7,6 +7,12 @@ vi.mock('@/services/http-client', () => ({
   httpPost: vi.fn(),
   httpDelete: vi.fn(),
 }))
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore),
+}))
 vi.mock('@/utils/logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
@@ -58,6 +64,7 @@ describe('access.service', () => {
     expect(httpPost).toHaveBeenCalledWith('/permission/access/SOURCE/123/role/7', {
       accessType: 'WRITE',
     })
+    expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
     expect(result.success).toBe(true)
   })
 
@@ -69,6 +76,7 @@ describe('access.service', () => {
     expect(httpDelete).toHaveBeenCalledWith('/permission/access/SOURCE/123/role/7', {
       body: { accessType: 'READ' },
     })
+    expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
     expect(result.success).toBe(true)
   })
 })

--- a/tests/unit/services/characterization.service.spec.ts
+++ b/tests/unit/services/characterization.service.spec.ts
@@ -12,6 +12,14 @@ vi.mock('@/utils/logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
 
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore),
+}))
+
 import {
   listCharacterizations,
   getCharacterization,
@@ -49,6 +57,7 @@ describe('services/characterization.service', () => {
     vi.clearAllMocks()
     mockFetch = vi.fn()
     global.fetch = mockFetch
+    mockAuthStore.executeWithUserRefresh.mockImplementation((operation: () => Promise<unknown>) => operation())
   })
 
   function ok(body: unknown) {

--- a/tests/unit/services/cohort-definition.service.spec.ts
+++ b/tests/unit/services/cohort-definition.service.spec.ts
@@ -4,8 +4,12 @@ vi.mock('@/utils/logger', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
 
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+
 vi.mock('@/stores/auth', () => ({
-  useAuthStore: vi.fn(() => ({ token: 'mock-token' })),
+  useAuthStore: vi.fn(() => ({ token: 'mock-token', ...mockAuthStore })),
 }))
 
 import {
@@ -174,6 +178,17 @@ describe('services/cohort-definition.service', () => {
       const [url, options] = mockFetch.mock.calls[0]
       expect(url).toContain('/cohortdefinition/5')
       expect(options.method).toBe('PUT')
+    })
+
+    it('wraps successful saves in executeWithUserRefresh', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ id: 1, name: 'C', expression: {} }),
+      })
+
+      await saveCohortDefinition({ name: 'C', expression: {} })
+
+      expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/services/concept-set.service.spec.ts
+++ b/tests/unit/services/concept-set.service.spec.ts
@@ -12,6 +12,14 @@ vi.mock('@/services/http-client', () => ({
   httpDelete: vi.fn(),
 }))
 
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore),
+}))
+
 // Mock logger
 vi.mock('@/utils/logger', () => ({
   logger: {
@@ -59,6 +67,7 @@ describe('ConceptSetService', () => {
     vi.clearAllMocks()
     getValidVocabularySource.mockReturnValue(null)
     localStorage.clear()
+    mockAuthStore.executeWithUserRefresh.mockImplementation((operation: () => Promise<unknown>) => operation())
   })
 
   afterEach(() => {
@@ -123,7 +132,7 @@ describe('ConceptSetService', () => {
     })
 
     it('should return null on fetch failure', async () => {
-      vi.mocked(httpGet).mockRejectedValue(new Error('HTTP 404: Not Found'))
+      vi.mocked(httpGet).mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
 
       const result = await getConceptSetById(999)
 
@@ -131,7 +140,7 @@ describe('ConceptSetService', () => {
     })
 
     it('should return null on network error', async () => {
-      vi.mocked(httpGet).mockRejectedValue(new Error('Network error'))
+      vi.mocked(httpGet).mockRejectedValueOnce(new Error('Network error'))
 
       const result = await getConceptSetById(1)
 
@@ -168,6 +177,7 @@ describe('ConceptSetService', () => {
         name: 'New Concept Set',
         description: 'New description',
       })
+      expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
       expect(result).not.toBeNull()
     })
 
@@ -200,6 +210,7 @@ describe('ConceptSetService', () => {
 
       expect(httpPut).toHaveBeenCalledWith('/conceptset/1', metadata)
       expect(httpPut).toHaveBeenCalledWith('/conceptset/1/items', [])
+      expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
       expect(result).not.toBeNull()
     })
 

--- a/tests/unit/services/strata-normalization.spec.ts
+++ b/tests/unit/services/strata-normalization.spec.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { CharacterizationDefinition } from '@/models/characterization.types'
 import type { IncidenceRate, IncidenceRateExpression } from '@/models/incidence-rate.types'
 
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+
 const { httpPut } = vi.hoisted(() => ({ httpPut: vi.fn() }))
 
 vi.mock('@/services/http-client', () => ({
@@ -12,13 +16,20 @@ vi.mock('@/services/http-client', () => ({
   httpPostRead: vi.fn(),
 }))
 
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore),
+}))
+
 const timeAtRisk = {
   start: { DateField: 'StartDate', Offset: 0 },
   end: { DateField: 'EndDate', Offset: 0 },
 } satisfies IncidenceRateExpression['timeAtRisk']
 
 describe('criteria groups leaving through the strata save paths', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuthStore.executeWithUserRefresh.mockImplementation((operation: () => Promise<unknown>) => operation())
+  })
 
   it('characterization strata reach the wire with Type and Count', async () => {
     const design: CharacterizationDefinition = {

--- a/tests/unit/stores/auth.spec.ts
+++ b/tests/unit/stores/auth.spec.ts
@@ -71,6 +71,7 @@ import { storageManager } from '@/services/auth/storageManager'
 import { tokenManager } from '@/services/auth/tokenManager'
 import { refreshManager } from '@/services/auth/refreshManager'
 import { permissionService } from '@/services/auth/permissions'
+import { authService } from '@/services/auth/authService'
 
 describe('Auth Store', () => {
   beforeEach(() => {
@@ -263,6 +264,89 @@ describe('Auth Store', () => {
 
       expect(store.user).toBeNull()
       expect(store.permissions).toEqual({})
+    })
+  })
+
+  describe('refreshUser Action', () => {
+    it('should fetch user info and update the store', async () => {
+      const store = useAuthStore()
+      const user: UserInfo = {
+        login: 'jdoe',
+        displayName: 'John Doe',
+        permissionIdx: { cohort: ['cohort:read'] },
+      } as UserInfo
+
+      vi.mocked(authService.fetchUserInfo).mockResolvedValue(user)
+
+      const result = await store.refreshUser()
+
+      expect(authService.fetchUserInfo).toHaveBeenCalled()
+      expect(result).toEqual(user)
+      expect(store.user).toEqual(user)
+      expect(permissionService.clearCache).toHaveBeenCalled()
+    })
+
+    it('should share the in-flight refresh promise', async () => {
+      const store = useAuthStore()
+      const user: UserInfo = {
+        login: 'jdoe',
+        displayName: 'John Doe',
+        permissionIdx: {},
+      } as UserInfo
+
+      vi.mocked(authService.fetchUserInfo).mockResolvedValue(user)
+
+      const first = store.refreshUser()
+      const second = store.refreshUser()
+
+      await expect(first).resolves.toEqual(user)
+      await expect(second).resolves.toEqual(user)
+      expect(authService.fetchUserInfo).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('executeWithUserRefresh Action', () => {
+    it('should run the operation then refresh the user', async () => {
+      const store = useAuthStore()
+      const user: UserInfo = {
+        login: 'jdoe',
+        displayName: 'John Doe',
+        permissionIdx: {},
+      } as UserInfo
+
+      vi.mocked(authService.fetchUserInfo).mockResolvedValue(user)
+
+      const operation = vi.fn().mockResolvedValue('saved')
+
+      const result = await store.executeWithUserRefresh(operation)
+
+      expect(operation).toHaveBeenCalled()
+      expect(result).toBe('saved')
+      expect(authService.fetchUserInfo).toHaveBeenCalled()
+    })
+  })
+
+  describe('permission refresh polling', () => {
+    it('should refresh permissions on the polling interval', async () => {
+      vi.useFakeTimers()
+
+      const store = useAuthStore()
+      const user: UserInfo = {
+        login: 'jdoe',
+        displayName: 'John Doe',
+        permissionIdx: {},
+      } as UserInfo
+
+      vi.mocked(authService.fetchUserInfo).mockResolvedValue(user)
+
+      store.startPermissionRefreshPolling()
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(authService.fetchUserInfo).toHaveBeenCalled()
+
+      store.stopPermissionRefreshPolling()
+      vi.useRealTimers()
     })
   })
 

--- a/tests/unit/stores/roles.test.ts
+++ b/tests/unit/stores/roles.test.ts
@@ -9,6 +9,14 @@ import type { Role, RoleCreate, RoleUpdate, Permission, User } from '@/models/ro
 import type { ApiResult } from '@/types/api'
 import { ApiError } from '@/services/api-error'
 
+const mockAuthStore = {
+  executeWithUserRefresh: vi.fn((operation: () => Promise<unknown>) => operation()),
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(() => mockAuthStore),
+}))
+
 // Mock the services
 vi.mock('@/services/role.service')
 vi.mock('@/services/permission.service')
@@ -240,6 +248,21 @@ describe('useRolesStore', () => {
       resolveCreate(successResult)
       await createPromise
       expect(store.isSaving).toBe(false)
+    })
+  })
+
+  describe('permission mutations', () => {
+    it('should refresh the user after assigning a permission', async () => {
+      vi.spyOn(roleService, 'assignPermissionToRole').mockResolvedValue({
+        success: true,
+        data: undefined,
+      })
+
+      const store = useRolesStore()
+      const result = await store.assignPermissionToRole(1, 77)
+
+      expect(result).toBe(true)
+      expect(mockAuthStore.executeWithUserRefresh).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Adds refresh user perms wrapper around create operations, and also refreshes user permissions on nav switch and polling intervals.

Superseeds #281.
Fixes #274
Fixes #268