### PR TITLE
Order and show asset lists by the date each asset was last touched

### DIFF
--- a/src/components/analysis/AnalysisDataTable.vue
+++ b/src/components/analysis/AnalysisDataTable.vue
@@ -1,7 +1,7 @@
 <template>
   <AtlasDataTable
     v-model:sort-by="sortByModel"
-    :headers="headers"
+    :headers="tableHeaders"
     :items="items"
     :loading="loading"
     :items-per-page="itemsPerPage"
@@ -59,8 +59,8 @@
     </template>
 
     <template #[`item.modifiedDate`]="{ item }">
-      <span :title="formatDate(dateField(item, 'modifiedDate'))">
-        {{ formatRelativeTime(dateField(item, 'modifiedDate')) }}
+      <span :title="formatDate(updatedField(item))">
+        {{ formatRelativeTime(updatedField(item)) }}
       </span>
     </template>
 
@@ -149,7 +149,7 @@
 import { AtlasChip, AtlasDataTable, AtlasIcon, AtlasIconButton, AtlasSkeleton } from '@/components/ui'
 import { computed, ref, useSlots, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
-import { formatDate, formatRelativeTime } from '@/utils/date-format'
+import { formatDate, formatRelativeTime, lastTouchedDate } from '@/utils/date-format'
 import { tagColor, tagContrastColor } from '@/utils/tag-color'
 
 interface Tag { id?: number; name: string; color?: string }
@@ -275,6 +275,19 @@ function strField(item: T, key: string): string | undefined {
   const v = (item as Record<string, unknown>)[key]
   return typeof v === 'string' ? v : undefined
 }
+
+function updatedField(item: T): string | number | undefined {
+  return lastTouchedDate(item as { modifiedDate?: string | number | null; createdDate?: string | number | null })
+}
+
+// Vuetify sorts the Updated column off the raw `modifiedDate`, which the slot
+// above no longer displays. Give that one header the same fallback the cell
+// uses, so the order on screen matches the dates on screen (#292).
+const tableHeaders = computed(() =>
+  props.headers.map(header =>
+    header.key === 'modifiedDate' ? { ...header, value: (item: unknown) => updatedField(item as T) } : header
+  )
+)
 
 function dateField(item: T, key: string): string | number | undefined {
   const v = (item as Record<string, unknown>)[key]

--- a/src/components/cohort/CohortTable.vue
+++ b/src/components/cohort/CohortTable.vue
@@ -226,7 +226,7 @@
               {{ formatDate(cohort.createdDate) }}
             </td>
             <td class="cohort-table__col-date">
-              {{ formatDate(cohort.modifiedDate) }}
+              {{ formatDate(lastTouchedDate(cohort)) }}
             </td>
             <td class="cohort-table__col-actions">
               <div class="cohort-table__actions">
@@ -270,6 +270,7 @@
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from '@/composables/useI18n'
+import { lastTouchedDate } from '@/utils/date-format'
 import { useEntityAccessFor } from '@/composables/useEntityAccess'
 import type { CohortDefinitionSummary } from '@/models/webapi.types'
 import { AtlasAlert, AtlasButton, AtlasCard, AtlasChip, AtlasIcon, AtlasIconButton, AtlasSkeleton } from '@/components/ui'
@@ -341,8 +342,10 @@ function sortValue(cohort: CohortDefinitionSummary, key: SortKey): string | numb
       return formatUser(cohort.createdBy).toLowerCase()
     case 'createdDate':
       return cohort.createdDate ? new Date(cohort.createdDate).getTime() : 0
-    case 'modifiedDate':
-      return cohort.modifiedDate ? new Date(cohort.modifiedDate).getTime() : 0
+    case 'modifiedDate': {
+      const touched = lastTouchedDate(cohort)
+      return touched ? new Date(touched).getTime() : 0
+    }
   }
 }
 

--- a/src/components/concepts/ConceptSetList.vue
+++ b/src/components/concepts/ConceptSetList.vue
@@ -90,7 +90,7 @@
 
         <!-- Modified Date -->
         <template #item.modifiedDate="{ item }">
-          {{ formatDate(item.modifiedDate) }}
+          {{ formatDate(lastTouchedDate(item)) }}
         </template>
 
         <!-- Author (Created By) -->
@@ -162,7 +162,7 @@ import { useI18n } from '@/composables/useI18n'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import { usePermissions } from '@/composables/usePermissions'
 import { useEntityAccessFor } from '@/composables/useEntityAccess'
