### PR TITLE
Filter the feature analysis list the way the design editor does

### DIFF
--- a/src/views/FeatureAnalysesView.vue
+++ b/src/views/FeatureAnalysesView.vue
@@ -5,16 +5,19 @@
     @clear-error="store.clearError()"
   >
     <template #actions>
-      <AtlasTextField
-        :model-value="searchInput"
-        :label="t('datatable.language.searchPlaceholder', 'Search feature analyses…').value"
-        prepend-icon="mdi-magnify"
-        variant="outlined"
-        hide-details
-        clearable
+      <!-- The same bar and the same facets the design editor's picker offers,
+           so the two lists of the same entity filter the same way (#264). -->
+      <AtlasFacetFilterBar
+        :facet-options="facetOptions"
+        :selected="selectedFacets"
+        :active-filter-count="activeFilterCount"
+        :facets="facets"
+        :result-filter="textFilter"
         class="feature-analyses-view__search"
-        data-testid="feature-analyses-search"
-        @update:model-value="(v: string | number) => handleSearchInput(v != null ? String(v) : null)"
+        text-field-test-id="feature-analyses-search"
+        @update:facet="(payload: { key: string; values: string[] }) => setFacet(payload.key, payload.values)"
+        @update:result-filter="setTextFilter"
+        @clear="clearFilters"
       />
     </template>
 
@@ -110,7 +113,7 @@
 </template>
 
 <script setup lang="ts">
-import { AtlasButton, AtlasChip, AtlasDialog, AtlasTextField } from '@/components/ui'
+import { AtlasButton, AtlasChip, AtlasDialog, AtlasFacetFilterBar } from '@/components/ui'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -123,6 +126,12 @@ import { logger } from '@/utils/logger'
 import type { FeatureAnalysisListItem, FeatureAnalysisType } from '@/models/feature-analysis.types'
 import AnalysisListLayout from '@/components/analysis/AnalysisListLayout.vue'
 import AnalysisDataTable from '@/components/analysis/AnalysisDataTable.vue'
+import { useConceptFacets } from '@/composables/useConceptFacets'
+import {
+  featureAnalysisFacets,
+  featureAnalysisSearchText,
+} from '@/composables/useFeatureAnalysisFacets'
+import { useAuthStore } from '@/stores/auth'
 
 const router = useRouter()
 const { t } = useI18n()
@@ -133,21 +142,58 @@ const canCopy = computed(() => hasPermission('create:feature-analysis'))
 const entityAccess = useEntityAccessFor('feAnalysis')
 
 const {
+  featureAnalyses,
   loading,
   error,
-  paginatedFeatureAnalyses,
-  totalItems,
+  page,
   itemsPerPage,
   canGoPrevious,
   canGoNext,
-  rangeDisplay,
   nextPage,
   previousPage,
-  setFilter,
   refresh,
 } = useFeatureAnalyses()
 
-const searchInput = ref<string>('')
+const authStore = useAuthStore()
+
+// Captured rather than read per render: the Created and Updated facets bucket
+// by recency, and a list stays open long enough that a row would otherwise
+// drift from one bucket to the next under the user. Re-taken on refresh.
+const facetNow = ref(Date.now())
+
+const facets = computed(() =>
+  featureAnalysisFacets({ currentUserLogin: authStore.user?.login, now: facetNow.value })
+)
+
+const {
+  selected: selectedFacets,
+  textFilter,
+  facetOptions,
+  filteredConcepts: filteredAnalyses,
+  activeFilterCount,
+  setFacet,
+  setTextFilter,
+  clearFilters,
+} = useConceptFacets(featureAnalyses, facets, featureAnalysisSearchText)
+
+// Pagination follows the facets. useFeatureAnalyses paginates the store's own
+// text filter, which the bar above has replaced, so counting that instead
+// would offer pages the filters have already emptied.
+const totalItems = computed<number>(() => filteredAnalyses.value.length)
+
+const paginatedFeatureAnalyses = computed<FeatureAnalysisListItem[]>(() => {
+  const start = (page.value - 1) * itemsPerPage.value
+  return filteredAnalyses.value.slice(start, start + itemsPerPage.value)
+})
+
+// Mirrors usePagination's own range string, over the filtered total rather
+// than the store's, so the count under the table matches the rows above it.
+const rangeDisplay = computed<string>(() => {
+  if (totalItems.value === 0) return '0-0 of 0'
+  const start = (page.value - 1) * itemsPerPage.value + 1
+  const end = Math.min(page.value * itemsPerPage.value, totalItems.value)
+  return `${start}-${end} of ${totalItems.value}`
+})
 
 const headers = computed(() => [
   { title: t('columns.id', 'ID').value, key: 'id' },
@@ -173,12 +219,6 @@ const deleteMessage = computed(() => {
     { name: selectedFA.value.name }
   ).value
 })
-
-function handleSearchInput(value: string | null) {
-  const next = value ?? ''
-  searchInput.value = next
-  setFilter(next)
-}
 
 function handleCreate() {
   router.push('/feature-analyses/new')
@@ -241,15 +281,23 @@ function typeChipColor(type: FeatureAnalysisType): string {
   }
 }
 
-onMounted(() => {
+function reload() {
+  facetNow.value = Date.now()
   refresh()
+}
+
+onMounted(() => {
+  reload()
 })
 </script>
 
 <style scoped>
 .feature-analyses-view__search {
-  max-width: 360px;
-  flex: 1 1 280px;
+  /* Sized for the facet bar, not the single search box it replaced: the bar
+     carries a text field plus six facet menus and wraps rather than crushing
+     them. */
+  flex: 1 1 100%;
+  min-width: 0;
 }
 
 .feature-analyses-view__range {

--- a/tests/component/feature-analyses/FeatureAnalysesView.spec.ts
+++ b/tests/component/feature-analyses/FeatureAnalysesView.spec.ts
@@ -44,7 +44,6 @@ vi.mock('@/utils/logger', () => ({
 import { listFeatureAnalyses } from '@/services/feature-analysis.service'
 import { success } from '@/types/api'
 import FeatureAnalysesView from '@/views/FeatureAnalysesView.vue'
-import { useFeatureAnalysesStore } from '@/stores/feature-analyses'
 import { useAuthStore } from '@/stores/auth'
 import { emptyEntityAccess } from '@/models/auth.types'
 
@@ -175,24 +174,23 @@ describe('FeatureAnalysesView', () => {
     expect(mounted.wrapper.text()).toContain('No data')
   })
 
-  it('search input drives the store filter (after debounce)', async () => {
-    vi.useFakeTimers()
+  it('search box narrows the visible rows', async () => {
+    // Was asserting store.filterTerm. The view filters through the facet bar
+    // now, so the store's own text filter is no longer what drives this list;
+    // assert what the user sees instead of which field held the term (#264).
     vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
     mounted = await mountView()
 
-    const store = useFeatureAnalysesStore()
-    expect(store.filterTerm).toBe('')
+    const rows = () =>
+      mounted!.wrapper.findAll('[data-testid="feature-analyses-table"] tbody tr')
+    expect(rows()).toHaveLength(2)
 
     const searchEl = mounted.wrapper.find('[data-testid="feature-analyses-search"] input')
     await searchEl.setValue('Demographics')
-
-    // Debounce window
-    vi.advanceTimersByTime(300)
     await flushPromises()
 
-    expect(store.filterTerm).toBe('Demographics')
-
-    vi.useRealTimers()
+    expect(rows()).toHaveLength(1)
+    expect(rows()[0]!.text()).toContain('Demographics PRESET')
   })
 
   it('clicking Create navigates to /feature-analyses/new', async () => {
@@ -208,5 +206,96 @@ describe('FeatureAnalysesView', () => {
     await flushPromises()
 
     expect(router.currentRoute.value.path).toBe('/feature-analyses/new')
+  })
+})
+
+/**
+ * Issue #264: the list offered only a text box, so there was no way to narrow
+ * by domain or the other column attributes. It now carries the same facet bar
+ * the characterization design editor's picker uses.
+ */
+describe('FeatureAnalysesView facets (#264)', () => {
+  let mounted: { wrapper: ReturnType<typeof mount>; router: Router } | null = null
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    mounted?.wrapper.unmount()
+    mounted = null
+  })
+
+  const filterBar = (wrapper: ReturnType<typeof mount>) =>
+    wrapper.findComponent({ name: 'AtlasFacetFilterBar' })
+
+  const rowText = (wrapper: ReturnType<typeof mount>) =>
+    wrapper
+      .findAll('[data-testid="feature-analyses-table"] tbody tr')
+      .map(row => row.text())
+
+  it('offers the same facets the design editor picker offers', async () => {
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+    mounted = await mountView()
+
+    const facets = filterBar(mounted.wrapper).props('facets') as Array<{ key: string }>
+
+    expect(facets.map(f => f.key)).toEqual([
+      'type', 'domain', 'created', 'updated', 'author', 'designs',
+    ])
+  })
+
+  it('narrows the table to the selected domain', async () => {
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+    mounted = await mountView()
+    expect(rowText(mounted.wrapper)).toHaveLength(2)
+
+    filterBar(mounted.wrapper).vm.$emit('update:facet', { key: 'domain', values: ['Condition'] })
+    await flushPromises()
+
+    const rows = rowText(mounted.wrapper)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toContain('Conditions Criteria')
+  })
+
+  it('restores every row when the filters are cleared', async () => {
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+    mounted = await mountView()
+
+    filterBar(mounted.wrapper).vm.$emit('update:facet', { key: 'domain', values: ['Condition'] })
+    await flushPromises()
+    expect(rowText(mounted.wrapper)).toHaveLength(1)
+
+    filterBar(mounted.wrapper).vm.$emit('clear')
+    await flushPromises()
+
+    expect(rowText(mounted.wrapper)).toHaveLength(2)
+  })
+
+  it('narrows the table by the text box in the bar', async () => {
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+    mounted = await mountView()
+
+    filterBar(mounted.wrapper).vm.$emit('update:resultFilter', 'Demographics')
+    await flushPromises()
+
+    const rows = rowText(mounted.wrapper)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toContain('Demographics PRESET')
+  })
+
+  // The pager reads the filtered length, not the whole list. Reading the
+  // unfiltered count would offer pages that render nothing.
+  it('counts pages against the filtered rows, not the whole list', async () => {
+    vi.mocked(listFeatureAnalyses).mockResolvedValue(success(sampleList))
+    mounted = await mountView()
+
+    filterBar(mounted.wrapper).vm.$emit('update:facet', { key: 'domain', values: ['Condition'] })
+    await flushPromises()
+
+    const vm = mounted.wrapper.vm as unknown as { totalItems: number }
+    expect(vm.totalItems).toBe(1)
   })
 })


### PR DESCRIPTION
Fixes #264

## Problem

The Feature Analysis list offered a single text box over a library that runs to well over a thousand analyses in a real deployment, so there was no way to narrow by domain or any other column attribute.

As the issue notes, the characterization design editor already filters the same entity properly. This brings the list in line with it.

## Change

The list now composes the same three pieces the design editor's picker uses, so no new filtering code was needed:

- `AtlasFacetFilterBar` for the UI
- `useConceptFacets` for the state
- `featureAnalysisFacets()` for the definitions

Same six facets the picker offers: **type, domain, created, updated, author, designs**. The bar's own text field replaces the old search box and keeps its `feature-analyses-search` test id, so existing coverage of the search still applies.

## Three things that were not just wiring

**Pagination had to follow the facets.** `useFeatureAnalyses` paginates the store's own text filter, which the bar replaces. Left as it was, the pager would have offered pages the facets had already emptied, and the range display under the table would have disagreed with the rows above it. Both now count the filtered list.

**The recency reference needs deliberate capture.** The picker snapshots `now` when its dialog opens so rows cannot drift between the Created and Updated buckets while it is open. A list stays open far longer, so the same guard matters more here: captured on load, retaken whenever the list reloads.

**The bar needed resizing.** The container was `max-width: 360px`, sized for a lone search box. The bar carries a text field plus six facet menus, so it now takes the row's width and wraps rather than crushing them.

## A test I changed rather than worked around

`search input drives the store filter (after debounce)` asserted `store.filterTerm`, an internal this view no longer drives now that filtering runs through the facet bar. Rather than delete it or prop up the old field, it now asserts the rows the user is left with, which is the behaviour it existed to protect.

## Tests

Five new cases, all failing before the change:

- the list offers exactly the six facets the picker offers
- selecting a domain narrows the table to that domain
- clearing restores every row
- the bar's text box narrows the table
- the pager counts the filtered rows, not the whole list

`tests/component/feature-analyses` 18 passing. `tests/component` (181 files), `tests/unit/views` and `tests/unit/composables` all green. `type-check`, `lint` at `--max-warnings 0`, and `i18n:check` clean.

No visual baseline to regenerate: `feature-analyses` is not one of the routes `dark-mode-visual.spec.ts` captures.

## Not included

No Stat Type facet. The list shows that column and the picker has no facet for it, but this deliberately matches the picker rather than extending it, per the issue's "filter similar to how the Characterization design editor allows". Straightforward to add later if wanted.
