### PR TITLE
Show who created and last changed an asset in its editor

### DIFF
--- a/src/components/analysis/AnalysisBuilderShell.vue
+++ b/src/components/analysis/AnalysisBuilderShell.vue
@@ -18,6 +18,12 @@
     >
       <slot name="subtitle" />
     </template>
+    <template
+      v-if="authorship"
+      #meta
+    >
+      <AssetAuthorship v-bind="authorship" />
+    </template>
     <template #actions>
       <AtlasButton
         v-if="showBack"
@@ -65,10 +71,20 @@
 <script setup lang="ts">
 import { useI18n } from '@/composables/useI18n'
 import { AtlasAlert, AtlasButton, AtlasPageShell } from '@/components/ui'
+import AssetAuthorship from '@/components/shared/AssetAuthorship.vue'
+
+export interface AuthorshipProps {
+  createdBy?: unknown
+  createdDate?: string | number | null
+  modifiedBy?: unknown
+  modifiedDate?: string | number | null
+}
 
 interface Props {
   title?: string
   subtitle?: string
+  /** Who created and last changed the asset, shown under the hero subtitle. */
+  authorship?: AuthorshipProps | null
   /**
    * Optional eyebrow text for the hero header (e.g. "OHDSI ·
    * Characterization"). When omitted no eyebrow is rendered.
@@ -83,6 +99,7 @@ interface Props {
 withDefaults(defineProps<Props>(), {
   title: undefined,
   subtitle: undefined,
+  authorship: null,
   eyebrow: undefined,
   error: null,
   showBack: true,

--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -975,6 +975,10 @@ async function loadCohort(id: string) {
       description: atlasCohort.description || '',
       tags: atlasCohort.tags || [],
       expression: atlasCohort.expression,
+      createdBy: atlasCohort.createdBy,
+      createdDate: atlasCohort.createdDate,
+      modifiedBy: atlasCohort.modifiedBy,
+      modifiedDate: atlasCohort.modifiedDate,
     }
     cohortStore.setCohort(cohortDef)
     cohortStore.markClean()
@@ -1492,7 +1496,20 @@ function _getStatusText(status: string): string {
 // toolbar in the hero header (with hide-internal-toolbar). The
 // proxy returned by defineExpose auto-unwraps refs at access
 // time, so a parent reading `builderRef.canSave` gets a number.
+// Read by the host view, which owns the hero header this belongs under.
+const authorship = computed(() => {
+  const cohort = cohortStore.currentCohort
+  if (!cohort?.id) return null
+  return {
+    createdBy: cohort.createdBy,
+    createdDate: cohort.createdDate,
+    modifiedBy: cohort.modifiedBy,
+    modifiedDate: cohort.modifiedDate,
+  }
+})
+
 defineExpose({
+  authorship,
   // Status state
   totalConceptSets: computed(() => expression.value.ConceptSets?.length || 0),
   unusedConceptSetCount: computed(() => (expression.value.ConceptSets?.length || 0) - usedConceptSets.value.length),

--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -44,6 +44,11 @@
                 {{ nameError }}
               </p>
             </v-form>
+            <AssetAuthorship
+              v-if="authorship"
+              v-bind="authorship"
+              class="cs-editor__authorship"
+            />
           </div>
 
           <div class="cs-editor__actions">
@@ -687,6 +692,7 @@
 
 <script setup lang="ts">
 import { logger } from '@/utils/logger'
+import AssetAuthorship from '@/components/shared/AssetAuthorship.vue'
 import { ref, computed, inject, watch, toRef, onBeforeUnmount } from 'vue'
 import { useI18n } from '@/composables/useI18n'
 import { useConceptSetsStore } from '@/stores/concept-sets'
@@ -744,6 +750,19 @@ const emit = defineEmits<{
 // ============================================================================
 
 const store = useConceptSetsStore()
+
+// Ownership drives what the current user may do with a set, so the editor says
+// who owns it rather than leaving that to be inferred (#269).
+const authorship = computed(() => {
+  const set = store.currentSet
+  if (!set?.id || set.id === 'new') return null
+  return {
+    createdBy: set.createdBy,
+    createdDate: set.createdDate,
+    modifiedBy: set.modifiedBy,
+    modifiedDate: set.modifiedDate,
+  }
+})
 const notify = useNotifications()
 
 // ============================================================================
@@ -1461,6 +1480,10 @@ function closeJsonDialog() {
 .cs-editor__title-input:disabled {
   color: rgb(var(--v-theme-on-surface-variant));
   cursor: not-allowed;
+}
+
+.cs-editor__authorship {
+  margin-top: 4px;
 }
 
 .cs-editor__title-error {

--- a/src/components/incidence-rate/IncidenceRateBuilder.vue
+++ b/src/components/incidence-rate/IncidenceRateBuilder.vue
@@ -3,6 +3,7 @@
     :eyebrow="t('navigation.incidenceRates', 'Incidence rate analysis').value"
     :title="title"
     :subtitle="subtitle"
+    :authorship="store.currentIR"
     :show-back="false"
     testid="ir-builder"
     @back="handleBack"

--- a/src/components/pathway/PathwayBuilder.vue
+++ b/src/components/pathway/PathwayBuilder.vue
@@ -3,6 +3,7 @@
     :eyebrow="t('navigation.pathways', 'Pathway analysis').value"
     :title="title"
     :subtitle="subtitle"
+    :authorship="store.currentPathway"
     :show-back="false"
     testid="pathway-builder"
     @back="handleBack"

--- a/src/components/shared/AssetAuthorship.vue
+++ b/src/components/shared/AssetAuthorship.vue
@@ -1,0 +1,83 @@
+<template>
+  <div
+    v-if="createdLabel || updatedLabel"
+    class="asset-authorship"
+    data-testid="asset-authorship"
+  >
+    <span
+      v-if="createdLabel"
+      data-testid="asset-authorship-created"
+    >{{ createdLabel }}</span>
+    <span
+      v-if="createdLabel && updatedLabel"
+      class="asset-authorship__sep"
+      aria-hidden="true"
+    >·</span>
+    <span
+      v-if="updatedLabel"
+      data-testid="asset-authorship-updated"
+    >{{ updatedLabel }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from '@/composables/useI18n'
+import { formatDate } from '@/utils/date-format'
+import { userDisplayName } from '@/utils/user-display'
+
+interface Props {
+  createdBy?: unknown
+  createdDate?: string | number | null
+  modifiedBy?: unknown
+  modifiedDate?: string | number | null
+}
+
+const props = defineProps<Props>()
+
+const { tv } = useI18n()
+
+function line(labelWithUser: string, labelDateOnly: string, user: unknown, date: string | number | null | undefined) {
+  const name = userDisplayName(user)
+  if (!name && !date) return null
+  if (!name) return `${labelDateOnly} ${formatDate(date)}`
+  return date ? `${labelWithUser} ${name}, ${formatDate(date)}` : `${labelWithUser} ${name}`
+}
+
+const createdLabel = computed(() =>
+  line(
+    tv('common.authorship.createdBy', 'Created by'),
+    tv('common.authorship.created', 'Created'),
+    props.createdBy,
+    props.createdDate
+  )
+)
+
+// Suppressed entirely until the asset has actually been modified. On something
+// only ever created it would otherwise restate the line beside it, which is the
+// noise the "show modified only when it differs" question in #269 is about.
+const updatedLabel = computed(() => {
+  if (!props.modifiedDate) return null
+  return line(
+    tv('common.authorship.updatedBy', 'Updated by'),
+    tv('common.authorship.updated', 'Updated'),
+    props.modifiedBy,
+    props.modifiedDate
+  )
+})
+</script>
+
+<style scoped>
+.asset-authorship {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: rgb(var(--v-theme-on-surface-variant));
+}
+
+.asset-authorship__sep {
+  opacity: 0.6;
+}
+</style>

--- a/src/components/ui/AtlasPageShell.vue
+++ b/src/components/ui/AtlasPageShell.vue
@@ -63,6 +63,12 @@
           >
             {{ subtitle }}
           </p>
+          <div
+            v-if="$slots.meta"
+            class="page-header__meta"
+          >
+            <slot name="meta" />
+          </div>
         </div>
         <div
           v-if="$slots.actions"
@@ -112,11 +118,15 @@ const props = defineProps<Props>()
 const slots = useSlots()
 
 const hasHeader = computed(() =>
-  Boolean(props.title || slots.title || slots.actions || slots.subtitle)
+  Boolean(props.title || slots.title || slots.actions || slots.subtitle || slots.meta)
 )
 </script>
 
 <style scoped>
+.page-header__meta {
+  margin-top: 4px;
+}
+
 .page-wrapper {
   min-height: 100%;
   background-color: rgb(var(--v-theme-surface-variant));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,6 +90,12 @@
     }
   },
   "common": {
+    "authorship": {
+      "created": "Created",
+      "createdBy": "Created by",
+      "updated": "Updated",
+      "updatedBy": "Updated by"
+    },
     "accessDenied": "Access denied",
     "add": "Add",
     "and": "and",

--- a/src/utils/user-display.ts
+++ b/src/utils/user-display.ts
@@ -1,0 +1,11 @@
+/**
+ * WebAPI returns a user on an entity as either a `{ id, login, name }` object
+ * or, on older records, a bare login string. Both shapes reach the UI, so a
+ * caller that reads `.name` directly renders nothing for half of them.
+ */
+export function userDisplayName(user: unknown): string | null {
+  if (!user) return null
+  if (typeof user === 'string') return user.trim() || null
+  const candidate = user as { name?: string | null; login?: string | null }
+  return candidate.name?.trim() || candidate.login?.trim() || null
+}

--- a/src/views/CharacterizationBuilderView.vue
+++ b/src/views/CharacterizationBuilderView.vue
@@ -18,6 +18,7 @@
     :eyebrow="t('cc.title', 'Characterization').value"
     :title="titleText"
     :error="storeError"
+    :authorship="store.currentCharacterization"
     :show-back="false"
     testid="char-builder"
     @back="handleBack"

--- a/src/views/CohortBuilderView.vue
+++ b/src/views/CohortBuilderView.vue
@@ -26,6 +26,13 @@
       >
     </template>
 
+    <template
+      v-if="builderRef?.authorship"
+      #meta
+    >
+      <AssetAuthorship v-bind="builderRef.authorship" />
+    </template>
+
     <!-- Toolbar shares the title row. We render it here (in the
          page-shell hero header) but the state still lives in
          <cohort-builder> below — we read it through `builderRef`,
@@ -85,6 +92,7 @@ import { ref, computed } from 'vue'
 import { AtlasPageShell } from '@/components/ui'
 import CohortBuilder from '@/components/cohort/CohortBuilder.vue'
 import CohortToolbarStatus from '@/components/cohort/CohortToolbarStatus.vue'
+import AssetAuthorship from '@/components/shared/AssetAuthorship.vue'
 import CohortToolbarActions from '@/components/cohort/CohortToolbarActions.vue'
 import { useI18n } from '@/composables/useI18n'
 

--- a/src/views/FeatureAnalysisEditorView.vue
+++ b/src/views/FeatureAnalysisEditorView.vue
@@ -15,6 +15,7 @@
   <AnalysisBuilderShell
     :title="titleText"
     :error="storeError"
+    :authorship="store.currentFA"
     :show-back="false"
     testid="feature-analysis-editor"
     @back="handleBack"

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -15,6 +15,7 @@ import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { ref } from 'vue'
+import { defaultExpression } from '@/models/circe-types'
 
 // Mock i18n composable with real translations
 vi.mock('@/composables/useI18n', async () => {
@@ -859,7 +860,7 @@ describe('CohortBuilder', () => {
 
     expect(conceptSetSelectionDialog(wrapper).props('modelValue')).toBe(false)
     expect(targetRef.value).toBeUndefined()
-    expect(setup.expression.ConceptSets).toBeUndefined()
+    expect(setup.expression.ConceptSets).toEqual(defaultExpression.ConceptSets)
   })
 
   // ---------------------------------------------------------------------------

--- a/tests/component/concepts/ConceptSetEditor.included.spec.ts
+++ b/tests/component/concepts/ConceptSetEditor.included.spec.ts
@@ -8,7 +8,10 @@ import ConceptSetEditor from '@/components/concepts/ConceptSetEditor.vue'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 
 vi.mock('@/composables/useI18n', () => ({
-  useI18n: () => ({ t: (_k: string, fallback?: string) => ({ value: fallback ?? _k }) }),
+  useI18n: () => ({
+    t: (_k: string, fallback?: string) => ({ value: fallback ?? _k }),
+    tv: (_k: string, fallback?: string) => fallback ?? _k,
+  }),
 }))
 vi.mock('@/composables/usePermissions', () => ({
   usePermissions: () => ({ hasPermission: () => true }),

--- a/tests/unit/components/shared/AssetAuthorship.spec.ts
+++ b/tests/unit/components/shared/AssetAuthorship.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * The created-by / updated-by line shown in the asset editors (#269).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import AssetAuthorship from '@/components/shared/AssetAuthorship.vue'
+
+vi.mock('@/composables/useI18n', async () => {
+  const { mockUseI18n } = await import('../../../helpers/i18n-mock')
+  return mockUseI18n
+})
+
+function mountIt(props: Record<string, unknown>) {
+  return mount(AssetAuthorship, { props })
+}
+
+describe('AssetAuthorship', () => {
+  it('names the creator and the date', () => {
+    const w = mountIt({
+      createdBy: { name: 'Jane Doe' },
+      createdDate: '2026-03-01T00:00:00Z',
+    })
+    expect(w.get('[data-testid="asset-authorship-created"]').text()).toContain('Jane Doe')
+    expect(w.get('[data-testid="asset-authorship-created"]').text()).toContain('03/01/2026')
+  })
+
+  it('adds the modifier once the asset has actually been modified', () => {
+    const w = mountIt({
+      createdBy: { name: 'Jane Doe' },
+      createdDate: '2026-03-01T00:00:00Z',
+      modifiedBy: { name: 'John Roe' },
+      modifiedDate: '2026-06-02T00:00:00Z',
+    })
+    expect(w.get('[data-testid="asset-authorship-updated"]').text()).toContain('John Roe')
+    expect(w.get('[data-testid="asset-authorship-updated"]').text()).toContain('06/02/2026')
+  })
+
+  it('says nothing about updates for an asset only ever created', () => {
+    const w = mountIt({
+      createdBy: { name: 'Jane Doe' },
+      createdDate: '2026-03-01T00:00:00Z',
+      modifiedBy: { name: 'Jane Doe' },
+      modifiedDate: null,
+    })
+    expect(w.find('[data-testid="asset-authorship-updated"]').exists()).toBe(false)
+  })
+
+  it('still reports the date when the user is missing', () => {
+    const w = mountIt({ createdDate: '2026-03-01T00:00:00Z' })
+    expect(w.get('[data-testid="asset-authorship-created"]').text()).toContain('03/01/2026')
+  })
+
+  it('renders nothing at all when the asset carries neither', () => {
+    expect(mountIt({}).find('[data-testid="asset-authorship"]').exists()).toBe(false)
+  })
+})

--- a/tests/unit/models/webapi.types.spec.ts
+++ b/tests/unit/models/webapi.types.spec.ts
@@ -7,7 +7,7 @@ describe('webapi generation status mapping', () => {
   })
 
   it('parses cohort generation info ERROR as FAILED', () => {
-    const result = CohortGenerationInfoSchema.safeParse({
+    const parsed = CohortGenerationInfoSchema.parse({
       id: { cohortDefinitionId: 54, sourceId: 1 },
       startTime: 1787855182500,
       executionDuration: 661,
@@ -26,9 +26,6 @@ describe('webapi generation status mapping', () => {
       isDemographic: false,
     })
 
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe('FAILED')
-    }
+    expect(parsed.status).toBe('FAILED')
   })
 })

--- a/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
+++ b/tests/unit/plugins/pythiaBridge-use-concept-set.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
-import type { CohortExpression } from '@/models/circe-types'
+import { defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 vi.mock('@/router', () => ({
   default: {
@@ -170,7 +170,7 @@ describe('pythiaBridge useConceptSet', () => {
     const res = await applyProposalDirect(useConceptSetProposal({ conceptSetId: 42 }))
 
     expect(res).toEqual({ applied: false })
-    expect(store.currentCohort?.expression?.InclusionRules).toBeUndefined()
+    expect(store.currentCohort?.expression?.InclusionRules).toEqual(defaultExpression.InclusionRules)
     expect(severities()).toEqual([
       { severity: 'danger', title: 'Concept set "Statins" has no concepts' },
     ])

--- a/tests/unit/services/agent-injection-shapes.spec.ts
+++ b/tests/unit/services/agent-injection-shapes.spec.ts
@@ -23,7 +23,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 import { translateCapability } from '@/plugins/host/capabilities/translate'
 import { useCohortStore } from '@/stores/cohort'
-import { CohortExpressionSchema, type CohortExpression } from '@/models/circe-types'
+import { CohortExpressionSchema, defaultExpression, type CohortExpression } from '@/models/circe-types'
 
 const CONCEPT = {
   conceptId: 40481087,
@@ -259,7 +259,7 @@ describe('shapes of everything the agent injects', () => {
     const store = newCohort()
     store.applyProposal(translateCapability('set_event_limits', { entryEvents: 'first' }) as never)
     expect(store.currentCohort!.expression!.PrimaryCriteria?.PrimaryCriteriaLimit?.Type).toBe('First')
-    expect(store.currentCohort!.expression!.QualifiedLimit).toBeUndefined()
+    expect(store.currentCohort!.expression!.QualifiedLimit).toEqual(defaultExpression.QualifiedLimit)
   })
 
   it('proposes nothing for an unrecognised limit', () => {

--- a/tests/unit/utils/user-display.spec.ts
+++ b/tests/unit/utils/user-display.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { userDisplayName } from '@/utils/user-display'
+
+describe('userDisplayName (#269)', () => {
+  it('prefers the display name on the object shape', () => {
+    expect(userDisplayName({ id: 1, login: 'jdoe', name: 'Jane Doe' })).toBe('Jane Doe')
+  })
+
+  it('falls back to the login when there is no name', () => {
+    expect(userDisplayName({ id: 1, login: 'jdoe' })).toBe('jdoe')
+    expect(userDisplayName({ id: 1, login: 'jdoe', name: '  ' })).toBe('jdoe')
+  })
+
+  it('accepts the bare string shape older records use', () => {
+    expect(userDisplayName('jdoe')).toBe('jdoe')
+  })
+
+  it('reports nothing when there is no usable name', () => {
+    expect(userDisplayName(null)).toBeNull()
+    expect(userDisplayName(undefined)).toBeNull()
+    expect(userDisplayName('')).toBeNull()
+    expect(userDisplayName({})).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #269

## Problem

The asset editors named neither the creator nor the last modifier. As the issue puts it, ownership is what several functions gate on, so being unable to see it makes an unexplained disabled control harder to reason about:

> showing the creator here is important because several functions depend on 'who is the owner' of a entity. It would be helpful to see that you can't assign tags to something you don't own if you can see who the real owner is.

Atlas 2.x showed it on the editor itself.

## Change

A shared `AssetAuthorship` line, rendered under the hero title through a new `meta` slot on `AtlasPageShell`. Wired into every asset editor:

| Editor | Route in |
|---|---|
| Characterization, Incidence Rate, Pathway, Feature Analysis | `AnalysisBuilderShell`'s new `authorship` prop |
| Cohort builder | exposed from `CohortBuilder`, rendered by the host view that owns its header |
| Concept set editor | rendered under its own title block |

The cohort builder also now carries `createdBy` / `createdDate` / `modifiedBy` / `modifiedDate` through from the loaded definition, which it was dropping.

## On the design question

> Should we show the modified only if it is different than the creator?

The created line always shows. The updated line appears only once the asset has actually been modified.

The reasoning: on an asset that was only ever created, an updated line restates the line beside it, and that is the case worth suppressing. When a real modification exists the date is informative even if the same person made it, so keying the decision on "was it modified" rather than "is it a different person" drops the noise without hiding anything. Easy to flip if you would rather compare the users.

## Incidental

`userDisplayName()` handles both shapes WebAPI returns for a user, the `{id, login, name}` object and the bare login string older records carry. Six components each carry their own copy of that logic; this adds a shared one for the new component and leaves the existing six alone rather than churning unrelated files.

One test's local `useI18n` mock stubbed only `t`, so it threw once a child component used `tv`. Its mock now provides both.

## Tests

- `userDisplayName`: object shape, login fallback, bare string, and the no-usable-name cases
- `AssetAuthorship`: names creator and date; adds the modifier once modified; says nothing about updates for an asset only ever created; still shows a date when the user is missing; renders nothing when given neither

## Verification

`npm run type-check` clean, lint clean, `npm run i18n:check` clean (2210 call sites). `tests/component` (178 files), `tests/unit/components` (108) and `tests/unit/views` all pass.

Includes the fix from #306 so this branch builds; that commit drops out of this diff once #306 lands.