### PR TITLE
Let concepts be selected on the included and source code tabs

### DIFF
--- a/src/components/concepts/ConceptSetEditor.vue
+++ b/src/components/concepts/ConceptSetEditor.vue
@@ -301,6 +301,7 @@
                   :manual-count="store.currentSet?.items?.length ?? 0"
                   :source-key="sourceKey"
                   @view-concept="onViewConcept"
+                  @add-concepts="onAddFromResolved"
                   @retry="store.resolveIncluded(sourceKey)"
                 />
               </v-window-item>
@@ -311,6 +312,7 @@
                   :active="activeTab === 'source-codes'"
                   :source-key="sourceKey"
                   @view-concept="onViewConcept"
+                  @add-concepts="onAddFromResolved"
                 />
               </v-window-item>
 
@@ -1217,6 +1219,20 @@ function onAddConcepts(concepts: Concept[], flags?: ConceptAddFlags) {
   }
   hasUnsavedChanges.value = true
   showResultAfterFirstAdd(wasEmpty)
+}
+
+/**
+ * Adding from the Included Concepts or Source Codes tabs, where the rows are
+ * the resolved expansion of the expression rather than its items. The new items
+ * change what resolves, so the lists have to be recomputed or the row the user
+ * just excluded stays on screen and nothing appears to have happened (#224).
+ */
+function onAddFromResolved(concepts: Concept[], flags?: ConceptAddFlags) {
+  onAddConcepts(concepts, flags)
+  void store.resolveIncluded(sourceKey.value)
+  if (activeTab.value === 'source-codes') {
+    void store.resolveSourceCodes(sourceKey.value)
+  }
 }
 
 function onRemoveConcept(concept: Concept) {

--- a/src/components/concepts/IncludedConceptsTable.vue
+++ b/src/components/concepts/IncludedConceptsTable.vue
@@ -33,6 +33,16 @@
       @clear="clearFilters()"
     />
 
+    <!-- These rows are the resolved expansion of the expression, not its items,
+         so the way to drop one is to add an item excluding it (#224). -->
+    <ConceptAddOptions
+      v-if="!loading && items.length > 0"
+      v-model="addFlags"
+      :selected-count="selected.length"
+      class="mb-3"
+      @add="onAddSelected"
+    />
+
     <AtlasCard
       v-if="loading || items.length > 0"
       padding="none"
@@ -47,6 +57,30 @@
         hover
         class="included-concepts-table__table"
       >
+        <template #header.select>
+          <div data-testid="included-concepts-select-all">
+            <v-checkbox-btn
+              :model-value="allVisibleSelected"
+              :indeterminate="someVisibleSelected && !allVisibleSelected"
+              :aria-label="t('components.conceptTable.selectAllConcepts', 'Select all concepts').value"
+              density="compact"
+              hide-details
+              @update:model-value="onToggleSelectAll"
+            />
+          </div>
+        </template>
+
+        <template #item.select="{ item }">
+          <div :data-testid="`included-concepts-row-checkbox-${(item as Concept).conceptId}`">
+            <v-checkbox-btn
+              :model-value="selectedSet.has((item as Concept).conceptId)"
+              :aria-label="(item as Concept).conceptName"
+              density="compact"
+              hide-details
+              @update:model-value="(v: boolean | null) => onToggleRow((item as Concept).conceptId, v)"
+            />
+          </div>
+        </template>
         <template
           v-if="sourceKey"
           #item.conceptName="{ item }"
@@ -156,7 +190,7 @@
 <script setup lang="ts">
 import { ref, computed, toRef } from 'vue'
 import { useI18n } from '@/composables/useI18n'
-import type { Concept } from '@/models/concept-set.types'
+import type { Concept, ConceptAddFlags } from '@/models/concept-set.types'
 import {
   AtlasAlert,
   AtlasButton,
@@ -167,6 +201,7 @@ import {
   AtlasSkeleton,
 } from '@/components/ui'
 import ConceptFacetFilters from './ConceptFacetFilters.vue'
+import ConceptAddOptions from './ConceptAddOptions.vue'
 import { CONCEPT_FACETS, useConceptFacets } from '@/composables/useConceptFacets'
 import { getDomainColor } from '@/utils/domain-colors'
 import { useThemeStore } from '@/stores/theme'
@@ -185,8 +220,51 @@ const props = defineProps<Props>()
 
 const emit = defineEmits<{
   'view-concept': [payload: { conceptId: number; sourceKey: string }]
+  'add-concepts': [concepts: Concept[], flags: Required<ConceptAddFlags>]
   retry: []
 }>()
+
+// Exclude rather than include: a concept already listed here is by definition
+// in the set, so the reason to select it is almost always to take it back out.
+const addFlags = ref<Required<ConceptAddFlags>>({
+  isExcluded: true,
+  includeDescendants: false,
+  includeMapped: false,
+})
+
+const selected = ref<number[]>([])
+const selectedSet = computed(() => new Set(selected.value))
+
+// Select-all covers the rows the facets have left on screen, not every resolved
+// concept: offering to select rows the user has filtered away would be a trap.
+const visibleIds = computed(() => visibleConcepts.value.map(c => c.conceptId))
+const allVisibleSelected = computed(
+  () => visibleIds.value.length > 0 && visibleIds.value.every(id => selectedSet.value.has(id))
+)
+const someVisibleSelected = computed(() => visibleIds.value.some(id => selectedSet.value.has(id)))
+
+function onToggleRow(conceptId: number, checked: boolean | null) {
+  selected.value = checked
+    ? [...selected.value, conceptId]
+    : selected.value.filter(id => id !== conceptId)
+}
+
+function onToggleSelectAll(checked: boolean | null) {
+  if (checked) {
+    const merged = new Set([...selected.value, ...visibleIds.value])
+    selected.value = [...merged]
+    return
+  }
+  const dropped = new Set(visibleIds.value)
+  selected.value = selected.value.filter(id => !dropped.has(id))
+}
+
+function onAddSelected() {
+  if (selected.value.length === 0) return
+  const picked = props.items.filter(c => selectedSet.value.has(c.conceptId))
+  emit('add-concepts', picked, { ...addFlags.value })
+  selected.value = []
+}
 
 const sortBy = ref([{ key: 'conceptId', order: 'asc' as const }])
 
@@ -217,6 +295,7 @@ const {
 } = useConceptFacets(toRef(props, 'items'), facets)
 
 const headers = [
+  { title: '', key: 'select', sortable: false, width: '48px' },
   { title: t('columns.conceptId', 'ID').value, key: 'conceptId', sortable: true, width: '90px' },
   { title: t('columns.conceptCode', 'Code').value, key: 'conceptCode', sortable: true, width: '110px' },
   { title: t('columns.conceptName', 'Name').value, key: 'conceptName', sortable: true },

--- a/src/components/concepts/IncludedSourceCodesTable.vue
+++ b/src/components/concepts/IncludedSourceCodesTable.vue
@@ -33,6 +33,16 @@
       @clear="clearFilters()"
     />
 
+    <!-- Source codes resolve out of the expression like included concepts do,
+         so acting on one means adding an expression item for it (#224). -->
+    <ConceptAddOptions
+      v-if="!store.sourceCodeLoading && store.sourceCodeItems.length > 0"
+      v-model="addFlags"
+      :selected-count="selected.length"
+      class="mb-3"
+      @add="onAddSelected"
+    />
+
     <AtlasCard
       v-if="store.sourceCodeLoading || store.sourceCodeItems.length > 0"
       padding="none"
@@ -47,6 +57,30 @@
         hover
         class="included-source-codes-table__table"
       >
+        <template #header.select>
+          <div data-testid="included-source-codes-select-all">
+            <v-checkbox-btn
+              :model-value="allVisibleSelected"
+              :indeterminate="someVisibleSelected && !allVisibleSelected"
+              :aria-label="t('components.conceptTable.selectAllConcepts', 'Select all concepts').value"
+              density="compact"
+              hide-details
+              @update:model-value="onToggleSelectAll"
+            />
+          </div>
+        </template>
+
+        <template #item.select="{ item }">
+          <div :data-testid="`included-source-codes-row-checkbox-${(item as Concept).conceptId}`">
+            <v-checkbox-btn
+              :model-value="selectedSet.has((item as Concept).conceptId)"
+              :aria-label="(item as Concept).conceptName"
+              density="compact"
+              hide-details
+              @update:model-value="(v: boolean | null) => onToggleRow((item as Concept).conceptId, v)"
+            />
+          </div>
+        </template>
         <template
           v-if="props.sourceKey"
           #item.conceptName="{ item }"
@@ -135,7 +169,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useI18n } from '@/composables/useI18n'
-import type { Concept } from '@/models/concept-set.types'
+import type { Concept, ConceptAddFlags } from '@/models/concept-set.types'
 import { useConceptSetsStore } from '@/stores/concept-sets'
 import {
   AtlasAlert,
@@ -147,6 +181,7 @@ import {
   AtlasSkeleton,
 } from '@/components/ui'
 import ConceptFacetFilters from './ConceptFacetFilters.vue'
+import ConceptAddOptions from './ConceptAddOptions.vue'
 import { CONCEPT_FACETS, useConceptFacets } from '@/composables/useConceptFacets'
 import { getDomainColor } from '@/utils/domain-colors'
 import { useThemeStore } from '@/stores/theme'
@@ -163,7 +198,49 @@ const props = defineProps<Props>()
 
 const emit = defineEmits<{
   'view-concept': [payload: { conceptId: number; sourceKey: string }]
+  'add-concepts': [concepts: Concept[], flags: Required<ConceptAddFlags>]
 }>()
+
+// Exclude by default, as on the included concepts tab: a code listed here is
+// already in the set, so selecting it is usually about taking it back out.
+const addFlags = ref<Required<ConceptAddFlags>>({
+  isExcluded: true,
+  includeDescendants: false,
+  includeMapped: false,
+})
+
+const selected = ref<number[]>([])
+const selectedSet = computed(() => new Set(selected.value))
+
+// Only the rows the facets have left on screen, so select-all cannot reach
+// rows the user has filtered away.
+const visibleIds = computed(() => visibleSourceCodes.value.map(c => c.conceptId))
+const allVisibleSelected = computed(
+  () => visibleIds.value.length > 0 && visibleIds.value.every(id => selectedSet.value.has(id))
+)
+const someVisibleSelected = computed(() => visibleIds.value.some(id => selectedSet.value.has(id)))
+
+function onToggleRow(conceptId: number, checked: boolean | null) {
+  selected.value = checked
+    ? [...selected.value, conceptId]
+    : selected.value.filter(id => id !== conceptId)
+}
+
+function onToggleSelectAll(checked: boolean | null) {
+  if (checked) {
+    selected.value = [...new Set([...selected.value, ...visibleIds.value])]
+    return
+  }
+  const dropped = new Set(visibleIds.value)
+  selected.value = selected.value.filter(id => !dropped.has(id))
+}
+
+function onAddSelected() {
+  if (selected.value.length === 0) return
+  const picked = store.sourceCodeItems.filter(c => selectedSet.value.has(c.conceptId))
+  emit('add-concepts', picked, { ...addFlags.value })
+  selected.value = []
+}
 
 const sortBy = ref([{ key: 'conceptId', order: 'asc' as const }])
 
@@ -193,6 +270,7 @@ const {
 } = useConceptFacets(sourceCodeItems, facets)
 
 const headers = [
+  { title: '', key: 'select', sortable: false, width: '48px' },
   { title: t('columns.conceptId', 'ID').value, key: 'conceptId', sortable: true, width: '90px' },
   { title: t('columns.conceptCode', 'Code').value, key: 'conceptCode', sortable: true, width: '110px' },
   { title: t('columns.conceptName', 'Name').value, key: 'conceptName', sortable: true },

--- a/tests/component/concepts/ConceptSetEditor.included.spec.ts
+++ b/tests/component/concepts/ConceptSetEditor.included.spec.ts
@@ -79,3 +79,74 @@ describe('ConceptSetEditor — Included tab', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 })
+
+/**
+ * Issue #224. The Included and Source Codes tabs list the resolved expansion of
+ * the expression, not its items, so adding from them adds a new item and the
+ * lists have to be re-resolved or the row the user just excluded stays put.
+ */
+describe('ConceptSetEditor — adding from a resolved tab (#224)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  const concept = (id: number) => ({
+    conceptId: id,
+    conceptName: `Concept ${id}`,
+    conceptCode: `${id}`,
+    domainId: 'Condition',
+    vocabularyId: 'SNOMED',
+    conceptClassId: 'Clinical Finding',
+    standardConcept: 'S',
+    invalidReason: null,
+  })
+
+  // v-window renders only the open tab, so the Included table does not exist
+  // until that tab is selected.
+  async function mountEditor() {
+    const wrapper = mount(ConceptSetEditor, {
+      global: { plugins: [vuetify], stubs: globalStubs },
+      props: { modelValue: true, conceptSet: { id: 1, name: 's', items: [] } },
+    })
+    ;(wrapper.vm as unknown as { activeTab: string }).activeTab = 'included'
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  it('adds the concepts to the expression with the flags it was given', async () => {
+    const store = useConceptSetsStore()
+    store.currentSet = { id: 1, name: 's', items: [] }
+    const wrapper = await mountEditor()
+
+    const table = wrapper.findComponent({ name: 'IncludedConceptsTable' })
+    table.vm.$emit('add-concepts', [concept(1), concept(2)], {
+      isExcluded: true,
+      includeDescendants: false,
+      includeMapped: false,
+    })
+    await wrapper.vm.$nextTick()
+
+    expect(store.currentSet!.items).toHaveLength(2)
+    expect(store.currentSet!.items.every(i => i.isExcluded)).toBe(true)
+    expect(store.currentSet!.items.map(i => i.conceptId)).toEqual([1, 2])
+  })
+
+  // Without this the excluded row sits there unchanged and it looks like the
+  // click did nothing.
+  it('re-resolves the included list so the excluded row disappears', async () => {
+    const store = useConceptSetsStore()
+    store.currentSet = { id: 1, name: 's', items: [] }
+    const resolveIncluded = vi.spyOn(store, 'resolveIncluded').mockResolvedValue()
+    const wrapper = await mountEditor()
+    resolveIncluded.mockClear()
+
+    wrapper.findComponent({ name: 'IncludedConceptsTable' }).vm.$emit(
+      'add-concepts',
+      [concept(1)],
+      { isExcluded: true, includeDescendants: false, includeMapped: false }
+    )
+    await wrapper.vm.$nextTick()
+
+    expect(resolveIncluded).toHaveBeenCalled()
+  })
+})

--- a/tests/component/concepts/IncludedConceptsTable.spec.ts
+++ b/tests/component/concepts/IncludedConceptsTable.spec.ts
@@ -111,6 +111,10 @@ describe('IncludedConceptsTable', () => {
   })
 
   it('does not render any descendants/mapped/exclude checkbox columns', () => {
+    // These rows are the resolved expansion of the expression, not its items,
+    // so there are no per-row flags to toggle. Narrowed from "no checkbox
+    // anywhere" once #224 added selection checkboxes and an add-options bar,
+    // which are a different thing from a per-row flag column.
     const wrapper = mount(IncludedConceptsTable, {
       global: { plugins: [vuetify] },
       props: {
@@ -120,7 +124,10 @@ describe('IncludedConceptsTable', () => {
         manualCount: 1,
       },
     })
-    expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
+    const headings = wrapper.findAll('thead th').map(th => th.text().toLowerCase()).join(' ')
+    expect(headings).not.toContain('descendant')
+    expect(headings).not.toContain('mapped')
+    expect(headings).not.toContain('exclude')
   })
 })
 
@@ -264,5 +271,76 @@ describe('IncludedConceptsTable — filtering, sorting and pagination (issue #26
       { key: 'conceptName', order: 'asc' },
       { key: 'conceptId', order: 'desc' },
     ])
+  })
+})
+
+/**
+ * Issue #224: the Included Concepts tab shows the resolved expansion of the
+ * expression, so the way to drop one of these concepts is to add a new
+ * expression item excluding it. That needed multi-select, which only the
+ * Search tab had.
+ */
+describe('IncludedConceptsTable multi-select (#224)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  const mountTable = (items = [makeConcept(1), makeConcept(2), makeConcept(3)]) =>
+    mount(IncludedConceptsTable, {
+      global: { plugins: [vuetify] },
+      props: { items, loading: false, error: null, manualCount: 1, sourceKey: 'SYNPUF1K' },
+    })
+
+  const addOptions = (wrapper: ReturnType<typeof mountTable>) =>
+    wrapper.findComponent({ name: 'ConceptAddOptions' })
+
+  it('offers the add-options bar', () => {
+    expect(addOptions(mountTable()).exists()).toBe(true)
+  })
+
+  // Excluding is the point of selecting here, so it should not need a click.
+  it('pre-checks Exclude, unlike the search tab', () => {
+    const flags = addOptions(mountTable()).props('modelValue') as Record<string, boolean>
+    expect(flags.isExcluded).toBe(true)
+    expect(flags.includeDescendants).toBe(false)
+    expect(flags.includeMapped).toBe(false)
+  })
+
+  it('reports nothing selected until a row is picked', () => {
+    expect(addOptions(mountTable()).props('selectedCount')).toBe(0)
+  })
+
+  it('emits the picked concepts with the current flags', async () => {
+    const wrapper = mountTable()
+    await wrapper.get('[data-testid="included-concepts-row-checkbox-1"] input').setValue(true)
+    await wrapper.get('[data-testid="included-concepts-row-checkbox-3"] input').setValue(true)
+
+    expect(addOptions(wrapper).props('selectedCount')).toBe(2)
+
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    const emitted = wrapper.emitted('add-concepts')
+    expect(emitted).toHaveLength(1)
+    const [concepts, flags] = emitted![0] as [Concept[], Record<string, boolean>]
+    expect(concepts.map(c => c.conceptId)).toEqual([1, 3])
+    expect(flags.isExcluded).toBe(true)
+  })
+
+  it('clears the selection after adding, so the next pick starts clean', async () => {
+    const wrapper = mountTable()
+    await wrapper.get('[data-testid="included-concepts-row-checkbox-1"] input').setValue(true)
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(addOptions(wrapper).props('selectedCount')).toBe(0)
+  })
+
+  it('selects every row with the header checkbox', async () => {
+    const wrapper = mountTable()
+    await wrapper.get('[data-testid="included-concepts-select-all"] input').setValue(true)
+
+    expect(addOptions(wrapper).props('selectedCount')).toBe(3)
   })
 })

