### PR TITLE
Repair the unit-tests and mutation-pr gates on develop

### DIFF
--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {


### PR DESCRIPTION
`unit-tests` and `mutation-pr` have been failing on `develop` itself since #296, so every open pull request inherits a red build. Both failures come from that one commit. No production code is touched here.

## unit-tests

#296 added a generation-status test whose assertion sits inside a guard:

```ts
expect(result.success).toBe(true)
if (result.success) {
  expect(result.data.status).toBe('FAILED')
}
```

The repo's own `test:no-conditional-assertions` gate rejects that shape, because the inner assertion vanishes silently whenever the guard is false. That gate runs before the suite, which is why the job failed in 20 seconds without reporting a single test.

Parsing with `parse` rather than `safeParse` drops the guard, and a schema failure now reports Zod's own message instead of `expected false to be true`.

## mutation-pr

Stryker refuses to start when its initial test run has failures, so this job never got as far as mutating anything:

```
ERROR DryRunExecutor One or more tests failed in the initial test run:
	CohortBuilder handleClearConceptSet closes the active selection without changing the expression
		expected [] to be undefined
```

#296 also gave a new cohort a fleshed-out default expression in place of `{}`. Three tests still asserted the sparse shape it replaced:

| Test | Asserted | Now |
|---|---|---|
| `CohortBuilder > handleClearConceptSet` | `ConceptSets` undefined | equals `defaultExpression.ConceptSets` |
| `pythiaBridge useConceptSet > empty concept set` | `InclusionRules` undefined | equals `defaultExpression.InclusionRules` |
| `agent-injection-shapes > leaves the other limit alone` | `QualifiedLimit` undefined | equals `defaultExpression.QualifiedLimit` |

Each of those tests means "nothing touched this field", not "this field does not exist". Comparing against `defaultExpression` says that directly and will not go stale the next time the default moves.

## Verification

- `test:no-conditional-assertions`: 0 guards, 0 tautological assertions across 564 spec files (was 1 guard, exit 1)
- `npm run type-check`: clean
- Full suite: 8430 passing, 38 skipped, **0 failing** across `tests/unit` (6607), `tests/component` (1667) and `tests/integration` (156)

## Ordering

This wants to land before the other open fixes. They are branched off the red `develop` and will stay red until their base includes this.