-import { formatDate } from '@/utils/date-format'
+import { formatDate, lastTouchedDate } from '@/utils/date-format'
 import { tagColor, tagContrastColor } from '@/utils/tag-color'
 import type { ConceptSetListItem } from '@/models/concept-set.types'
 import ConceptSetFilters from './ConceptSetFilters.vue'
@@ -209,6 +209,9 @@ const headers = [
   {
     title: t('columns.updated', 'Updated').value,
     key: 'modifiedDate',
+    // Sorted off the same fallback the cell displays, so a set that was only
+    // ever created orders by its creation date rather than sinking (#292).
+    value: (item: unknown) => lastTouchedDate(item as ConceptSetListItem),
     sortable: true,
     width: '120px',
   },

--- a/src/utils/date-format.ts
+++ b/src/utils/date-format.ts
@@ -10,6 +10,22 @@ import { logger } from '@/utils/logger'
  * @param isoDate ISO 8601 date string or Unix timestamp (milliseconds)
  * @returns Formatted date string or "Invalid Date" if parsing fails
  */
+/**
+ * The moment an asset was last touched, for both sorting and display.
+ *
+ * WebAPI leaves `modifiedDate` unset on an asset that has only ever been
+ * created. Read literally that is "no date", which sorted such an asset to the
+ * far end of a most-recently-updated list and rendered it as Unknown, so a
+ * cohort created minutes ago sank below one last edited months back (#292).
+ * Creation is the last time an unmodified asset was touched, so it stands in.
+ */
+export function lastTouchedDate(entity: {
+  modifiedDate?: string | number | null
+  createdDate?: string | number | null
+}): string | number | undefined {
+  return entity.modifiedDate ?? entity.createdDate ?? undefined
+}
+
 export function formatDate(isoDate: string | number | undefined | null): string {
   if (!isoDate) {
     return '—' // em dash for missing dates

--- a/tests/component/analysis/AnalysisDataTable.updated.spec.ts
+++ b/tests/component/analysis/AnalysisDataTable.updated.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * The Updated column across the four analysis lists (characterizations,
+ * incidence rates, pathways, feature analyses).
+ *
+ * WebAPI leaves modifiedDate unset until an asset is edited. Both the cell and
+ * the sort now read the creation date in that case, so a freshly created
+ * analysis is not shown as Unknown and does not sink to the bottom of a
+ * most-recently-updated list (#292).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+import AnalysisDataTable from '@/components/analysis/AnalysisDataTable.vue'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+const vuetify = createVuetify({ components, directives })
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn(),
+}))
+
+const headers = [
+  { title: 'Name', key: 'name' },
+  { title: 'Updated', key: 'modifiedDate' },
+]
+
+const items = [
+  { id: 1, name: 'Edited months ago', createdDate: '2026-01-01T00:00:00Z', modifiedDate: '2026-04-01T00:00:00Z' },
+  { id: 2, name: 'Just created', createdDate: '2026-06-01T00:00:00Z', modifiedDate: null },
+]
+
+function mountTable() {
+  return mount(AnalysisDataTable, {
+    global: { plugins: [vuetify] },
+    props: { headers, items, testid: 'analysis-table' },
+  })
+}
+
+function rowNames(wrapper: ReturnType<typeof mountTable>) {
+  return wrapper.findAll('tbody tr').map(r => r.findAll('td')[0]!.text().trim())
+}
+
+describe('AnalysisDataTable Updated column (#292)', () => {
+  it('does not report a never-modified analysis as Unknown', () => {
+    const wrapper = mountTable()
+    expect(wrapper.text()).not.toContain('Unknown')
+  })
+
+  it('opens with the most recently touched analysis first, creation date included', () => {
+    expect(rowNames(mountTable())).toEqual(['Just created', 'Edited months ago'])
+  })
+})

--- a/tests/component/cohort/CohortTable.spec.ts
+++ b/tests/component/cohort/CohortTable.spec.ts
@@ -192,6 +192,39 @@ describe('CohortTable', () => {
       ])
     })
 