--- a/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
+++ b/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
@@ -26,6 +26,12 @@ const stubs = {
     },
     template: '<table class="stub-table"><tbody><tr v-for="i in items" :key="i.conceptId"><td>{{ i.conceptName }}</td></tr></tbody><tfoot v-if="items.length === 0"><slot name="no-data" /></tfoot></table>',
   },
+  ConceptAddOptions: {
+    name: 'ConceptAddOptions',
+    props: ['modelValue', 'selectedCount', 'disabled'],
+    emits: ['update:modelValue', 'add'],
+    template: '<div class="stub-add-options" />',
+  },
   ConceptFacetFilters: {
     name: 'ConceptFacetFilters',
     props: ['facets', 'facetOptions', 'selected', 'activeFilterCount', 'resultFilter'],

--- a/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
+++ b/tests/unit/components/concepts/IncludedSourceCodesTable.spec.ts
@@ -24,7 +24,15 @@ const stubs = {
       multiSort: Boolean,
       sortBy: { type: Array, default: () => [] },
     },
-    template: '<table class="stub-table"><tbody><tr v-for="i in items" :key="i.conceptId"><td>{{ i.conceptName }}</td></tr></tbody><tfoot v-if="items.length === 0"><slot name="no-data" /></tfoot></table>',
+    template: '<table class="stub-table"><thead><tr><th><slot name="header.select" /></th></tr></thead><tbody><tr v-for="i in items" :key="i.conceptId"><td><slot name="item.select" :item="i" /></td><td>{{ i.conceptName }}</td></tr></tbody><tfoot v-if="items.length === 0"><slot name="no-data" /></tfoot></table>',
+  },
+  // A plain input so the selection tests can drive it; this spec installs no
+  // Vuetify, by design, and stubs every child.
+  VCheckboxBtn: {
+    name: 'VCheckboxBtn',
+    props: ['modelValue', 'indeterminate'],
+    emits: ['update:modelValue'],
+    template: '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)">',
   },
   ConceptAddOptions: {
     name: 'ConceptAddOptions',
@@ -207,5 +215,103 @@ describe('IncludedSourceCodesTable — filtering and pagination (issue #266)', (
     await wrapper.find('[data-testid="source-codes-clear-filters-btn"]').trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).toContain('Code 1')
+  })
+})
+
+/**
+ * Issue #224: source codes resolve out of the expression the same way included
+ * concepts do, so acting on one means adding an expression item for it. That
+ * needed multi-select here too.
+ */
+describe('IncludedSourceCodesTable multi-select (#224)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(useConceptSetsStore(), 'resolveSourceCodes').mockResolvedValue()
+  })
+
+  const code = (id: number, over: Record<string, unknown> = {}) => ({
+    conceptId: id,
+    conceptName: `Code ${id}`,
+    conceptCode: `C${id}`,
+    domainId: 'Condition',
+    vocabularyId: 'ICD10CM',
+    conceptClassId: 'ICD10 code',
+    standardConcept: null,
+    invalidReason: null,
+    ...over,
+  })
+
+  function seed(items: ReturnType<typeof code>[]) {
+    useConceptSetsStore().sourceCodeItems = items as never
+  }
+
+  const addOptions = (wrapper: ReturnType<typeof makeWrapper>) =>
+    wrapper.findComponent({ name: 'ConceptAddOptions' })
+
+  it('pre-checks Exclude, as the included concepts tab does', () => {
+    seed([code(1)])
+    const flags = addOptions(makeWrapper()).props('modelValue') as Record<string, boolean>
+
+    expect(flags.isExcluded).toBe(true)
+    expect(flags.includeDescendants).toBe(false)
+    expect(flags.includeMapped).toBe(false)
+  })
+
+  it('emits the picked source codes with the current flags', async () => {
+    seed([code(1), code(2), code(3)])
+    const wrapper = makeWrapper()
+
+    await wrapper.get('[data-testid="included-source-codes-row-checkbox-1"] input').setValue(true)
+    await wrapper.get('[data-testid="included-source-codes-row-checkbox-3"] input').setValue(true)
+    expect(addOptions(wrapper).props('selectedCount')).toBe(2)
+
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    const emitted = wrapper.emitted('add-concepts')
+    expect(emitted).toHaveLength(1)
+    const [concepts, flags] = emitted![0] as [Array<{ conceptId: number }>, Record<string, boolean>]
+    expect(concepts.map(c => c.conceptId)).toEqual([1, 3])
+    expect(flags.isExcluded).toBe(true)
+  })
+
+  it('clears the selection after adding', async () => {
+    seed([code(1)])
+    const wrapper = makeWrapper()
+    await wrapper.get('[data-testid="included-source-codes-row-checkbox-1"] input').setValue(true)
+
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(addOptions(wrapper).props('selectedCount')).toBe(0)
+  })
+
+  it('emits nothing when no row is picked', async () => {
+    seed([code(1)])
+    const wrapper = makeWrapper()
+
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('add-concepts')).toBeUndefined()
+  })
+
+  // Select-all must not reach rows the facets have filtered away.
+  it('selects only the rows left on screen by the filters', async () => {
+    seed([code(1, { vocabularyId: 'ICD10CM' }), code(2, { vocabularyId: 'READ' })])
+    const wrapper = makeWrapper()
+
+    wrapper.findComponent({ name: 'ConceptFacetFilters' })
+      .vm.$emit('update:facet', { key: 'vocabularyId', values: ['ICD10CM'] })
+    await wrapper.vm.$nextTick()
+
+    await wrapper.get('[data-testid="included-source-codes-select-all"] input').setValue(true)
+
+    expect(addOptions(wrapper).props('selectedCount')).toBe(1)
+
+    addOptions(wrapper).vm.$emit('add')
+    await wrapper.vm.$nextTick()
+    const [concepts] = wrapper.emitted('add-concepts')![0] as [Array<{ conceptId: number }>]
+    expect(concepts.map(c => c.conceptId)).toEqual([1])
   })
 })


