### PR TITLE
Tooltip why Save is disabled instead of leaving the user to guess

### DIFF
--- a/src/components/cohort/CohortBuilder.vue
+++ b/src/components/cohort/CohortBuilder.vue
@@ -71,6 +71,7 @@
         <template #actions>
           <cohort-toolbar-actions
             :can-save="canSave"
+            :save-disabled-reason="saveDisabledReason"
             :is-dirty="hasUnsavedChanges"
             :is-previewing-version="isPreviewingVersion"
             @cancel="handleCancel"
@@ -328,6 +329,7 @@ import CohortToolbarActions from './CohortToolbarActions.vue'
 import CohortToolbarStatus from './CohortToolbarStatus.vue'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { nextConceptSetId } from '@/utils/concept-set-id'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 import ConceptSetsListDialog from './ConceptSetsListDialog.vue'
 import CohortJsonDialog from './CohortJsonDialog.vue'
 import ValidationMessagesDialog from './ValidationMessagesDialog.vue'
@@ -598,6 +600,17 @@ const canSavePermission = computed(() =>
 const canSave = computed(() => {
   return cohortName.value.trim().length > 0 && canSavePermission.value
 })
+
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.cohort', 'cohort'),
+    isNew: cohortId.value === null,
+    hasName: cohortName.value.trim().length > 0,
+    hasPermission: canSavePermission.value,
+    isPreviewing: isPreviewingVersion.value,
+    translate: tv,
+  })
+)
 
 // Preview mode state. A preview installed for another cohort survives until
 // this editor loads its own definition, and the first render happens before