+    it('orders a never-modified cohort by its creation date (#292)', async () => {
+      // WebAPI leaves modifiedDate unset until an asset is edited. Reading that
+      // as "no date" sent a cohort created today below one edited months ago.
+      const withUnmodified: CohortDefinitionSummary[] = [
+        {
+          id: 1,
+          name: 'Aspirin',
+          createdBy: { name: 'alice' },
+          createdDate: '2026-01-01T00:00:00Z',
+          modifiedDate: '2026-04-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          name: 'Brand new',
+          createdBy: { name: 'bob' },
+          createdDate: '2026-06-01T00:00:00Z',
+          modifiedDate: null,
+        },
+      ] as never
+
+      expect(names(makeWrapper({ cohorts: withUnmodified }))).toEqual(['Brand new', 'Aspirin'])
+    })
+
+    it('shows the creation date in the Updated column when never modified (#292)', () => {
+      const wrapper = makeWrapper({
+        cohorts: [
+          { id: 2, name: 'Brand new', createdBy: { name: 'bob' }, createdDate: '2026-06-01T00:00:00Z', modifiedDate: null },
+        ] as never,
+      })
+      const cells = wrapper.find('[data-testid=cohort-table-row]').findAll('td')
+      expect(cells[cells.length - 2]!.text()).toBe('Jun 1, 2026')
+    })
+
     it('sorts by id, and reverses on a second click', async () => {
       const wrapper = makeWrapper({ cohorts: rows })
 

--- a/tests/unit/utils/date-format.spec.ts
+++ b/tests/unit/utils/date-format.spec.ts
@@ -14,7 +14,7 @@ vi.mock('@/utils/logger', () => ({
   },
 }))
 
-import { formatDate, formatRelativeTime } from '@/utils/date-format'
+import { formatDate, formatRelativeTime, lastTouchedDate } from '@/utils/date-format'
 
 describe('Date Format Utils', () => {
   beforeEach(() => {
@@ -25,6 +25,26 @@ describe('Date Format Utils', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  describe('lastTouchedDate (#292)', () => {
+    it('uses the modified date when the asset has one', () => {
+      expect(
+        lastTouchedDate({ modifiedDate: '2026-05-01T00:00:00Z', createdDate: '2026-01-01T00:00:00Z' })
+      ).toBe('2026-05-01T00:00:00Z')
+    })
+
+    it('falls back to the created date for an asset never modified', () => {
+      expect(lastTouchedDate({ modifiedDate: null, createdDate: '2026-01-01T00:00:00Z' })).toBe(
+        '2026-01-01T00:00:00Z'
+      )
+      expect(lastTouchedDate({ createdDate: 1767225600000 })).toBe(1767225600000)
+    })
+
+    it('reports nothing when the asset carries neither date', () => {
+      expect(lastTouchedDate({})).toBeUndefined()
+      expect(lastTouchedDate({ modifiedDate: null, createdDate: null })).toBeUndefined()
+    })
   })
 
   describe('formatDate', () => {


### PR DESCRIPTION
Fixes #292

## Already done

Item 1 of the issue, every asset list defaulting to Updated descending, is in place: the cohort list, the concept set list and all four analysis lists open on `modifiedDate` desc.

## The problem that remains

WebAPI leaves `modifiedDate` unset on an asset that has only ever been created. Every list read that absence literally, which is the third screenshot in the issue:

- the analysis lists printed **Unknown** in the Updated column (`formatRelativeTime(null)`)
- the sort placed those rows by a missing value, so a cohort created minutes ago sat below one last edited months back

## Change (item 2)

Creation is the last time an unmodified asset was touched. A shared `lastTouchedDate()` says that once, and every list sorts and displays through it:

| List | Sorting | Display |
|---|---|---|
| `CohortTable` | own `sortValue` | own `formatDate` cell |
| `AnalysisDataTable` (×4 lists) | `value` on the Updated header | `#item.modifiedDate` cell |
| `ConceptSetList` | `value` on the Updated header | `#item.modifiedDate` cell |

The analysis and concept set tables hand sorting to Vuetify, which reads the raw `modifiedDate` the cells no longer render. Giving that one header the same fallback as its cell keeps the order on screen consistent with the dates on screen.

## Item 3, deliberately left

> maybe we can just omit the Created date from the default view, but provide the option to add columns

Left alone. That is a change to every list's default columns plus a column picker, rather than a fix to the sorting, and the issue raises it as a suggestion rather than a requirement. Happy to take it separately if wanted.

## Tests

All fail without the change:

- `lastTouchedDate`: prefers modified, falls back to created, reports nothing when neither exists
- `CohortTable`: a never-modified cohort orders by creation date, and its Updated cell shows that date
- `AnalysisDataTable`: no "Unknown", and the most recently touched analysis sorts first

## Verification

`npm run type-check` clean, lint clean. `tests/component` (178 files), `tests/unit/components`, `tests/unit/views` and `tests/unit/utils` all pass.

Includes the fix from #306 so this branch builds; that commit drops out of this diff once #306 lands.