### PR TITLE
Distinguish a missing inclusion report from a cohort that matched nobody

### DIFF
--- a/src/components/reports/inclusion/InclusionRuleReport.vue
+++ b/src/components/reports/inclusion/InclusionRuleReport.vue
@@ -42,6 +42,19 @@
     </AtlasAlert>
 
     <AtlasAlert
+      v-else-if="report && !hasStatistics"
+      severity="info"
+      data-testid="inclusion-rule-report-no-stats"
+    >
+      {{
+        t(
+          'components.inclusionRuleReport.noStatsRecorded',
+          'This generation recorded no inclusion statistics for this mode, so there is no attrition to report. The cohort itself may still contain records; see the generation panel for its record count.'
+        ).value
+      }}
+    </AtlasAlert>
+
+    <AtlasAlert
       v-else-if="!report"
       severity="info"
       data-testid="inclusion-rule-report-empty"
@@ -143,6 +156,24 @@ const report = ref<InclusionRuleReport | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
 
+// WebAPI hands back a default Summary, every count zero and percentMatched
+// unset, when the results schema holds no cohort_summary_stats row for this
+// cohort and mode. Its row mapper always fills percentMatched when a row does
+// exist, and a genuinely empty cohort still reports "0.00%", so that null
+// together with zeroed counts means "nothing was recorded" rather than
+// "nothing matched". Rendering it as a report of zeros contradicted the
+// generation panel's own record count (#299).
+const hasStatistics = computed<boolean>(() => {
+  const summary = report.value?.summary
+  if (!summary) return false
+  return (
+    summary.percentMatched !== null ||
+    summary.baseCount !== 0 ||
+    summary.finalCount !== 0 ||
+    summary.lostCount !== 0
+  )
+})
+
 const cumulativeRemaining = computed<number[] | undefined>(() => {
   if (!report.value) return undefined
   // computeAttritionSteps returns [Initial, ...perRule]; drop the initial step
@@ -187,7 +218,7 @@ function formatPercent(s: string | null): string {
 defineOptions({ name: 'InclusionRuleReport' })
 
 // Expose internal refs so tests can drive the tab switch deterministically
-defineExpose({ mode, report, loading, error })
+defineExpose({ mode, report, loading, error, hasStatistics })
 </script>
 
 <style scoped>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -461,6 +461,7 @@
       "perRuleSatisfaction": "Per-rule satisfaction",
       "populationBreakdown": "Population breakdown",
       "noReportData": "No inclusion-rule report data is available for this cohort and source. The cohort may have no inclusion rules, or it may not have been generated yet. If you've generated it already, try re-running.",
+      "noStatsRecorded": "This generation recorded no inclusion statistics for this mode, so there is no attrition to report. The cohort itself may still contain records; see the generation panel for its record count.",
       "loadError": "Failed to load the inclusion-rule report",
       "attrition": "Attrition",
       "noAttritionData": "No attrition data available",

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/component/reports/inclusion/InclusionRuleReport.spec.ts
+++ b/tests/component/reports/inclusion/InclusionRuleReport.spec.ts
@@ -97,6 +97,54 @@ describe('InclusionRuleReport', () => {
     expect(wrapper.find('[data-testid=inclusion-summary-match-rate]').text()).toContain('—')
   })
 
+  it('says no statistics were recorded rather than reporting zeros (#299)', async () => {
+    // What WebAPI returns when the results schema holds no cohort_summary_stats
+    // row for this cohort and mode: a default Summary, every count zero and
+    // percentMatched unset. Reporting that as real data told the user there
+    // were no records while the generation panel showed a populated cohort.
+    fetchMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        summary: { baseCount: 0, finalCount: 0, lostCount: 0, percentMatched: null },
+        inclusionRuleStats: [],
+        treemap: null,
+      },
+    })
+
+    const wrapper = mount(InclusionRuleReport, {
+      global,
+      props: { cohortId: 54, sourceKey: 'SYNPUF5' },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid=inclusion-rule-report-no-stats]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid=inclusion-summary-final-count]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid=inclusion-rule-report-empty]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid=inclusion-rule-report-error]').exists()).toBe(false)
+  })
+
+  it('still reports a genuinely empty cohort, which carries a percent (#299)', async () => {
+    // A generation that ran and matched nobody writes a row, so the mapper
+    // fills percentMatched. That is real data and must render as a report.
+    fetchMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        summary: { baseCount: 0, finalCount: 0, lostCount: 0, percentMatched: '0.00' },
+        inclusionRuleStats: [],
+        treemap: null,
+      },
+    })
+
+    const wrapper = mount(InclusionRuleReport, {
+      global,
+      props: { cohortId: 54, sourceKey: 'SYNPUF5' },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid=inclusion-rule-report-no-stats]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid=inclusion-summary-final-count]').exists()).toBe(true)
+  })
+
   it('refetches with the correct mode when the user switches the tab', async () => {
     fetchMock.mockResolvedValue({ success: true, data: fullReport })
 

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {


### PR DESCRIPTION
Refs #299

## Scope

#299 makes three claims. The third, that the eye icon on a previous run does nothing, is already fixed on `develop`: `CohortGenerationSection` now wires `@select="onViewRunResults"`.

This PR addresses the second, that the Inclusion Report showed no records for a cohort the generation panel reported 1,331 records for. It does not explain why that generation recorded no statistics, which needs the server's results schema and is out of reach from here.

## Cause

`CohortDefinitionService.getInclusionRuleReportSummary` falls back to a default object when its query returns nothing:

```java
List<InclusionRuleReport.Summary> result = ...query(...);
return result.isEmpty() ? new InclusionRuleReport.Summary() : result.get(0);
```

`Summary`'s fields are primitive `long`s, so that default is every count zero, and `percentMatched` is left null. Atlas3 rendered it as an ordinary report: a match rate of nothing over nothing, next to a generation panel showing a populated cohort.

## Why the two cases are separable

The row mapper always computes `percentMatched` when a row exists, including for a generation that matched nobody:

```java
double matchRatio = (summary.baseCount > 0) ? ((double) summary.finalCount / (double) summary.baseCount) : 0.0;
summary.percentMatched = new BigDecimal(matchRatio * 100.0)...toPlainString() + "%";
```

So a null `percentMatched` alongside zeroed counts means no row was found, not that nothing matched. That is an exact discriminator, and the client now says "no inclusion statistics were recorded" rather than reporting zeros.

The check requires the zeroed counts as well as the null percent, so a response that carries real counts with an absent percent keeps rendering as a report. An existing test covers that case.

## Tests

- the no-row shape renders the new notice, and no summary tiles, error or generic empty state
- a genuinely empty cohort, which carries `"0.00"`, still renders as a report

The first fails without the change.

## Verification

`npm run type-check` clean, lint clean, `tests/component/reports`, `tests/unit/components/cohort` and `getInclusionRuleReport.spec.ts` pass (32 files, 716 tests).