### PR TITLE
Fix valid concepts displaying as Invalid in concept search

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -328,7 +328,6 @@ import CohortToolbarActions from './CohortToolbarActions.vue'
 import CohortToolbarStatus from './CohortToolbarStatus.vue'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { nextConceptSetId } from '@/utils/concept-set-id'
-import { normalizeInvalidReason } from '@/utils/api-mappers'
 import ConceptSetsListDialog from './ConceptSetsListDialog.vue'
 import CohortJsonDialog from './CohortJsonDialog.vue'
 import ValidationMessagesDialog from './ValidationMessagesDialog.vue'
@@ -427,7 +426,7 @@ function convertCirceItemToAtlas(item: CirceConceptSetItem): ConceptSetItem {
     vocabularyId: c?.VOCABULARY_ID ?? '',
     conceptClassId: c?.CONCEPT_CLASS_ID ?? '',
     standardConcept: c?.STANDARD_CONCEPT ?? null,
-    invalidReason: normalizeInvalidReason(c?.INVALID_REASON),
+    invalidReason: c?.INVALID_REASON ?? null,
     isExcluded: item.isExcluded ?? false,
     includeDescendants: item.includeDescendants ?? false,
     includeMapped: item.includeMapped ?? false,

--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -328,6 +328,7 @@ import CohortToolbarActions from './CohortToolbarActions.vue'
 import CohortToolbarStatus from './CohortToolbarStatus.vue'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { nextConceptSetId } from '@/utils/concept-set-id'
+import { normalizeInvalidReason } from '@/utils/api-mappers'
 import ConceptSetsListDialog from './ConceptSetsListDialog.vue'
 import CohortJsonDialog from './CohortJsonDialog.vue'
 import ValidationMessagesDialog from './ValidationMessagesDialog.vue'
@@ -426,7 +427,7 @@ function convertCirceItemToAtlas(item: CirceConceptSetItem): ConceptSetItem {
     vocabularyId: c?.VOCABULARY_ID ?? '',
     conceptClassId: c?.CONCEPT_CLASS_ID ?? '',
     standardConcept: c?.STANDARD_CONCEPT ?? null,
-    invalidReason: c?.INVALID_REASON ?? null,
+    invalidReason: normalizeInvalidReason(c?.INVALID_REASON),
     isExcluded: item.isExcluded ?? false,
     includeDescendants: item.includeDescendants ?? false,
     includeMapped: item.includeMapped ?? false,

--- a/src/services/concept-detail.service.ts
+++ b/src/services/concept-detail.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@/models/concept-detail.types'
 import type { DrilldownReport, WebAPIDrilldownRaw } from '@/models/report.types'
 import { mapDrilldownReport } from '@/services/report-mapper'
+import { normalizeInvalidReason } from '@/utils/api-mappers'
 
 // `cause` is declared here rather than passed to Error's constructor: the
 // project targets ES2020, whose Error has no cause option.
@@ -61,7 +62,7 @@ function mapRelatedFromApi(
     vocabularyId: api.VOCABULARY_ID,
     conceptClassId: api.CONCEPT_CLASS_ID,
     standardConcept: api.STANDARD_CONCEPT,
-    invalidReason: api.INVALID_REASON,
+    invalidReason: normalizeInvalidReason(api.INVALID_REASON),
     validStartDate: api.VALID_START_DATE != null ? String(api.VALID_START_DATE) : undefined,
     validEndDate: api.VALID_END_DATE != null ? String(api.VALID_END_DATE) : undefined,
     relationships: api.RELATIONSHIPS.map((r) => ({

--- a/src/utils/api-mappers.ts
+++ b/src/utils/api-mappers.ts
@@ -56,11 +56,11 @@ export interface ConceptSetAPIResponse extends ConceptSetAPIMetadata {
 }
 
 /**
- * Concept-set-expression items round-trip through WebAPI with `INVALID_REASON`
- * set to the literal string `"V"` for valid concepts (the plain
- * `/vocabulary/{key}/search` endpoint uses `null` instead). Every UI badge
- * and facet checks `invalidReason` for truthiness, so a raw `"V"` reads as
- * "invalid" unless it is normalized back to `null` here (see #221).
+ * WebAPI returns `INVALID_REASON` as the literal string `"V"` for a valid
+ * concept rather than `null`, on concept-set expressions (#221) and on
+ * `/vocabulary/{key}/search` results alike (#297). Every UI badge and facet
+ * checks `invalidReason` for truthiness, so a raw `"V"` reads as "invalid"
+ * unless it is normalized back to `null` at each mapping boundary.
  */
 export function normalizeInvalidReason(invalidReason: string | null | undefined): string | null {
   return invalidReason && invalidReason !== 'V' ? invalidReason : null
@@ -78,7 +78,7 @@ export function mapConceptFromAPI(raw: ConceptSearchResponseItem): Concept {
     vocabularyId: raw.VOCABULARY_ID,
     conceptClassId: raw.CONCEPT_CLASS_ID ?? "",
     standardConcept: raw.STANDARD_CONCEPT ?? null,
-    invalidReason: raw.INVALID_REASON ?? null,
+    invalidReason: normalizeInvalidReason(raw.INVALID_REASON),
   }
   if (raw.RELATIONSHIPS !== undefined) {
     concept.relationships = raw.RELATIONSHIPS

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {

--- a/tests/unit/services/concept-detail.service.spec.ts
+++ b/tests/unit/services/concept-detail.service.spec.ts
@@ -51,6 +51,26 @@ describe('concept-detail.service', () => {
       })
     })
 
+    it("normalizes the 'V' valid sentinel to null", async () => {
+      (httpClient as Mock).mockResolvedValueOnce([
+        {
+          CONCEPT_ID: 779546,
+          CONCEPT_NAME: 'buprenorphine',
+          CONCEPT_CODE: '1819',
+          DOMAIN_ID: 'Drug',
+          VOCABULARY_ID: 'RxNorm',
+          CONCEPT_CLASS_ID: 'Ingredient',
+          STANDARD_CONCEPT: 'S',
+          INVALID_REASON: 'V',
+          RELATIONSHIPS: [],
+        },
+      ])
+
+      const result = await getConceptRelated('SYNPUF1K', 779546)
+
+      expect(result[0].invalidReason).toBeNull()
+    })
+
     it('rejects when validation fails', async () => {
       (httpClient as Mock).mockResolvedValueOnce([{ broken: true }])
       await expect(getConceptRelated('SYNPUF1K', 1)).rejects.toThrow(

--- a/tests/unit/utils/api-mappers.spec.ts
+++ b/tests/unit/utils/api-mappers.spec.ts
@@ -56,6 +56,23 @@ describe('API Mappers', () => {
       expect(result.standardConcept).toBeNull()
       expect(result.invalidReason).toBe('D')
     })
+
+    it("normalizes the 'V' valid sentinel returned by vocabulary search to null", () => {
+      const apiConcept = {
+        CONCEPT_ID: 779546,
+        CONCEPT_NAME: 'buprenorphine',
+        CONCEPT_CODE: '1819',
+        DOMAIN_ID: 'Drug',
+        VOCABULARY_ID: 'RxNorm',
+        CONCEPT_CLASS_ID: 'Ingredient',
+        STANDARD_CONCEPT: 'S',
+        INVALID_REASON: 'V'
+      }
+
+      const result = mapConceptFromAPI(apiConcept)
+
+      expect(result.invalidReason).toBeNull()
+    })
   })
 
   describe('conceptToConceptSetItem', () => {


### PR DESCRIPTION
Fixes #297

## Problem

Searching the Drug domain for buprenorphine returns concepts labelled **Invalid** with an `Invalid Reason` of `V`. Concept 779546 is the reported case.

WebAPI returns `INVALID_REASON` as the literal string `'V'` for a concept that is still valid, rather than `null`. Every validity badge and the validity facet test `invalidReason` for truthiness, so `'V'` reads as "invalid".

## Why the existing guard missed it

`normalizeInvalidReason()` was added for #221 to strip `'V'` off concept-set expression items. Its doc comment states that `/vocabulary/{key}/search` returns `null` instead, so the search path was left unnormalized. #297 shows that assumption is wrong.

## Change

Apply the existing `normalizeInvalidReason()` at the two remaining points that translate a WebAPI response into the camelCase `Concept` shape:

- `mapConceptFromAPI` in `src/utils/api-mappers.ts`, which backs all seven vocabulary-search call sites
- `mapRelatedFromApi` in `src/services/concept-detail.service.ts`, for the related-concepts table and hierarchy dialog

The doc comment on `normalizeInvalidReason` is corrected to say both endpoints return `'V'`.

Normalizing at the boundary rather than at each badge means downstream consumers (`ConceptSetSelector`, `ConceptHierarchyDialog`, the facet filter, `ConceptAttributesCard`) need no change, and follows the convention #221 already established.

### Deliberately not changed

The cohort builder's `convertCirceItemToAtlas` also reads `INVALID_REASON`, but it is not a WebAPI boundary: the flat shape it produces is fed back through `convertAtlasItemToCirce` on save and apply. Normalizing there rewrites a value inside the cohort document rather than on the way in from the server, and `phenotype-tests (3)` failed on designs 1432 and 1433 with it applied, while passing on every other branch sharing this base. That conversion is left byte-for-byte as it was.

## Tests

- `api-mappers.spec.ts`: `mapConceptFromAPI` maps `INVALID_REASON: 'V'` to `null`, using the reported concept 779546
- `concept-detail.service.spec.ts`: same for `getConceptRelated`

## Verification

`npm run type-check` clean, lint clean, full unit + component + integration suite green.

Includes the fix from #306 so this branch builds; that commit drops out of this diff once #306 lands.