### PR DESCRIPTION
Fixes #224

## Problem

The Search tab lets you pick several concepts and add them in one go with Descendants / Mapped / Exclude. The Included Concepts and Included Source Codes tabs did not.

That matters for the use case in the issue: you build an expression with descendants, look at what it actually resolved to, and want to exclude a handful of them. Without selection you had to leave the tab, search each unwanted concept by name, and add it back as an exclusion one at a time.

## Change

Both tabs get the same selection and the same `ConceptAddOptions` bar the Search tab has, emitting into the editor's existing add handler.

**No store changes were needed.** `addConceptToSet` already allows one concept to appear with different flags and refuses only an exact repeat (#226). That is what makes "include the descendants of X, exclude X itself" expressible, and it is exactly the shape this produces.

## Three decisions worth reviewing

**Exclude is pre-checked on these two tabs, and untouched on Search.** A concept listed here is by definition already in the set, so selecting it is nearly always about taking it back out. The issue floated making exclusion the *only* action; the full option set is kept because adding an already-included concept explicitly, for instance with Mapped, is a real use, and because differing from Search only in the defaults is easier to reason about than differing in the controls.

**Select-all covers the rows the facets have left on screen**, not every resolved concept. Both tables sit behind filter bars, so offering to select rows the user has filtered away would be a trap.

**The tabs re-resolve after adding.** These rows are the resolved expansion of the expression, not its items, so adding does not edit the row that was clicked: it adds an item that changes what resolves. Without the re-resolve, the row you just excluded sits there unchanged and it looks like nothing happened.

## Two existing tests changed rather than worked around

- `does not render any descendants/mapped/exclude checkbox columns` asserted that no `input[type="checkbox"]` existed anywhere. Its name states the narrower and more meaningful claim, that there are no per-row flag *columns*, since these rows are resolved concepts with no per-row flags to toggle. It now checks the column headings, so it still guards its intent instead of being deleted for being in the way.
- `IncludedSourceCodesTable`'s unit spec stubs every child and installs no Vuetify, so it gained a stub for the new child in the same style.

## Tests

Six new cases on `IncludedConceptsTable`, all failing before the change: the bar renders, Exclude is pre-checked (and Descendants/Mapped are not), nothing is selected initially, the picked concepts and current flags are emitted, the selection clears after adding, and the header checkbox selects every row.

`tests/component` 1694 passing, `tests/unit/components` 1669 passing, `type-check`, `lint` at `--max-warnings 0` and `i18n:check` all clean. Rebased onto `develop` after #316 and #317 landed, and re-verified since #317 touches the same editor file.

## Not included

No change to the Search tab, no new store code, and no "remove from expression" action on these tabs: they show resolved output, so there is no single expression item behind a given row to remove.
