### PR TITLE
Fix previously loaded incidence rate results appearing on a new or cloned design

### DIFF
--- a/src/composables/useIncidenceRateBuilder.ts
+++ b/src/composables/useIncidenceRateBuilder.ts
@@ -72,6 +72,9 @@ export function useIncidenceRateBuilder() {
       return false
     }
     store.setIR(result.data)
+    // The copy has never been generated; carrying the source design's polled
+    // execution info over made its workbench render the source's results.
+    store.resetGenerationState()
     notify('Copied', 'success')
     if (result.data.id !== undefined) {
       router.push(`/incidence-rates/${result.data.id}`)

--- a/src/stores/incidence-rate.ts
+++ b/src/stores/incidence-rate.ts
@@ -88,15 +88,23 @@ export const useIncidenceRateStore = defineStore('incidence-rate', () => {
     validationErrors.value = []
   }
 
+  // The workbench is not remounted across /incidence-rates/:id navigations, so
+  // any state scoped to one design (polled execution info and the report's
+  // target/outcome/source selection) has to be dropped whenever the store
+  // adopts a different design, or the previous design's results keep showing.
+  function resetGenerationState() {
+    executionInfoBySourceKey.value = {}
+    selectedTargetId.value = null
+    selectedOutcomeId.value = null
+    selectedSourceKey.value = null
+  }
+
   function createNewIR() {
     setIR(emptyIR())
     previewVersion.value = null
     isReadOnly.value = false
     cohortNameById.value = new Map()
-    executionInfoBySourceKey.value = {}
-    selectedTargetId.value = null
-    selectedOutcomeId.value = null
-    selectedSourceKey.value = null
+    resetGenerationState()
   }
 
   function markDirty() {
@@ -211,7 +219,7 @@ export const useIncidenceRateStore = defineStore('incidence-rate', () => {
     setIR(result.data)
     previewVersion.value = null
     isReadOnly.value = false
-    executionInfoBySourceKey.value = {}
+    resetGenerationState()
     await resolveCohortNames(result.data)
     return true
   }
@@ -581,6 +589,7 @@ export const useIncidenceRateStore = defineStore('incidence-rate', () => {
     removeTag,
     syncTags,
     setExecutionInfo,
+    resetGenerationState,
     setSelectedSource,
     setSelectedTargetOutcome,
     setRateMultiplier,

--- a/src/views/IncidenceRateManagerView.vue
+++ b/src/views/IncidenceRateManagerView.vue
@@ -32,7 +32,10 @@ async function load() {
 
   const idStr = props.id ?? (route.params.id as string | undefined)
   if (!idStr || idStr === 'new') {
-    if (!store.currentIR) {
+    // Only an unsaved draft (no id) may be reused here. A saved design left
+    // loaded by an earlier visit, and its polled execution info, must not
+    // leak into a freshly started design.
+    if (!store.currentIR || store.currentIR.id !== undefined) {
       // Try draft first; otherwise empty.
       if (!store.restoreFromDraft()) store.createNewIR()
     }

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/composables/useIncidenceRateBuilder.spec.ts
+++ b/tests/unit/composables/useIncidenceRateBuilder.spec.ts
@@ -243,6 +243,32 @@ describe('useIncidenceRateBuilder', () => {
       expect(pushMock).toHaveBeenCalledWith('/incidence-rates/12')
       expect(feedback.value).toEqual({ message: 'Copied', color: 'success' })
     })
+
+    it('does not carry the source design\'s execution info into the copy (#293)', async () => {
+      const store = useIncidenceRateStore()
+      store.setIR(makeValidIR({ id: 5 }))
+      store.setExecutionInfo('SynPUF5', {
+        executionInfo: {
+          id: { sourceId: 1, analysisId: 5 },
+          status: 'COMPLETE',
+          startTime: Date.now(),
+        },
+      } as never)
+      store.setSelectedTargetOutcome(1, 2)
+      expect(store.executions.length).toBe(1)
+
+      vi.mocked(webapi.copyIncidenceRate).mockResolvedValue({
+        success: true,
+        data: makeValidIR({ id: 12 }),
+      })
+
+      const { copy } = useIncidenceRateBuilder()
+      await copy()
+
+      expect(store.executions).toEqual([])
+      expect(store.selectedTargetId).toBeNull()
+      expect(store.selectedOutcomeId).toBeNull()
+    })
   })
 
   describe('remove', () => {

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {

--- a/tests/unit/views/IncidenceRateManagerView.spec.ts
+++ b/tests/unit/views/IncidenceRateManagerView.spec.ts
@@ -162,6 +162,29 @@ describe('IncidenceRateManagerView.vue', () => {
     expect(wrapper.find('.state.error').text()).toBe('Failed to load incidence rate')
   })
 
+  it('reuses an unsaved draft already in the store when navigating to "new"', async () => {
+    mockRoute.params = { id: 'new' }
+    store.currentIR = { id: undefined as unknown as number }
+
+    wrapper = mount(IncidenceRateManagerView, { props: { id: 'new' } })
+    await flushMounted()
+
+    expect(store.restoreFromDraft).not.toHaveBeenCalled()
+    expect(store.createNewIR).not.toHaveBeenCalled()
+  })
+
+  it('starts a fresh draft when navigating to "new" from a previously loaded saved design (#293)', async () => {
+    // A saved design (with results already polled into the store) was left
+    // loaded from a prior visit; navigating to "new" must not keep showing it.
+    mockRoute.params = { id: 'new' }
+    store.currentIR = { id: 5 }
+
+    wrapper = mount(IncidenceRateManagerView, { props: { id: 'new' } })
+    await flushMounted()
+
+    expect(store.createNewIR).toHaveBeenCalled()
+  })
+
   it('does not reload when route.params is replaced with identical id and version', async () => {
     mockRoute.params = { id: '5', version: '3' }
 


### PR DESCRIPTION
Fixes #293

## Problem

Open an existing IR design that has results, then clone it. The clone's workbench renders the source design's generation results and its target/outcome selection. Refreshing the browser clears it, which is why the issue reads as a caching problem.

The same leak happens when starting a new design while a saved one with results is still loaded.

## Cause

`executionInfoBySourceKey` is keyed by data source, not by the loaded design, and the workbench is not remounted across `/incidence-rates/:id` navigations. `createNewIR()` and `loadIR()` both cleared that map; `copy()` and the `new` route did not:

- `copy()` swapped in the new design's metadata through `setIR()` and left the polled execution info in place
- `IncidenceRateManagerView.load()` reused whatever was in `store.currentIR` for the `new` route, including a saved design left over from a previous visit

## Change

Extract the reset the two working paths already performed into `resetGenerationState()` on the store, and call it from both remaining paths. The `new` route now only reuses an in-memory IR when it is genuinely an unsaved draft (no id).

## Tests

Both fail on `develop` and pass with the change:

- `useIncidenceRateBuilder.spec.ts`: copying a design with polled execution info and a target/outcome selection leaves the copy with neither
- `IncidenceRateManagerView.spec.ts`: navigating to `new` with a saved design still loaded starts a fresh draft; a genuine unsaved draft is still reused

## Verification

`npm run type-check` clean, lint clean. `tests/unit/stores`, `tests/unit/composables`, `tests/unit/views` and `tests/component` all pass, apart from `CohortBuilder > handleClearConceptSet`, which also fails on a clean `develop` checkout and is unrelated.