### PR TITLE
Drop the select-all checkbox from the characterization cohort picker

### DIFF
--- a/src/components/characterization/LinkedCohortPicker.vue
+++ b/src/components/characterization/LinkedCohortPicker.vue
@@ -89,7 +89,14 @@
           item-value="id"
           show-select
           data-testid="linked-cohort-picker-table"
-        />
+        >
+          <!-- Rows are picked one at a time here. A characterization runs every
+               linked cohort, so a single click that sweeps in a whole page of a
+               20k-definition list is a cost nobody meant to incur (#215).
+               Vuetify has no select strategy that keeps multi-select without
+               the header checkbox, so the header select cell is emptied. -->
+          <template #[`header.data-table-select`] />
+        </AtlasDataTable>
       </div>
       <template #actions>
         <AtlasButton

--- a/tests/component/characterization/LinkedCohortPicker.spec.ts
+++ b/tests/component/characterization/LinkedCohortPicker.spec.ts
@@ -169,6 +169,41 @@ describe('LinkedCohortPicker cohort id (#215)', () => {
       document.querySelectorAll('[data-testid="linked-cohort-picker-table"] tbody tr')
     ).map(row => row.textContent ?? '')
 
+  it('offers no select-all checkbox, only per-row selection (#215)', async () => {
+    const wrapper = mountPicker([])
+    await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+    await flushPromises()
+
+    const table = document.querySelector('[data-testid="linked-cohort-picker-table"]')!
+    expect(table.querySelectorAll('thead input[type="checkbox"]')).toHaveLength(0)
+    expect(table.querySelectorAll('tbody input[type="checkbox"]')).toHaveLength(3)
+    wrapper.unmount()
+  })
+
+  it('still adds several cohorts in one go (#215)', async () => {
+    const wrapper = mountPicker([])
+    await wrapper.get('[data-testid="linked-cohort-picker-add"]').trigger('click')
+    await flushPromises()
+
+    const rowBox = (i: number) =>
+      document.querySelectorAll<HTMLInputElement>(
+        '[data-testid="linked-cohort-picker-table"] tbody input[type="checkbox"]'
+      )[i]!
+    rowBox(0).click()
+    await flushPromises()
+    rowBox(2).click()
+    await flushPromises()
+
+    ;(document.querySelector('[data-testid="linked-cohort-picker-confirm"]') as HTMLElement).click()
+    await flushPromises()
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toEqual([
+      { id: 1, name: 'Diabetes' },
+      { id: 3, name: 'Asthma' },
+    ])
+    wrapper.unmount()
+  })
+
   it('shows an ID column in the selector, ahead of the name', async () => {
     const wrapper = mountPicker([])
     await openDialog(wrapper)

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {


### PR DESCRIPTION
Fixes #215

This issue asked for two things. The first, showing the cohort id in the selector, landed in #252: the picker has an ID column ahead of the name, and its search matches on name or id. This PR covers the second.

## Problem

> I do not think it is a good idea to have a 'select all' in a characterization. a 20k characterization would blow up the universe. Maybe we can find an alternative where we can multi-select rows and add them as a group.

Multi-select and add-as-a-group already work. The select-all checkbox is still there. Mounting the picker and opening the dialog shows one checkbox in `thead` alongside the per-row ones.

A characterization runs every cohort linked to it, so one click that sweeps in a whole page of a list that can hold tens of thousands of definitions is a cost nobody meant to incur.

## Change

Empty the header select cell through its slot. Vuetify's data table has no select strategy that keeps multi-select without the header checkbox:

| `select-strategy` | `showSelectAll` | multi-select |
|---|---|---|
| `single` | false | no |
| `page` (default) | true | yes |
| `all` | true | yes |

The pathway and incidence rate cohort pickers already have no select-all for a different reason: they are plain `AtlasList`s using the `independent` select strategy, which is a list strategy rather than a table one. They are left alone.

## Tests

- no checkbox in `thead`, three in `tbody`
- selecting two rows and confirming still emits both, so adding a group is unaffected

The first fails without the change.

## Verification

`npm run type-check` clean, lint clean, `tests/component/characterization` and `tests/unit/components/characterization` pass (20 files, 144 tests).