@@ -1510,6 +1523,7 @@ const authorship = computed(() => {
 
 defineExpose({
   authorship,
+  saveDisabledReason,
   // Status state
   totalConceptSets: computed(() => expression.value.ConceptSets?.length || 0),
   unusedConceptSetCount: computed(() => (expression.value.ConceptSets?.length || 0) - usedConceptSets.value.length),

--- a/src/components/cohort/CohortToolbarActions.vue
+++ b/src/components/cohort/CohortToolbarActions.vue
@@ -56,13 +56,15 @@
         :title="t('common.unsavedChanges', 'Unsaved changes').value"
         data-testid="save-cohort-dirty-dot"
       />
-      <AtlasButton
-        :disabled="!canSave || isPreviewingVersion"
-        data-testid="save-cohort-btn"
-        @click="$emit('save')"
-      >
-        {{ t('common.save') }}
-      </AtlasButton>
+      <DisabledReasonTooltip :reason="saveDisabledReason">
+        <AtlasButton
+          :disabled="!canSave || isPreviewingVersion"
+          data-testid="save-cohort-btn"
+          @click="$emit('save')"
+        >
+          {{ t('common.save') }}
+        </AtlasButton>
+      </DisabledReasonTooltip>
     </span>
   </div>
 </template>
@@ -70,14 +72,20 @@
 <script setup lang="ts">
 import { AtlasButton, AtlasIcon, AtlasIconButton, AtlasList, AtlasListItem, AtlasMenu } from '@/components/ui'
 import { useI18n } from '@/composables/useI18n'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
 
 interface Props {
   canSave: boolean
   isDirty?: boolean
   isPreviewingVersion?: boolean
+  /**
+   * Why Save is disabled, resolved by the builder. This component only sees a
+   * single canSave boolean, which cannot say more than "you cannot save".
+   */
+  saveDisabledReason?: string
 }
 
-defineProps<Props>()
+withDefaults(defineProps<Props>(), { saveDisabledReason: '' })
 
 defineEmits<{
   (e: 'cancel'): void

--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -139,20 +139,22 @@
               {{ t('common.cancel', 'Cancel') }}
             </AtlasButton>
 
-            <AtlasButton
-              :disabled="!formValid || loading || !canSubmit"
-              :loading="loading"
-              data-testid="cs-editor-primary-btn"
-              @click="embedded ? onApply() : onSave()"
-            >
-              {{
-                embedded
-                  ? t('common.apply', 'Apply')
-                  : isEditMode
-                    ? t('common.save', 'Save')
-                    : t('common.create', 'Create')
-              }}
-            </AtlasButton>
+            <DisabledReasonTooltip :reason="saveDisabledReason">
+              <AtlasButton
+                :disabled="!formValid || loading || !canSubmit"
+                :loading="loading"
+                data-testid="cs-editor-primary-btn"
+                @click="embedded ? onApply() : onSave()"
+              >
+                {{
+                  embedded
+                    ? t('common.apply', 'Apply')
+                    : isEditMode
+                      ? t('common.save', 'Save')
+                      : t('common.create', 'Create')
+                }}
+              </AtlasButton>
+            </DisabledReasonTooltip>
 
             <AtlasIconButton
               icon="mdi-close"
@@ -699,6 +701,8 @@ import { useConceptSetsStore } from '@/stores/concept-sets'
 import { useNotifications } from '@/stores/notifications'
 import { usePermissions } from '@/composables/usePermissions'
 import { useEntityAccess } from '@/composables/useEntityAccess'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 import type { ConceptSet, Concept, ConceptSetItem, ConceptAddFlags } from '@/models/concept-set.types'
 import type { VersionsConfig, VersionsTableItem, User } from '@/components/versions/types'
 import TagSelectionDialog from '@/components/tags/TagSelectionDialog.vue'
@@ -902,6 +906,19 @@ const canSubmit = computed<boolean>(() => {
   if (props.embedded) return true
   return isEditMode.value ? canWrite.value : hasPermission('create:conceptset')
 })
+
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.conceptSet', 'concept set'),
+    isNew: !isEditMode.value,
+    // nameError already says what is wrong with the name, so it is surfaced
+    // verbatim rather than replaced with the generic "give it a name".
+    hasName: !nameError.value,
+    hasPermission: canSubmit.value,
+    isSaving: loading.value,
+    translate: tv,
+  })
+)
 
 const itemCount = computed(() => {
   return store.currentSet?.items?.length || 0

--- a/src/components/incidence-rate/IncidenceRateBuilder.vue
+++ b/src/components/incidence-rate/IncidenceRateBuilder.vue
@@ -207,15 +207,17 @@
           >
             {{ t('common.delete', 'Delete') }}
           </AtlasButton>
-          <AtlasButton
-            variant="primary"
-            :disabled="!store.canSave || saving || !canSave"
-            :loading="saving"
-            data-testid="ir-builder-save"
-            @click="onSave"
-          >
-            {{ t('common.save', 'Save') }}
-          </AtlasButton>
+          <DisabledReasonTooltip :reason="saveDisabledReason">
+            <AtlasButton
+              variant="primary"
+              :disabled="!store.canSave || saving || !canSave"
+              :loading="saving"
+              data-testid="ir-builder-save"
+              @click="onSave"
+            >
+              {{ t('common.save', 'Save') }}
+            </AtlasButton>
+          </DisabledReasonTooltip>
         </template>
       </AtlasActionToolbar>
     </template>
@@ -321,11 +323,13 @@ import IncidenceRateWorkbench from '@/components/incidence-rate/IncidenceRateWor
 import IncidenceRateConceptSetsPanel from '@/components/incidence-rate/IncidenceRateConceptSetsPanel.vue'
 import IncidenceRateVersionsPanel from '@/components/incidence-rate/IncidenceRateVersionsPanel.vue'
 import TagSelectionDialog from '@/components/tags/TagSelectionDialog.vue'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 import { exportIncidenceRate, importIncidenceRate } from '@/services/incidence-rate.service'
 import { logger } from '@/utils/logger'
 import type { Tag } from '@/models/webapi.types'
 
-const { t } = useI18n()
+const { t, tv } = useI18n()
 const store = useIncidenceRateStore()
 const router = useRouter()
 const { save, copy, remove, feedback } = useIncidenceRateBuilder()
@@ -450,6 +454,19 @@ const { canWrite, canDelete } = useEntityAccess('incidenceRate', irId)
 const canCopy = computed<boolean>(() => hasPermission('create:incidence'))
 const canSave = computed<boolean>(() =>
   irId.value === null ? hasPermission('create:incidence') : canWrite.value
+)
+
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.incidenceRate', 'incidence rate analysis'),
+    isNew: irId.value === null,
+    hasName: true,
+    hasPermission: canSave.value,
+    isPreviewing: store.isPreviewMode,
+    hasValidationErrors: store.hasErrors,
+    isSaving: saving.value,
+    translate: tv,
+  })
 )
 
 const title = computed(() => {

--- a/src/components/pathway/PathwayBuilder.vue
+++ b/src/components/pathway/PathwayBuilder.vue
@@ -193,14 +193,16 @@
           >
             {{ t('common.delete', 'Delete') }}
           </AtlasButton>
-          <AtlasButton
-            variant="primary"
-            :disabled="!canSave"
-            data-testid="pathway-builder-save"
-            @click="onSave"
-          >
-            {{ t('common.save', 'Save') }}
-          </AtlasButton>
+          <DisabledReasonTooltip :reason="saveDisabledReason">
+            <AtlasButton
+              variant="primary"
+              :disabled="!canSave"
+              data-testid="pathway-builder-save"
+              @click="onSave"
+            >
+              {{ t('common.save', 'Save') }}
+            </AtlasButton>
+          </DisabledReasonTooltip>
         </template>
       </AtlasActionToolbar>
     </template>
@@ -285,6 +287,8 @@ import TagSelectionDialog from '@/components/tags/TagSelectionDialog.vue'
 import { exportPathway, importPathway } from '@/services/pathway.service'
 import { logger } from '@/utils/logger'
 import type { VersionsConfig, VersionsTableItem } from '@/components/versions/types'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 import type { Tag } from '@/models/webapi.types'
 
 const store = usePathwayStore()
@@ -292,7 +296,22 @@ const router = useRouter()
 const { currentPathway, previewVersion, isDirty, isPreviewMode, canSave } = storeToRefs(store)
 const { save, copy, remove, feedback } = usePathwayBuilder()
 const { hasPermission } = usePermissions()
-const { t } = useI18n()
+
+// hasPermission is true here because this button does not gate on write access
+// at all, unlike every sibling editor. Reporting a permission reason it does
+// not actually enforce would be a lie; the gap is raised in OHDSI/Atlas3#300.
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.pathway', 'pathway analysis'),
+    isNew: !currentPathway.value?.id,
+    hasName: true,
+    hasPermission: true,
+    isPreviewing: isPreviewMode.value,
+    hasValidationErrors: store.hasErrors,
+    translate: tv,
+  })
+)
+const { t, tv } = useI18n()
 
 const feedbackSeverity = computed<AtlasSnackbarSeverity>(() =>
   feedback.value?.color === 'error' ? 'danger' : (feedback.value?.color ?? 'info')

--- a/src/components/shared/DisabledReasonTooltip.vue
+++ b/src/components/shared/DisabledReasonTooltip.vue
@@ -1,0 +1,43 @@
+<template>
+  <AtlasTooltip
+    v-if="reason"
+    :location="location"
+  >
+    <template #activator="{ props: tipProps }">
+      <!-- The span is what makes this work. A disabled control receives no
+           pointer events, so a tooltip bound directly to it never opens; the
+           wrapper is what the pointer actually hits. `title` carries the same
+           text for anyone not hovering with a mouse, since the tooltip itself
+           renders into an overlay only on hover. -->
+      <span
+        v-bind="tipProps"
+        :title="reason"
+        class="disabled-reason-tooltip"
+        data-testid="disabled-reason-wrap"
+      >
+        <slot />
+      </span>
+    </template>
+    <span>{{ reason }}</span>
+  </AtlasTooltip>
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { AtlasTooltip } from '@/components/ui'
+
+withDefaults(
+  defineProps<{
+    /** Empty renders the slot untouched, so callers need no v-if of their own. */
+    reason?: string
+    location?: 'top' | 'bottom' | 'start' | 'end'
+  }>(),
+  { reason: '', location: 'bottom' }
+)
+</script>
+
+<style scoped>
+.disabled-reason-tooltip {
+  display: inline-flex;
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4609,7 +4609,20 @@
     "ruleDescription": "Description"
   },
   "const": {
+    "entityName": {
+      "characterization": "characterization",
+      "cohort": "cohort",
+      "conceptSet": "concept set",
+      "featureAnalysis": "feature analysis",
+      "incidenceRate": "incidence rate analysis",
+      "pathway": "pathway analysis"
+    },
     "disabledReason": {
+      "previewingVersion": "You are previewing an earlier version. Return to the current version to save.",
+      "noCreatePermission": "You do not have permission to create a {entity}.",
+      "noWriteAccess": "You do not own this {entity} and have not been granted write access to it.",
+      "needsName": "Give the {entity} a name before saving.",
+      "hasErrors": "Resolve the validation errors before saving.",
       "dirty": "Save changes before generate",
       "accessDenied": "Access denied",
       "invalidTar": "Invalid TAR",

--- a/src/utils/save-disabled-reason.ts
+++ b/src/utils/save-disabled-reason.ts
@@ -1,0 +1,66 @@
+/**
+ * Why a Save button is disabled, in words the user can act on.
+ *
+ * A disabled Save with no explanation reads as a broken feature rather than a
+ * permission boundary, and the user cannot tell whether to ask for access or
+ * fix something themselves (#300). Every module resolves its reason here so the
+ * same situation is described the same way wherever it comes up.
+ */
+export interface SaveGate {
+  /** The noun for this module, already translated: "cohort", "concept set". */
+  entity: string
+  /** An unsaved asset is gated on create permission, a saved one on write access. */
+  isNew: boolean
+  hasName: boolean
+  hasPermission: boolean
+  isPreviewing?: boolean
+  hasValidationErrors?: boolean
+  /** Present only where the module gates Save on having changes at all. */
+  isDirty?: boolean
+  isSaving?: boolean
+  translate: (key: string, fallback: string, params?: Record<string, string>) => string
+}
+
+/**
+ * The first blocker worth reporting, or an empty string to show no tooltip.
+ *
+ * Order is deliberate. A user who cannot save at all should hear that before
+ * being sent to fill in a name, and someone reading a historical version needs
+ * to know that first of all, since every other gate is downstream of it.
+ */
+export function resolveSaveDisabledReason(gate: SaveGate): string {
+  const { translate: t, entity } = gate
+
+  if (gate.isPreviewing) {
+    return t(
+      'const.disabledReason.previewingVersion',
+      'You are previewing an earlier version. Return to the current version to save.'
+    )
+  }
+
+  if (!gate.hasPermission) {
+    return gate.isNew
+      ? t('const.disabledReason.noCreatePermission', 'You do not have permission to create a {entity}.', {
+          entity,
+        })
+      : t(
+          'const.disabledReason.noWriteAccess',
+          'You do not own this {entity} and have not been granted write access to it.',
+          { entity }
+        )
+  }
+
+  if (!gate.hasName) {
+    return t('const.disabledReason.needsName', 'Give the {entity} a name before saving.', { entity })
+  }
+
+  if (gate.hasValidationErrors) {
+    return t('const.disabledReason.hasErrors', 'Resolve the validation errors before saving.')
+  }
+
+  // Everything below here is either self-evident or momentary: nothing has
+  // changed yet, or a save is already running. Explaining those would put a
+  // tooltip on the most common state of every editor and teach the user to
+  // ignore it.
+  return ''
+}

--- a/src/views/CharacterizationBuilderView.vue
+++ b/src/views/CharacterizationBuilderView.vue
@@ -197,15 +197,17 @@
           >
             {{ t('common.delete', 'Delete') }}
           </AtlasButton>
-          <AtlasButton
-            variant="primary"
-            :disabled="!canSave"
-            :loading="saving"
-            data-testid="char-builder-save"
-            @click="handleSave"
-          >
-            {{ t('common.save', 'Save') }}
-          </AtlasButton>
+          <DisabledReasonTooltip :reason="saveDisabledReason">
+            <AtlasButton
+              variant="primary"
+              :disabled="!canSave"
+              :loading="saving"
+              data-testid="char-builder-save"
+              @click="handleSave"
+            >
+              {{ t('common.save', 'Save') }}
+            </AtlasButton>
+          </DisabledReasonTooltip>
         </template>
       </AtlasActionToolbar>
     </template>
@@ -342,6 +344,8 @@ import { AtlasButton, AtlasBadge, AtlasDialog, AtlasIcon, AtlasIconButton, Atlas
 import type { AtlasSnackbarSeverity } from '@/components/ui'
 import ExplorePrevalenceDialog from '@/components/characterization-results/ExplorePrevalenceDialog.vue'
 import AnalysisBuilderShell from '@/components/analysis/AnalysisBuilderShell.vue'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { validateCharacterization, countByLevel } from '@/utils/characterization-validators'
 import type { CharacterizationDefinition, PrevalenceStat } from '@/models/characterization.types'
@@ -353,7 +357,7 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
-const { t } = useI18n()
+const { t, tv } = useI18n()
 const store = useCharacterizationStore()
 
 // ---------------------------------------------------------------------------
@@ -453,6 +457,17 @@ const canSave = computed<boolean>(() => {
   if (draft.value.name.trim().length === 0) return false
   return isEditing.value ? canWrite.value : hasPermission('create:cohort-characterization')
 })
+
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.characterization', 'characterization'),
+    isNew: !isEditing.value,
+    hasName: draft.value.name.trim().length > 0,
+    hasPermission: isEditing.value ? canWrite.value : hasPermission('create:cohort-characterization'),
+    isSaving: saving.value || loading.value,
+    translate: tv,
+  })
+)
 
 const deleteMessage = computed<string>(() => {
   return t('cc.viewEdit.deleteConfirmation', `Delete characterization '${draft.value.name}'?`, {

--- a/src/views/CohortBuilderView.vue
+++ b/src/views/CohortBuilderView.vue
@@ -63,6 +63,7 @@
 
         <cohort-toolbar-actions
           :can-save="builderRef.canSave"
+          :save-disabled-reason="builderRef.saveDisabledReason"
           :is-dirty="builderRef.hasUnsavedChanges"
           :is-previewing-version="builderRef.isPreviewingVersion"
           @cancel="builderRef.handleCancel()"

--- a/src/views/FeatureAnalysisEditorView.vue
+++ b/src/views/FeatureAnalysisEditorView.vue
@@ -77,15 +77,17 @@
           >
             {{ t('common.delete', 'Delete') }}
           </AtlasButton>
-          <AtlasButton
-            variant="primary"
-            :disabled="!canSave"
-            :loading="saving"
-            data-testid="feature-analysis-editor-save"
-            @click="handleSave"
-          >
-            {{ t('common.save', 'Save') }}
-          </AtlasButton>
+          <DisabledReasonTooltip :reason="saveDisabledReason">
+            <AtlasButton
+              variant="primary"
+              :disabled="!canSave"
+              :loading="saving"
+              data-testid="feature-analysis-editor-save"
+              @click="handleSave"
+            >
+              {{ t('common.save', 'Save') }}
+            </AtlasButton>
+          </DisabledReasonTooltip>
         </template>
       </AtlasActionToolbar>
     </template>
@@ -355,13 +357,15 @@ import type { ConceptSetReference } from '@/models/concept-set.types'
 import AnalysisBuilderShell from '@/components/analysis/AnalysisBuilderShell.vue'
 import AtlasActionToolbar from '@/components/ui/AtlasActionToolbar.vue'
 import { EntityAccessDialog, EntityAccessLockButton } from '@/components/access'
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
 
 const props = defineProps<{
   id?: string
 }>()
 
 const router = useRouter()
-const { t } = useI18n()
+const { t, tv } = useI18n()
 const store = useFeatureAnalysesStore()
 
 // ---------------------------------------------------------------------------
@@ -476,6 +480,17 @@ const canSave = computed<boolean>(() => {
   if (draft.value.name.trim().length === 0) return false
   return isEditing.value ? canWrite.value : hasPermission('create:feature-analysis')
 })
+
+const saveDisabledReason = computed<string>(() =>
+  resolveSaveDisabledReason({
+    entity: tv('const.entityName.featureAnalysis', 'feature analysis'),
+    isNew: !isEditing.value,
+    hasName: draft.value.name.trim().length > 0,
+    hasPermission: isEditing.value ? canWrite.value : hasPermission('create:feature-analysis'),
+    isSaving: saving.value || loading.value,
+    translate: tv,
+  })
+)
 
 const deleteMessage = computed<string>(() => {
   return t(

--- a/tests/component/cohort/CohortBuilder.spec.ts
+++ b/tests/component/cohort/CohortBuilder.spec.ts
@@ -2266,6 +2266,31 @@ describe('CohortBuilder', () => {
     return wrapper
   }
 
+  // #300: a disabled Save said nothing about why, so the user could not tell
+  // whether to ask for access or fix something themselves.
+  it('explains a disabled Save when the cohort has no name yet', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = ''
+    await wrapper.vm.$nextTick()
+
+    const vm = wrapper.vm as unknown as { canSave: boolean; saveDisabledReason: string }
+    expect(vm.canSave).toBe(false)
+    expect(vm.saveDisabledReason).toMatch(/name/i)
+  })
+
+  it('offers no explanation once Save is available', async () => {
+    const wrapper = createWrapper()
+    await wrapper.vm.$nextTick()
+    const setup = getSetup(wrapper)
+    setup.cohortName = 'A named cohort'
+    await wrapper.vm.$nextTick()
+
+    const vm = wrapper.vm as unknown as { saveDisabledReason: string }
+    expect(vm.saveDisabledReason).toBe('')
+  })
+
   it('hasUnsavedChanges is false immediately after a cohort loads', async () => {
     const wrapper = await mountLoaded()
     const vm = wrapper.vm as any

--- a/tests/unit/components/shared/DisabledReasonTooltip.spec.ts
+++ b/tests/unit/components/shared/DisabledReasonTooltip.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Issue #300. The wrapper span is the point of this component: a disabled
+ * button swallows pointer events, so a tooltip bound straight to it never
+ * opens. Wrapping the button is what makes the explanation reachable.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+
+import DisabledReasonTooltip from '@/components/shared/DisabledReasonTooltip.vue'
+
+const vuetify = createVuetify({ components, directives })
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn(),
+}))
+
+function mountWith(reason: string) {
+  return mount(DisabledReasonTooltip, {
+    global: { plugins: [vuetify] },
+    props: { reason },
+    slots: { default: '<button data-testid="inner" disabled>Save</button>' },
+  })
+}
+
+describe('DisabledReasonTooltip', () => {
+  it('renders the slot content whether or not there is a reason', () => {
+    expect(mountWith('').find('[data-testid="inner"]').exists()).toBe(true)
+    expect(mountWith('No access').find('[data-testid="inner"]').exists()).toBe(true)
+  })
+
+  it('wraps the slot so a disabled control can still surface the tooltip', () => {
+    const wrapper = mountWith('No access')
+    const wrap = wrapper.find('[data-testid="disabled-reason-wrap"]')
+
+    expect(wrap.exists()).toBe(true)
+    expect(wrap.find('[data-testid="inner"]').exists()).toBe(true)
+  })
+
+  it('adds no wrapper when there is nothing to explain', () => {
+    const wrapper = mountWith('')
+    expect(wrapper.find('[data-testid="disabled-reason-wrap"]').exists()).toBe(false)
+  })
+
+  it('carries the reason as the accessible title too, not only the hover tooltip', () => {
+    // A Vuetify tooltip renders into an overlay on hover, so the reason would
+    // otherwise be unreachable to anyone not using a mouse.
+    const wrap = mountWith('You do not own this cohort').find('[data-testid="disabled-reason-wrap"]')
+    expect(wrap.attributes('title')).toBe('You do not own this cohort')
+  })
+})

--- a/tests/unit/utils/save-disabled-reason.spec.ts
+++ b/tests/unit/utils/save-disabled-reason.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #300: a disabled Save button said nothing about why it was disabled.
+ * The resolver owns both the wording and the order the reasons are reported in.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveSaveDisabledReason } from '@/utils/save-disabled-reason'
+
+/** Stands in for useI18n's tv: returns the fallback with params interpolated. */
+const translate = (_key: string, fallback: string, params?: Record<string, string>) =>
+  fallback.replace(/\{(\w+)\}/g, (_m, k: string) => params?.[k] ?? `{${k}}`)
+
+const base = {
+  entity: 'characterization',
+  isNew: false,
+  hasName: true,
+  hasPermission: true,
+  translate,
+}
+
+describe('resolveSaveDisabledReason (#300)', () => {
+  it('says nothing when there is no blocker', () => {
+    expect(resolveSaveDisabledReason(base)).toBe('')
+  })
+
+  it('stays silent for a clean or in-flight editor rather than stating the obvious', () => {
+    // Save is legitimately disabled here, but "nothing has changed" needs no
+    // explaining and would put a tooltip on every freshly opened editor.
+    expect(resolveSaveDisabledReason({ ...base, isDirty: false })).toBe('')
+    expect(resolveSaveDisabledReason({ ...base, isSaving: true })).toBe('')
+  })
+
+  it('explains a version preview', () => {
+    const reason = resolveSaveDisabledReason({ ...base, isPreviewing: true })
+    expect(reason).toContain('version')
+  })
+
+  it('distinguishes not being allowed to create from not being allowed to edit', () => {
+    const create = resolveSaveDisabledReason({ ...base, isNew: true, hasPermission: false })
+    const edit = resolveSaveDisabledReason({ ...base, isNew: false, hasPermission: false })
+
+    expect(create).toContain('permission')
+    expect(edit).toMatch(/own|granted|access/i)
+    expect(create).not.toBe(edit)
+  })
+
+  it('names the entity it is talking about', () => {
+    const reason = resolveSaveDisabledReason({
+      ...base,
+      entity: 'concept set',
+      isNew: false,
+      hasPermission: false,
+    })
+    expect(reason).toContain('concept set')
+  })
+
+  it('asks for a name when one is missing', () => {
+    const reason = resolveSaveDisabledReason({ ...base, hasName: false })
+    expect(reason).toMatch(/name/i)
+  })
+
+  it('reports validation errors', () => {
+    const reason = resolveSaveDisabledReason({ ...base, hasValidationErrors: true })
+    expect(reason).toMatch(/error/i)
+  })
+
+  // Priority matters: telling someone to fill in a name they are not allowed to
+  // save anyway sends them down a dead end.
+  it('reports the permission problem ahead of a missing name', () => {
+    const reason = resolveSaveDisabledReason({
+      ...base,
+      hasName: false,
+      hasPermission: false,
+    })
+    expect(reason).toMatch(/own|granted|access|permission/i)
+    expect(reason).not.toMatch(/give it a name/i)
+  })
+
+  it('reports the version preview ahead of everything else', () => {
+    const reason = resolveSaveDisabledReason({
+      ...base,
+      isPreviewing: true,
+      hasPermission: false,
+      hasName: false,
+    })
+    expect(reason).toContain('version')
+  })
+})


### PR DESCRIPTION
Fixes #300

## Problem

A disabled Save button gave no indication of why. As the issue puts it, the feature is not broken, but the user cannot tell whether to ask someone for access or fix something themselves, so it reads as broken.

## Change

Hovering a disabled Save now explains it, in all six editors: cohort, concept set, characterization, incidence rate, pathway and feature analysis.

Two pieces, both following patterns already in the repo:

- **`resolveSaveDisabledReason`** mirrors the existing `resolveRunDisabledReason`. It owns the wording and the priority order, so the same situation reads the same wherever it comes up rather than each module inventing its own phrasing.
- **`DisabledReasonTooltip`** extracts the wrapper `<span>` that `DataSourceRunRow` already uses. That span is the load-bearing part: a disabled control receives no pointer events, so a tooltip bound directly to it never opens. It also sets `title`, because a Vuetify tooltip only renders into an overlay on hover and would otherwise be unreachable to anyone not using a mouse.

## The order the reasons are reported in

```
previewing a version  →  permission/ownership  →  missing name  →  validation errors  →  (silent)
```

Previewing comes first because every other gate is downstream of it. **Permission comes before a missing name**: telling someone to fill in a name for an asset they are not allowed to save anyway sends them down a dead end. That ordering is asserted by a test rather than left to chance.

## What stays silent, deliberately

Nothing is said when Save is disabled only because nothing has changed yet, or because a save is already running. Those are self-evident and momentary, and explaining them would put a tooltip on the most common state of every editor and teach people to ignore it. The issue asks about ownership and prerequisites; those are what get explained.

## No gate changed

Every Save button is disabled in exactly the cases it was before. This PR only explains them. Verified by the existing editor suites passing untouched.

## A gap this surfaced, reported rather than fixed

**`PathwayBuilder` has no permission or ownership check on Save at all.** It has no `useEntityAccess` call; its Save is gated purely on `isDirty && !hasErrors && !isPreviewMode`. Every sibling editor gates on entity access. So a user without write access to a pathway sees an *enabled* Save, clicks it, and finds out from the server.

Its tooltip therefore passes `hasPermission: true`, because reporting a permission reason the button does not actually enforce would be a lie. Adding the missing gate would change behaviour, which is outside "explain why it is disabled" and deserves its own decision, so it is flagged here instead. Happy to do it in a follow-up.

## Entity nouns

New `const.entityName.*` keys rather than reusing the existing page titles, which are plural and capitalised. "You do not own this Cohort Characterizations" is not a sentence.

## Tests

- The resolver gets full branch coverage, including both priority rules
- `DisabledReasonTooltip`: wraps when there is a reason, renders the slot untouched when there is not, and carries the reason as `title`
- The cohort editor proves the wiring end to end: an unnamed cohort explains itself, a valid one says nothing

`type-check` clean, `lint` clean at `--max-warnings 0`, `i18n:check` ok at 2230 call sites. `tests/component` 1690 passing, `tests/unit` passing apart from `date-format.spec.ts > should pad single digit month and day`, which fails identically on a clean `develop` checkout here and is a timezone-dependent assertion unrelated to this change.

## Coverage note

The per-editor specs hardcode `canWrite: true` in their `useEntityAccess` mocks, so driving the permission path through each of the six would have meant restructuring six mock setups. The permission wording and its precedence are covered by the resolver's own tests instead, and the cohort editor covers the wiring. Worth knowing if you would rather see per-editor permission tests.
